### PR TITLE
use the same dir for the sqlite db when using the devnet setup

### DIFF
--- a/.hack/devnet/run.sh
+++ b/.hack/devnet/run.sh
@@ -57,7 +57,7 @@ indexer:
 database:
   engine: "sqlite"
   sqlite:
-    file: "./tmp-database.sqlite"
+    file: "${__dir}/generated-database.sqlite"
 EOF
 
 
@@ -65,5 +65,6 @@ cat <<EOF
 ============================================================================================================
 Dora config at ${__dir}/generated-dora-config.yaml
 Chain config at ${__dir}/generated-chain-config.yaml
+Database at ${__dir}/generated-database.sqlite
 ============================================================================================================
 EOF


### PR DESCRIPTION
Currently the sqlite db was being created in the root repo dir. It's better to have it in the devnet dir, so that it also gets cleaned up when running `make devnet-clean` ( Along the other configs .. ) 