### PR TITLE
clients pages: disable animations when many nodes

### DIFF
--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -180,6 +180,12 @@
     data.nodes[i].title = data.nodes[i].id;
   }
   var options = $_network.defaultOptions;
+
+  // Performance improvements. Less animations
+  if (data.nodes.length >= 20) {
+    options.physics.stabilization = true
+  }
+
   var network = new vis.Network(container, data, options);
 
   sleep(1000).then(() => {

--- a/templates/clients/clients_el.html
+++ b/templates/clients/clients_el.html
@@ -210,6 +210,12 @@
     data.nodes[i].title = data.nodes[i].id;
   }
   var options = $_network.defaultOptions;
+
+  // Performance improvements. Less animations
+  if (data.nodes.length >= 20) {
+    options.physics.stabilization = true
+  }
+
   var network = new vis.Network(container, data, options);
 
   sleep(1000).then(() => {


### PR DESCRIPTION
This change will stabilize the network graph when there are at least 20 nodes. This should result in better performance due to it skipping the animations needed to stabilize the graph. 