### PR TITLE
fix fork tracking

### DIFF
--- a/indexer/beacon/client.go
+++ b/indexer/beacon/client.go
@@ -364,10 +364,7 @@ func (c *Client) processBlock(slot phase0.Slot, root phase0.Root, header *phase0
 
 	if slot >= finalizedSlot && isNew {
 		// fork detection
-		forkId, err2 := c.indexer.forkCache.processBlock(block)
-		block.forkId = forkId
-		block.fokChecked = true
-
+		err2 := c.indexer.forkCache.processBlock(block)
 		if err2 != nil {
 			c.logger.Warnf("failed processing new fork: %v", err2)
 		}

--- a/indexer/beacon/fork.go
+++ b/indexer/beacon/fork.go
@@ -29,6 +29,7 @@ func newFork(forkId ForkKey, baseBlock *Block, leafBlock *Block, parentFork Fork
 		leafSlot:   leafBlock.Slot,
 		leafRoot:   leafBlock.Root,
 		parentFork: parentFork,
+		headBlock:  leafBlock,
 	}
 
 	return fork

--- a/indexer/beacon/forkcache.go
+++ b/indexer/beacon/forkcache.go
@@ -301,7 +301,7 @@ func (cache *forkCache) checkForkDistance(block1 *Block, block2 *Block, parentsM
 
 // processBlock processes a block and detects new forks if any.
 // It persists the new forks to the database, updates any subsequent blocks building on top of the given block and returns the fork ID.
-func (cache *forkCache) processBlock(block *Block) (ForkKey, error) {
+func (cache *forkCache) processBlock(block *Block) error {
 	cache.forkProcessLock.Lock()
 	defer cache.forkProcessLock.Unlock()
 
@@ -424,6 +424,9 @@ func (cache *forkCache) processBlock(block *Block) (ForkKey, error) {
 		}
 	}
 
+	block.forkId = currentForkId
+	block.fokChecked = true
+
 	if fork1 != nil || fork2 != nil || len(updatedBlocks) > 0 {
 		err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
 			if fork1 != nil {
@@ -475,11 +478,11 @@ func (cache *forkCache) processBlock(block *Block) (ForkKey, error) {
 			return nil
 		})
 		if err != nil {
-			return currentForkId, err
+			return err
 		}
 	}
 
-	return currentForkId, nil
+	return nil
 }
 
 // updateNewForkBlocks updates the fork blocks with the given fork. returns the roots of the updated blocks.


### PR DESCRIPTION
fix 2 issues with fork tracking:
* resolve race condition in `processBlock`:
  set the resolved fork id to the block.forkId field within the synchronized processBlock function to avoid a race condition with subsequent calls to processBlock that read the forkId of the previous block.
* assign `headBlock` on fork creation
  assign the current leaf block of a new fork as `headBlock`.
  Otherwise new forks are being ignored by the canonical head computation until at least 1 blocks builds on top of it.