### PR TITLE
fix: show EL in/out peer counts for besu

### DIFF
--- a/templates/clients/clients_el.html
+++ b/templates/clients/clients_el.html
@@ -76,7 +76,7 @@
                     </td>
                     <td style="font-size: 0.8rem; vertical-align: middle;">
                       <span style="width:30px;display: inline-block;" class="text-success" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Inbound Peers">
-                        {{ if and ($client.DidFetchPeers) (not (or (contains $client.Version "besu") (contains $client.Version "Nethermind"))) }}
+                        {{ if and ($client.DidFetchPeers) (not (contains $client.Version "Nethermind")) }}
                           {{ $client.PeersInboundCounter }}
                         {{ else }}
                           ?
@@ -84,7 +84,7 @@
                         <i class="fa-solid fa-arrow-down"></i>
                       </span>
                       <span style="width:30px;display: inline-block;" class="text-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Outbound Peers">
-                        {{ if and ($client.DidFetchPeers) (not (or (contains $client.Version "besu") (contains $client.Version "Nethermind"))) }}
+                        {{ if and ($client.DidFetchPeers) (not (contains $client.Version "Nethermind")) }}
                           {{ $client.PeersOutboundCounter }}
                         {{ else }}
                           ?


### PR DESCRIPTION
Besu now properly shows peers as inbound/outbound. So we can remove it from this condition.