### PR TITLE
Fix block selection methods to include pruned missed slots properly

### DIFF
--- a/db/slots.go
+++ b/db/slots.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/jmoiron/sqlx"
 	"github.com/mitchellh/mapstructure"
@@ -83,38 +84,6 @@ func InsertMissingSlot(block *dbtypes.SlotHeader, tx *sqlx.Tx) error {
 	return nil
 }
 
-func GetSlots(firstSlot uint64, limit uint32, withMissing bool, withOrphaned bool) []*dbtypes.AssignedSlot {
-	var sql strings.Builder
-	fmt.Fprintf(&sql, `SELECT slots.slot, slots.proposer`)
-	blockFields := []string{
-		"state_root", "root", "slot", "proposer", "status", "parent_root", "graffiti", "graffiti_text",
-		"attestation_count", "deposit_count", "exit_count", "withdraw_count", "withdraw_amount", "attester_slashing_count",
-		"proposer_slashing_count", "bls_change_count", "eth_transaction_count", "eth_block_number", "eth_block_hash",
-		"eth_block_extra", "eth_block_extra_text", "sync_participation", "fork_id",
-	}
-	for _, blockField := range blockFields {
-		fmt.Fprintf(&sql, ", slots.%v AS \"block.%v\"", blockField, blockField)
-	}
-	fmt.Fprintf(&sql, ` FROM slots `)
-	fmt.Fprintf(&sql, ` WHERE slot <= $1 `)
-
-	if !withMissing {
-		fmt.Fprintf(&sql, ` AND slots.status != 0 `)
-	}
-	if !withOrphaned {
-		fmt.Fprintf(&sql, ` AND slots.status != 2 `)
-	}
-	fmt.Fprintf(&sql, ` ORDER BY slot DESC LIMIT $2`)
-
-	rows, err := ReaderDb.Query(sql.String(), firstSlot, limit)
-	if err != nil {
-		logger.WithError(err).Errorf("Error while fetching slots: %v", sql.String())
-		return nil
-	}
-
-	return parseAssignedSlots(rows, blockFields, 2)
-}
-
 func GetSlotsRange(firstSlot uint64, lastSlot uint64, withMissing bool, withOrphaned bool) []*dbtypes.AssignedSlot {
 	var sql strings.Builder
 	fmt.Fprintf(&sql, `SELECT slots.slot, slots.proposer`)
@@ -182,6 +151,43 @@ func GetSlotByRoot(root []byte) *dbtypes.Slot {
 		return nil
 	}
 	return &block
+}
+
+func GetSlotsByRoots(roots [][]byte) map[phase0.Root]*dbtypes.Slot {
+	var sql strings.Builder
+	fmt.Fprintf(&sql, `SELECT
+		root, slot, parent_root, state_root, status, proposer, graffiti, graffiti_text,
+		attestation_count, deposit_count, exit_count, withdraw_count, withdraw_amount, attester_slashing_count, 
+		proposer_slashing_count, bls_change_count, eth_transaction_count, eth_block_number, eth_block_hash,
+		eth_block_extra, eth_block_extra_text, sync_participation, fork_id
+	FROM slots
+	WHERE root IN `)
+
+	argIdx := 0
+	args := make([]any, len(roots))
+	plcList := make([]string, len(roots))
+	for i, root := range roots {
+		plcList[i] = fmt.Sprintf("$%v", argIdx+1)
+		args[argIdx] = root
+		argIdx += 1
+	}
+	fmt.Fprintf(&sql, "(%v)", strings.Join(plcList, ", "))
+
+	fmt.Fprintf(&sql, " ORDER BY slot DESC")
+
+	slots := []*dbtypes.Slot{}
+	err := ReaderDb.Select(&slots, sql.String(), args...)
+	if err != nil {
+		//logger.Errorf("Error while fetching block by root 0x%x: %v", root, err)
+		return nil
+	}
+
+	slotMap := make(map[phase0.Root]*dbtypes.Slot)
+	for _, slot := range slots {
+		slotMap[phase0.Root(slot.Root)] = slot
+	}
+
+	return slotMap
 }
 
 func GetBlockHeadByRoot(root []byte) *dbtypes.BlockHead {

--- a/db/slots.go
+++ b/db/slots.go
@@ -163,8 +163,7 @@ func GetSlotsByRoots(roots [][]byte) map[phase0.Root]*dbtypes.Slot {
 		argIdx += 1
 	}
 
-	var sql strings.Builder
-	fmt.Fprintf(&sql,
+	sql := fmt.Sprintf(
 		`SELECT
 			root, slot, parent_root, state_root, status, proposer, graffiti, graffiti_text,
 			attestation_count, deposit_count, exit_count, withdraw_count, withdraw_amount, attester_slashing_count, 
@@ -177,7 +176,7 @@ func GetSlotsByRoots(roots [][]byte) map[phase0.Root]*dbtypes.Slot {
 	)
 
 	slots := []*dbtypes.Slot{}
-	err := ReaderDb.Select(&slots, sql.String(), args...)
+	err := ReaderDb.Select(&slots, sql, args...)
 	if err != nil {
 		logger.Errorf("Error while fetching block by roots: %v", err)
 		return nil

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -266,7 +266,12 @@ func buildIndexPageRecentBlocksData(pageData *models.IndexPageData, recentBlockC
 		WithOrphaned: 0,
 		WithMissing:  0,
 	}, 0, uint32(recentBlockCount), 0)
-	for i := 0; i < len(blocksData); i++ {
+	limit := len(blocksData)
+	if limit > recentBlockCount {
+		limit = recentBlockCount
+	}
+
+	for i := 0; i < limit; i++ {
 		blockData := blocksData[i].Block
 		if blockData == nil {
 			continue
@@ -330,6 +335,10 @@ func buildIndexPageRecentSlotsData(pageData *models.IndexPageData, firstSlot pha
 			pageData.RecentSlots = append(pageData.RecentSlots, slotData)
 			blockCount++
 			buildIndexPageSlotGraph(slotData, &maxOpenFork, openForks)
+
+			if blockCount >= uint64(slotLimit) {
+				break
+			}
 		}
 	}
 	pageData.RecentSlotCount = uint64(blockCount)

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -221,7 +221,7 @@ func buildIndexPageData() (*models.IndexPageData, time.Duration) {
 	buildIndexPageRecentEpochsData(pageData, currentEpoch, finalizedEpoch, justifiedEpoch, recentEpochCount)
 
 	// load recent blocks
-	buildIndexPageRecentBlocksData(pageData, currentSlot, recentBlockCount)
+	buildIndexPageRecentBlocksData(pageData, recentBlockCount)
 
 	// load recent slots
 	buildIndexPageRecentSlotsData(pageData, currentSlot, recentSlotsCount)
@@ -257,14 +257,17 @@ func buildIndexPageRecentEpochsData(pageData *models.IndexPageData, currentEpoch
 	pageData.RecentEpochCount = uint64(len(pageData.RecentEpochs))
 }
 
-func buildIndexPageRecentBlocksData(pageData *models.IndexPageData, currentSlot phase0.Slot, recentBlockCount int) {
+func buildIndexPageRecentBlocksData(pageData *models.IndexPageData, recentBlockCount int) {
 	pageData.RecentBlocks = make([]*models.IndexPageDataBlocks, 0)
 
 	chainState := services.GlobalBeaconService.GetChainState()
 
-	blocksData := services.GlobalBeaconService.GetDbBlocks(uint64(currentSlot), int32(recentBlockCount), false, false)
+	blocksData := services.GlobalBeaconService.GetDbBlocksByFilter(&dbtypes.BlockFilter{
+		WithOrphaned: 0,
+		WithMissing:  0,
+	}, 0, uint32(recentBlockCount), 0)
 	for i := 0; i < len(blocksData); i++ {
-		blockData := blocksData[i]
+		blockData := blocksData[i].Block
 		if blockData == nil {
 			continue
 		}

--- a/handlers/slots_filtered.go
+++ b/handlers/slots_filtered.go
@@ -226,7 +226,7 @@ func buildFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string
 		withScheduledCount = 16
 	}
 
-	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(blockFilter, pageIdx, uint32(pageSize), withScheduledCount)
+	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(blockFilter, pageIdx, uint32(pageSize)+1, withScheduledCount)
 	haveMore := false
 	for idx, dbBlock := range dbBlocks {
 		if idx >= int(pageSize) {

--- a/handlers/slots_filtered.go
+++ b/handlers/slots_filtered.go
@@ -221,7 +221,12 @@ func buildFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string
 		blockFilter.ProposerIndex = &pidx
 	}
 
-	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(blockFilter, pageIdx, uint32(pageSize))
+	withScheduledCount := chainState.GetSpecs().SlotsPerEpoch - uint64(chainState.SlotToSlotIndex(currentSlot)) - 1
+	if withScheduledCount > 16 {
+		withScheduledCount = 16
+	}
+
+	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(blockFilter, pageIdx, uint32(pageSize), withScheduledCount)
 	haveMore := false
 	for idx, dbBlock := range dbBlocks {
 		if idx >= int(pageSize) {

--- a/handlers/slots_filtered.go
+++ b/handlers/slots_filtered.go
@@ -226,7 +226,7 @@ func buildFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string
 		withScheduledCount = 16
 	}
 
-	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(blockFilter, pageIdx, uint32(pageSize)+1, withScheduledCount)
+	dbBlocks := services.GlobalBeaconService.GetDbBlocksByFilter(blockFilter, pageIdx, uint32(pageSize), withScheduledCount)
 	haveMore := false
 	for idx, dbBlock := range dbBlocks {
 		if idx >= int(pageSize) {

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -169,7 +169,7 @@ func buildValidatorPageData(validatorIndex uint64) (*models.ValidatorPageData, t
 		ProposerIndex: &validatorIndex,
 		WithOrphaned:  1,
 		WithMissing:   1,
-	}, 0, 10)
+	}, 0, 10, chainState.GetSpecs().SlotsPerEpoch)
 	for _, blockData := range blocksData {
 		var blockStatus dbtypes.SlotStatus
 		if blockData.Block == nil {

--- a/handlers/validator_slots.go
+++ b/handlers/validator_slots.go
@@ -104,7 +104,7 @@ func buildValidatorSlotsPageData(validator uint64, pageIdx uint64, pageSize uint
 		ProposerIndex: &validator,
 		WithOrphaned:  1,
 		WithMissing:   1,
-	}, pageIdx, uint32(pageSize))
+	}, pageIdx, uint32(pageSize), chainState.GetSpecs().SlotsPerEpoch)
 	haveMore := false
 	for idx, blockAssignment := range dbBlocks {
 		if idx >= int(pageSize) {

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -362,17 +362,6 @@ func (block *Block) GetDbConsolidationRequests(indexer *Indexer) []*dbtypes.Cons
 	return indexer.dbWriter.buildDbConsolidationRequests(block, orphaned, nil)
 }
 
-// GetExecutionExtraData returns the execution extra data of this block.
-func (block *Block) GetExecutionExtraData() []byte {
-	blockBody := block.GetBlock()
-	if blockBody == nil {
-		return []byte{}
-	}
-
-	data, _ := getBlockExecutionExtraData(blockBody)
-	return data
-}
-
 // GetForkId returns the fork ID of this block.
 func (block *Block) GetForkId() ForkKey {
 	return block.forkId

--- a/services/chainservice_blocks.go
+++ b/services/chainservice_blocks.go
@@ -636,7 +636,7 @@ func (bs *ChainService) GetDbBlocksByFilter(filter *dbtypes.BlockFilter, pageIdx
 			}
 		}
 
-		if uint64(len(cachedMatches)) >= uint64(pageIdx+1)*uint64(pageSize) {
+		if uint64(len(cachedMatches)) > uint64(pageIdx+1)*uint64(pageSize) {
 			break
 		}
 	}
@@ -649,7 +649,7 @@ func (bs *ChainService) GetDbBlocksByFilter(filter *dbtypes.BlockFilter, pageIdx
 
 	cachedStart := pageIdx * uint64(pageSize)
 	cachedEnd := cachedStart + uint64(pageSize)
-	if cachedEnd+1 < cachedMatchesLen {
+	if cachedEnd+1 <= cachedMatchesLen {
 		cachedEnd++
 	}
 
@@ -702,12 +702,15 @@ func (bs *ChainService) GetDbBlocksByFilter(filter *dbtypes.BlockFilter, pageIdx
 		}
 	}
 
-	if resIdx >= int(pageSize) {
+	if resIdx > int(pageSize) {
 		return resBlocks
 	}
 
 	// load finalized slots from db
-	dbPage := pageIdx - cachedPages
+	dbPage := uint64(0)
+	if pageIdx > cachedPages {
+		dbPage = pageIdx - cachedPages
+	}
 	dbCacheOffset := uint64(pageSize) - (cachedMatchesLen % uint64(pageSize))
 	var dbBlocks []*dbtypes.AssignedSlot
 	if dbPage == 0 {

--- a/services/chainservice_blocks.go
+++ b/services/chainservice_blocks.go
@@ -407,11 +407,12 @@ func (bs *ChainService) GetDbBlocksForSlots(firstSlot uint64, slotLimit uint32, 
 		// load selected blocks from db
 		if len(blockRoots) > 0 {
 			blockMap := db.GetSlotsByRoots(blockRoots)
-
-			for idx, blockRoot := range blockRoots {
-				if dbBlock, ok := blockMap[phase0.Root(blockRoot)]; ok {
-					dbBlock.Status = resBlocks[blockRootsIdx[idx]].Status
-					resBlocks[blockRootsIdx[idx]] = dbBlock
+			if blockMap != nil {
+				for idx, blockRoot := range blockRoots {
+					if dbBlock, ok := blockMap[phase0.Root(blockRoot)]; ok {
+						dbBlock.Status = resBlocks[blockRootsIdx[idx]].Status
+						resBlocks[blockRootsIdx[idx]] = dbBlock
+					}
 				}
 			}
 		}
@@ -688,16 +689,17 @@ func (bs *ChainService) GetDbBlocksByFilter(filter *dbtypes.BlockFilter, pageIdx
 	// load pruned blocks from database
 	if len(blockRoots) > 0 {
 		blockMap := db.GetSlotsByRoots(blockRoots)
+		if blockMap != nil {
+			for idx, blockRoot := range blockRoots {
+				if dbBlock, ok := blockMap[phase0.Root(blockRoot)]; ok {
 
-		for idx, blockRoot := range blockRoots {
-			if dbBlock, ok := blockMap[phase0.Root(blockRoot)]; ok {
+					dbBlock.Status = dbtypes.Canonical
+					if cachedMatches[blockRootsCachedId[idx]].orphaned {
+						dbBlock.Status = dbtypes.Orphaned
+					}
 
-				dbBlock.Status = dbtypes.Canonical
-				if cachedMatches[blockRootsCachedId[idx]].orphaned {
-					dbBlock.Status = dbtypes.Orphaned
+					resBlocks[blockRootsIdx[idx]].Block = dbBlock
 				}
-
-				resBlocks[blockRootsIdx[idx]].Block = dbBlock
 			}
 		}
 	}


### PR DESCRIPTION
One more regression coming from #83

This fixes #109 by reimplementing the 2 central slot selection methods (`GetDbBlocksForSlots` & `GetDbBlocksByFilter`)

Background:
The old indexer stored all old unfinalized slot assignments (including missing slots) in db after some epochs.
this is no longer the case with the new indexer, as missing slot duties may differ depending on which fork is seen as canonical.
for the new indexer, the proposer duties are available in cache for all unfinalized epochs.

I've missed updating the two slot selection methods for this slight logic change, 
therefore it still tried to load missing slots from db, which is no longer possible.

the two slot selection methods need to construct or load slots in 3 different ways depending on cache processing status:
* If slot is unfinalized & unpruned (`slot` >= `prunedSlot`):
  check filter & load block from cache, construct the slot entry on the fly and reconstruct missing blocks
* If slot is unfinalized & pruned (`slot` < `prunedSlot` && `slot` >= `finalizedSlot`):
  check filter based on cache, check canonical status, load relevant slot entries from db and reconstruct missing blocks
* If slot is finalized (`slot` < `finalizesSlot`):
  load filtered slot entries from db


