### PR TITLE
cleanup old blocks from cache in pruning routine

### DIFF
--- a/indexer/beacon/blockcache.go
+++ b/indexer/beacon/blockcache.go
@@ -212,6 +212,23 @@ func (cache *blockCache) getPruningBlocks(minInMemorySlot phase0.Slot) []*Block 
 	return blocks
 }
 
+// getCleanupBlocks returns the blocks that can be cleaned up based on the given finalized slot.
+func (cache *blockCache) getCleanupBlocks(finalizedSlot phase0.Slot) []*Block {
+	cache.cacheMutex.RLock()
+	defer cache.cacheMutex.RUnlock()
+
+	blocks := []*Block{}
+	for slot, slotBlocks := range cache.slotMap {
+		if slot >= finalizedSlot {
+			continue
+		}
+
+		blocks = append(blocks, slotBlocks...)
+	}
+
+	return blocks
+}
+
 // getForkBlocks returns a slice of blocks that belong to the specified forkId.
 func (cache *blockCache) getForkBlocks(forkId ForkKey) []*Block {
 	cache.cacheMutex.RLock()


### PR DESCRIPTION
Added a missing cleanup routine that removes block from the finalized block range from cache.
This 'should' never happen under normal conditions as the finalization routine is responsible for removing these block after processing.
However, there might be race conditions where a client receives a new block at the same time the finalization routine processes an epoch. That's clearly an edge case as new blocks even when orphaned usually do not arrive that late. But without the additional cleanup, these blocks would stay in memory forever.