### PR TITLE
fix endless loop when validator set cannot be loaded on dead chain

### DIFF
--- a/indexer/beacon/canonical.go
+++ b/indexer/beacon/canonical.go
@@ -365,7 +365,7 @@ func (indexer *Indexer) GetCanonicalValidatorSet(overrideForkId *ForkKey) []*v1.
 
 	for {
 		epoch := chainState.EpochOfSlot(canonicalHead.Slot)
-		if headEpoch-epoch > 2 {
+		if headEpoch-epoch > 2 || epoch == 0 {
 			return validatorSet
 		}
 


### PR DESCRIPTION
As currently seen on https://dora.ssz-devnet-0.ethpandaops.io

There is no validator set available as there is no blocks in the network and no epoch stats are loaded.
Due to an issue in the `GetCanonicalValidatorSet`, dora gets stuck in an endess loop, trying to iterate to the parent of epoch 0, which obviously doesn't work.

The error propagates down to several pages and other parts of the code as they're all calling the GetCanonicalValidatorSet` function:
![image](https://github.com/user-attachments/assets/ead9e6b8-9184-4b20-8816-464ea6a4b43e)
