### PR TITLE
fix loading validator set for epoch 0 (fix #151)

### DIFF
--- a/indexer/beacon/canonical.go
+++ b/indexer/beacon/canonical.go
@@ -365,7 +365,7 @@ func (indexer *Indexer) GetCanonicalValidatorSet(overrideForkId *ForkKey) []*v1.
 
 	for {
 		epoch := chainState.EpochOfSlot(canonicalHead.Slot)
-		if headEpoch-epoch > 2 || epoch == 0 {
+		if headEpoch-epoch > 2 {
 			return validatorSet
 		}
 
@@ -376,7 +376,7 @@ func (indexer *Indexer) GetCanonicalValidatorSet(overrideForkId *ForkKey) []*v1.
 		canonicalHead = dependentBlock
 
 		epochStats = indexer.epochCache.getEpochStats(epoch, dependentBlock.Root)
-		if epochStats == nil || epochStats.dependentState == nil || epochStats.dependentState.loadingStatus != 2 {
+		if epoch > 0 && (epochStats == nil || epochStats.dependentState == nil || epochStats.dependentState.loadingStatus != 2) {
 			continue // retry previous state
 		}
 


### PR DESCRIPTION
this fixes a regression introduced by #151. due to the fix, the validator set for epoch 0 could not be requested anymore, which leads to missing duties & validator stats for epoch 0.

this reverts the fix introduced by #151 and fixed the issue properly.