### PR TITLE
fix caching duration for slots page in epoch 0

### DIFF
--- a/handlers/slots.go
+++ b/handlers/slots.go
@@ -133,7 +133,7 @@ func buildSlotsPageData(firstSlot uint64, pageSize uint64) (*models.SlotsPageDat
 	maxOpenFork := 0
 	for slotIdx := int64(firstSlot); slotIdx >= int64(lastSlot); slotIdx-- {
 		slot := uint64(slotIdx)
-		finalized := finalizedEpoch >= chainState.EpochOfSlot(phase0.Slot(slot))
+		finalized := finalizedEpoch > 0 && finalizedEpoch >= chainState.EpochOfSlot(phase0.Slot(slot))
 		if !finalized {
 			allFinalized = false
 		}


### PR DESCRIPTION
`finalizedEpoch >= chainState.EpochOfSlot(phase0.Slot(slot))` is always true during epoch 0 when no epoch is finalized yet, so dora ended up caching the slots page for 30 minutes as it thought it's only showing finalized old blocks:
 
![image](https://github.com/user-attachments/assets/668a651b-1467-47a7-a66e-715d18113ab3)
this was triggered on ephemery
