### PR TITLE
fix parsing of validator names for single indexes

### DIFF
--- a/services/validatornames.go
+++ b/services/validatornames.go
@@ -400,7 +400,7 @@ func (vn *ValidatorNames) parseNamesMap(names map[string]string) int {
 			if err != nil {
 				continue
 			}
-			maxIdx := minIdx + 1
+			maxIdx := minIdx
 			if len(rangeParts) > 1 {
 				maxIdx, err = strconv.ParseUint(rangeParts[1], 10, 64)
 				if err != nil {


### PR DESCRIPTION
fix parsing of validator name inventories like this:
```yaml
# ephemery validators
0: "gvr_seed"
1-1000: "coincashew.eth-node1"
1001-1200: "ephemery-node1"
1201-6200: "ethpandaops-node1"
6201-8700: "laibe-node1"
8701-10400: "mario-node1"
```

the single index name ("gvr_seed") was applied to key index 0 & 1, which is wrong:
![image](https://github.com/user-attachments/assets/17c3bd59-878d-4e15-8e4e-93aabc5a14a0)
