### PR TITLE
fix index name collision in sql schema

### DIFF
--- a/db/schema/pgsql/20240805095505_pectra-updates2.sql
+++ b/db/schema/pgsql/20240805095505_pectra-updates2.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS public."consolidation_requests" (
     target_index BIGINT NULL,
     target_pubkey bytea NULL,
     tx_hash bytea NULL,
-    CONSTRAINT consolidation_pkey PRIMARY KEY (slot_root, slot_index)
+    CONSTRAINT consolidation_requests_pkey PRIMARY KEY (slot_root, slot_index)
 );
 
 CREATE INDEX IF NOT EXISTS "consolidation_requests_slot_idx"

--- a/db/schema/pgsql/20241006182734_pectra-updates3.sql
+++ b/db/schema/pgsql/20241006182734_pectra-updates3.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS public."consolidation_request_txs" (
     tx_sender bytea NOT NULL,
     tx_target bytea NOT NULL,
     dequeue_block BIGINT NOT NULL,
-    CONSTRAINT consolidation_pkey PRIMARY KEY (block_root, block_index)
+    CONSTRAINT consolidation_request_txs_pkey PRIMARY KEY (block_root, block_index)
 );
 
 CREATE INDEX IF NOT EXISTS "consolidation_request_txs_block_number_idx"

--- a/db/schema/sqlite/20240805095505_pectra-updates2.sql
+++ b/db/schema/sqlite/20240805095505_pectra-updates2.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS "consolidation_requests" (
     target_index BIGINT NULL,
     target_pubkey BLOB NULL,
     tx_hash BLOB NULL,
-    CONSTRAINT consolidation_pkey PRIMARY KEY (slot_root, slot_index)
+    CONSTRAINT consolidation_requests_pkey PRIMARY KEY (slot_root, slot_index)
 );
 
 CREATE INDEX IF NOT EXISTS "consolidation_requests_slot_idx"

--- a/db/schema/sqlite/20241006182734_pectra-updates3.sql
+++ b/db/schema/sqlite/20241006182734_pectra-updates3.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS "consolidation_request_txs" (
     tx_sender BLOB NOT NULL,
     tx_target BLOB NOT NULL,
     dequeue_block BIGINT NOT NULL,
-    CONSTRAINT consolidation_pkey PRIMARY KEY (block_root, block_index)
+    CONSTRAINT consolidation_request_txs_pkey PRIMARY KEY (block_root, block_index)
 );
 
 CREATE INDEX IF NOT EXISTS "consolidation_request_txs_block_number_idx"


### PR DESCRIPTION
upgrading the pgsql schema does currently not work:
`ERROR: relation "consolidation_pkey" already exists (SQLSTATE 42P07)`