### PR TITLE
fix insert query for consolidation request txs to pgsql

### DIFF
--- a/db/consolidation_request_txs.go
+++ b/db/consolidation_request_txs.go
@@ -53,7 +53,7 @@ func InsertConsolidationRequestTxs(consolidationTxs []*dbtypes.ConsolidationRequ
 		argIdx += fieldCount
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql:  " ON CONFLICT (block_number, block_index) DO UPDATE SET source_index = excluded.source_index, target_index = excluded.target_index, fork_id = excluded.fork_id",
+		dbtypes.DBEnginePgsql:  " ON CONFLICT (block_root, block_index) DO UPDATE SET source_index = excluded.source_index, target_index = excluded.target_index, fork_id = excluded.fork_id",
 		dbtypes.DBEngineSqlite: "",
 	}))
 

--- a/db/consolidation_requests.go
+++ b/db/consolidation_requests.go
@@ -50,7 +50,7 @@ func InsertConsolidationRequests(consolidations []*dbtypes.ConsolidationRequest,
 		argIdx += fieldCount
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
-		dbtypes.DBEnginePgsql:  " ON CONFLICT (slot_index, slot_root) DO UPDATE SET orphaned = excluded.orphaned, fork_id = excluded.fork_id",
+		dbtypes.DBEnginePgsql:  " ON CONFLICT (slot_root, slot_index) DO UPDATE SET orphaned = excluded.orphaned, fork_id = excluded.fork_id",
 		dbtypes.DBEngineSqlite: "",
 	}))
 	_, err := tx.Exec(sql.String(), args...)


### PR DESCRIPTION
fixes another SQL issue related to pgsql:
```
time="2024-10-30T10:20:47Z" level=error msg="indexer error: could not persist indexed transactions: error while persisting contract logs: error while inserting consolidation txs: ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10)" indexer=consolidations service=el-indexer
```