### PR TITLE
Fixes related to nft devnet

### DIFF
--- a/db/unfinalized_epochs.go
+++ b/db/unfinalized_epochs.go
@@ -80,7 +80,7 @@ func StreamUnfinalizedEpochs(epoch uint64, cb func(duty *dbtypes.UnfinalizedEpoc
 	return nil
 }
 
-func GetUnfinalizedEpochs(epoch uint64) *dbtypes.UnfinalizedEpoch {
+func GetUnfinalizedEpoch(epoch uint64, headRoot []byte) *dbtypes.UnfinalizedEpoch {
 	unfinalizedEpoch := dbtypes.UnfinalizedEpoch{}
 	err := ReaderDb.Get(&unfinalizedEpoch, `
 	SELECT
@@ -88,24 +88,8 @@ func GetUnfinalizedEpochs(epoch uint64) *dbtypes.UnfinalizedEpoch {
 		voted_head, voted_total, block_count, orphaned_count, attestation_count, deposit_count, exit_count, withdraw_count,
 		withdraw_amount, attester_slashing_count, proposer_slashing_count, bls_change_count, eth_transaction_count, sync_participation
 	FROM unfinalized_epochs
-	WHERE epoch = $1
-	`, epoch)
-	if err != nil {
-		return nil
-	}
-	return &unfinalizedEpoch
-}
-
-func GetUnfinalizedEpoch(epoch uint64) *dbtypes.UnfinalizedEpoch {
-	unfinalizedEpoch := dbtypes.UnfinalizedEpoch{}
-	err := ReaderDb.Get(&unfinalizedEpoch, `
-	SELECT
-		epoch, dependent_root, epoch_head_root, epoch_head_fork_id, validator_count, validator_balance, eligible, voted_target,
-		voted_head, voted_total, block_count, orphaned_count, attestation_count, deposit_count, exit_count, withdraw_count,
-		withdraw_amount, attester_slashing_count, proposer_slashing_count, bls_change_count, eth_transaction_count, sync_participation
-	FROM unfinalized_epochs
-	WHERE epoch = $1
-	`, epoch)
+	WHERE epoch = $1 AND epoch_head_root = $2
+	`, epoch, headRoot)
 	if err != nil {
 		return nil
 	}

--- a/indexer/beacon/canonical.go
+++ b/indexer/beacon/canonical.go
@@ -385,6 +385,10 @@ func (indexer *Indexer) GetCanonicalValidatorSet(overrideForkId *ForkKey) []*v1.
 		break
 	}
 
+	if epochStats == nil || epochStats.dependentState == nil || epochStats.dependentState.loadingStatus != 2 {
+		return validatorSet
+	}
+
 	epochStatsKey := getEpochStatsKey(epochStats.epoch, epochStats.dependentRoot)
 	if cachedValSet, found := indexer.validatorSetCache.Get(epochStatsKey); found {
 		return cachedValSet

--- a/indexer/beacon/canonical.go
+++ b/indexer/beacon/canonical.go
@@ -56,7 +56,9 @@ func (indexer *Indexer) GetCanonicalHead(overrideForkId *ForkKey) *Block {
 						factor = 0.5
 					}
 					percentagesI += chainHeadCandidates[i].PerEpochVotingPercent[k] * factor
-					percentagesJ += chainHeadCandidates[j].PerEpochVotingPercent[k] * factor
+					if len(chainHeadCandidates[j].PerEpochVotingPercent) > k {
+						percentagesJ += chainHeadCandidates[j].PerEpochVotingPercent[k] * factor
+					}
 				}
 
 				if percentagesI != percentagesJ {

--- a/indexer/beacon/epochcache.go
+++ b/indexer/beacon/epochcache.go
@@ -2,8 +2,9 @@ package beacon
 
 import (
 	"bytes"
+	"crypto/md5"
 	"encoding/binary"
-	"math/rand"
+	"fmt"
 	"runtime/debug"
 	"sort"
 	"sync"
@@ -450,7 +451,9 @@ func (cache *epochCache) loadEpochStats(epochStats *EpochStats) bool {
 			}
 		}
 
-		return rand.Intn(2) == 0
+		hashA := md5.Sum([]byte(fmt.Sprintf("%v-%v", cliA.client.GetIndex(), epochStats.epoch)))
+		hashB := md5.Sum([]byte(fmt.Sprintf("%v-%v", cliB.client.GetIndex(), epochStats.epoch)))
+		return bytes.Compare(hashA[:], hashB[:]) < 0
 	})
 
 	client := clients[int(epochStats.dependentState.retryCount)%len(clients)]

--- a/indexer/beacon/epochcache.go
+++ b/indexer/beacon/epochcache.go
@@ -49,7 +49,7 @@ type epochCache struct {
 // newEpochCache creates & returns a new instance of epochCache.
 // initializes the cache & starts the beacon state loader subroutine.
 func newEpochCache(indexer *Indexer) *epochCache {
-	votesCacheSize := int(indexer.inMemoryEpochs) * 10
+	votesCacheSize := int(indexer.inMemoryEpochs) * 4
 	if votesCacheSize < 10 {
 		votesCacheSize = 10
 	} else if votesCacheSize > 200 {

--- a/indexer/beacon/epochcache.go
+++ b/indexer/beacon/epochcache.go
@@ -49,7 +49,7 @@ type epochCache struct {
 // newEpochCache creates & returns a new instance of epochCache.
 // initializes the cache & starts the beacon state loader subroutine.
 func newEpochCache(indexer *Indexer) *epochCache {
-	votesCacheSize := int(indexer.inMemoryEpochs) * 3
+	votesCacheSize := int(indexer.inMemoryEpochs) * 10
 	if votesCacheSize < 10 {
 		votesCacheSize = 10
 	} else if votesCacheSize > 200 {

--- a/indexer/beacon/epochcache.go
+++ b/indexer/beacon/epochcache.go
@@ -460,7 +460,8 @@ func (cache *epochCache) loadEpochStats(epochStats *EpochStats) bool {
 
 	if epochStats.dependentState.loadingStatus != 2 {
 		// epoch state could not be loaded
-		return true
+		epochStats.dependentState.retryCount++
+		return false
 	}
 
 	dependentStats := []*EpochStats{}

--- a/indexer/beacon/epochcache.go
+++ b/indexer/beacon/epochcache.go
@@ -453,6 +453,13 @@ func (cache *epochCache) loadEpochStats(epochStats *EpochStats) bool {
 	})
 
 	client := clients[int(epochStats.dependentState.retryCount)%len(clients)]
+	log := cache.indexer.logger.WithField("client", client.client.GetName())
+	if epochStats.dependentState.retryCount > 0 {
+		log = log.WithField("retry", epochStats.dependentState.retryCount)
+	}
+
+	log.Infof("loading epoch %v stats (dep: %v, req: %v)", epochStats.epoch, epochStats.dependentRoot.String(), len(epochStats.requestedBy))
+
 	err := epochStats.dependentState.loadState(client.getContext(), client, cache)
 	if err != nil && epochStats.dependentState.loadingStatus == 0 {
 		client.logger.Warnf("failed loading epoch %v stats (dep: %v): %v", epochStats.epoch, epochStats.dependentRoot.String(), err)

--- a/indexer/beacon/epochcache.go
+++ b/indexer/beacon/epochcache.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"bytes"
 	"encoding/binary"
+	"math/rand"
 	"runtime/debug"
 	"sort"
 	"sync"
@@ -449,7 +450,7 @@ func (cache *epochCache) loadEpochStats(epochStats *EpochStats) bool {
 			}
 		}
 
-		return cliA.index < cliB.index
+		return rand.Intn(2) == 0
 	})
 
 	client := clients[int(epochStats.dependentState.retryCount)%len(clients)]

--- a/indexer/beacon/epochstats.go
+++ b/indexer/beacon/epochstats.go
@@ -649,7 +649,6 @@ func (es *EpochStats) GetDbEpoch(indexer *Indexer, headBlock *Block) *dbtypes.Ep
 	})
 
 	// compute epoch votes
-	indexer.logger.Warnf("compute epoch aggregation for epoch %v (head: %v)", es.epoch, headBlock.Root.String()) // TODO: remove log
 	epochVotes := es.GetEpochVotes(indexer, headBlock)
 
 	return indexer.dbWriter.buildDbEpoch(es.epoch, epochBlocks, es, epochVotes, nil)

--- a/indexer/beacon/epochstats.go
+++ b/indexer/beacon/epochstats.go
@@ -649,6 +649,7 @@ func (es *EpochStats) GetDbEpoch(indexer *Indexer, headBlock *Block) *dbtypes.Ep
 	})
 
 	// compute epoch votes
+	indexer.logger.Warnf("compute epoch aggregation for epoch %v (head: %v)", es.epoch, headBlock.Root.String()) // TODO: remove log
 	epochVotes := es.GetEpochVotes(indexer, headBlock)
 
 	return indexer.dbWriter.buildDbEpoch(es.epoch, epochBlocks, es, epochVotes, nil)

--- a/indexer/beacon/epochstats.go
+++ b/indexer/beacon/epochstats.go
@@ -90,6 +90,10 @@ func (es *EpochStats) GetEpoch() phase0.Epoch {
 	return es.epoch
 }
 
+func (es *EpochStats) GetDependentRoot() phase0.Root {
+	return es.dependentRoot
+}
+
 // addRequestedBy adds a client to the list of clients that have requested this EpochStats.
 func (es *EpochStats) addRequestedBy(client *Client) bool {
 	es.requestedMutex.Lock()
@@ -632,6 +636,10 @@ func (es *EpochStats) GetDbEpoch(indexer *Indexer, headBlock *Block) *dbtypes.Ep
 			}
 
 			return dbEpoch
+		}
+
+		if len(epochBlocks) > 0 {
+			indexer.logger.Warnf("no pruned epoch aggregation found for epoch %v (head: %v)", es.epoch, epochBlocks[0].Root.String())
 		}
 	}
 

--- a/indexer/beacon/epochvotes.go
+++ b/indexer/beacon/epochvotes.go
@@ -191,7 +191,7 @@ func (indexer *Indexer) aggregateEpochVotes(epoch phase0.Epoch, chainState *cons
 
 	indexer.epochCache.votesCache.Add(votesKey, votes)
 
-	indexer.logger.Debugf("aggregated epoch %v votes in %v (blocks: %v)", epoch, time.Since(t1), len(blocks))
+	indexer.logger.Infof("aggregated epoch %v votes in %v (blocks: %v) [0x%x]", epoch, time.Since(t1), len(blocks), votesKey[:]) //TODO: reduce to debug
 	return votes
 }
 

--- a/indexer/beacon/epochvotes.go
+++ b/indexer/beacon/epochvotes.go
@@ -191,7 +191,7 @@ func (indexer *Indexer) aggregateEpochVotes(epoch phase0.Epoch, chainState *cons
 
 	indexer.epochCache.votesCache.Add(votesKey, votes)
 
-	indexer.logger.Infof("aggregated epoch %v votes in %v (blocks: %v) [0x%x]", epoch, time.Since(t1), len(blocks), votesKey[:]) //TODO: reduce to debug
+	indexer.logger.Debugf("aggregated epoch %v votes in %v (blocks: %v) [0x%x]", epoch, time.Since(t1), len(blocks), votesKey[:])
 	return votes
 }
 


### PR DESCRIPTION
Some fixes for issues that came up in the nft devnet.
The root cause for most of these issues has been, that dora wasn't able to load the big beacon states within the timespan of one epoch. Due to that, epoch state requests were piling up and later dropped.