### PR TITLE
add dynamic spec check conditions

### DIFF
--- a/clients/consensus/chainstate.go
+++ b/clients/consensus/chainstate.go
@@ -74,7 +74,10 @@ func (cs *ChainState) setClientSpecs(specValues map[string]interface{}) (error, 
 	var warning error
 
 	if cs.specs != nil {
-		mismatches := cs.specs.CheckMismatch(specs)
+		mismatches, err := cs.specs.CheckMismatch(specs)
+		if err != nil {
+			return nil, err
+		}
 		if len(mismatches) > 0 {
 			return nil, fmt.Errorf("spec mismatch: %v", strings.Join(mismatches, ", "))
 		}
@@ -85,7 +88,10 @@ func (cs *ChainState) setClientSpecs(specValues map[string]interface{}) (error, 
 			return nil, err
 		}
 
-		mismatches = cs.specs.CheckMismatch(newSpecs)
+		mismatches, err = cs.specs.CheckMismatch(newSpecs)
+		if err != nil {
+			return nil, err
+		}
 		if len(mismatches) > 0 {
 			warning = fmt.Errorf("spec missing: %v", strings.Join(mismatches, ", "))
 		}


### PR DESCRIPTION
This PR introduces dynamic spec check conditions that are evaluated using [govaluate](https://github.com/Knetic/govaluate).
These conditions exclude spec values that are introduced by disabled forks.

This fixes problems with dora running on [holesky](https://dora.holesky.ethpandaops.io/clients/consensus) or [sepolia](https://dora.sepolia.ethpandaops.io/clients/consensus). 
More and more clients release electra code, which is not yet used, but spec values already exposed.
Upgrading our testnet nodes leads to spec mismatches for electra/peerdas values as some clients already include them and some not.
This is however not a real issue, as electra is not even planned for activation on these testnets.

With this PR, spec values of future forks (electra, peerdas) are only checked if the corresponding fork is planned for activation.