### PR TITLE
fix: make timestamp copy btn work in epoch page

### DIFF
--- a/templates/epoch/epoch.html
+++ b/templates/epoch/epoch.html
@@ -44,7 +44,7 @@
           <div class="col-md-6">
             <span aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="FROMNOW">{{ .Ts }}</span>
             (<span id="timestamp" aria-ethereum-date="{{ .Ts.Unix }}" aria-ethereum-date-format="LOCAL" data-timer="{{ .Ts.Unix }}">{{ formatRecentTimeShort .Ts }}</span>)
-            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" onclick="copyTs()"></i>
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .Ts }}"></i>
           </div>
         </div>
         <div class="row border-bottom p-2 mx-0">


### PR DESCRIPTION
Hi, I found that copy button for epoch timestamp doesn't work. `copyTs` seems a legacy function, so I changed it as other pages do.