### PR TITLE
fix: avoid reprocessing of validator activity

### DIFF
--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -35,6 +35,7 @@ type Block struct {
 	processingStatus  dbtypes.UnfinalizedBlockStatus
 	seenMutex         sync.RWMutex
 	seenMap           map[uint16]*Client
+	processedActivity uint8
 }
 
 // BlockBodyIndex holds important block propoerties that are used as index for cache lookups.

--- a/indexer/beacon/debug.go
+++ b/indexer/beacon/debug.go
@@ -162,13 +162,13 @@ func (indexer *Indexer) getValidatorCacheDebugStats(cacheStats *CacheDebugStats)
 			refs++
 		}
 		cacheStats.ValidatorCache.ValidatorDiffs += uint64(refs)
-
-		if validator.recentActivity != nil {
-			cacheStats.ValidatorCache.ValidatorActivity += uint64(len(validator.recentActivity))
-		}
 	}
 
 	cacheStats.ValidatorCache.ValidatorData = uint64(len(validatorsMap))
+
+	for _, recentActivity := range indexer.validatorCache.validatorActivityMap {
+		cacheStats.ValidatorCache.ValidatorActivity += uint64(len(recentActivity))
+	}
 
 	cacheStats.ValidatorCache.PubkeyMap = CacheDebugMapSize{
 		Length: len(indexer.validatorCache.pubkeyMap),


### PR DESCRIPTION
Avoid re-processing of the validator voting activity for each block.
This lead to a quite high processing overlay for instances with large validator sets (holesky).

With this PR, the validator activity is only processed twice per block, instead of for every voting aggregation.
It still needs to be twice, because each block can contain votes from the current and last epoch, so the the activity needs to be tracked when aggregation votes for the current and last epoch.