### PR TITLE
fix panic in electra duty calculation

### DIFF
--- a/indexer/beacon/duties/duties.go
+++ b/indexer/beacon/duties/duties.go
@@ -52,7 +52,18 @@ func UintToBytes(data any) []byte {
 }
 
 func BytesToUint(data []byte) uint64 {
-	return binary.LittleEndian.Uint64(data)
+	switch len(data) {
+	case 1:
+		return uint64(data[0])
+	case 2:
+		return uint64(binary.LittleEndian.Uint16(data))
+	case 4:
+		return uint64(binary.LittleEndian.Uint32(data))
+	case 8:
+		return binary.LittleEndian.Uint64(data)
+	default:
+		return 0
+	}
 }
 
 func SplitOffset(listSize, chunks, index uint64) uint64 {


### PR DESCRIPTION
fix panic in electra duty calculation:

```
panic: runtime error: index out of range [7] with length 2

goroutine 136 [running]:
encoding/binary.littleEndian.Uint64(...)
        /home/pk910/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/encoding/binary/binary.go:106
github.com/ethpandaops/dora/indexer/beacon/duties.BytesToUint(...)
        /home/pk910/github/ethpandaops/dora/indexer/beacon/duties/duties.go:55
github.com/ethpandaops/dora/indexer/beacon/duties.GetProposerIndex(0xc001924000, 0xc00162be88, 0x660)
        /home/pk910/github/ethpandaops/dora/indexer/beacon/duties/duties.go:180 +0x40f
github.com/ethpandaops/dora/indexer/beacon.(*EpochStats).parsePackedSSZ(0xc0016481a0, 0x10615a0?, 0xc000000300, {0xc0001d0f00?, 0xc0004802a0?, 0xc0000c2ec8?})
        /home/pk910/github/ethpandaops/dora/indexer/beacon/epochstats.go:247 +0x525
github.com/ethpandaops/dora/indexer/beacon.(*EpochStats).restoreFromDb(0xc0016481a0, 0x4ab84428d4285356?, 0x5c9931237cd56d4a?, 0xcfd406efb2652ee3?)
        /home/pk910/github/ethpandaops/dora/indexer/beacon/epochstats.go:128 +0x37
github.com/ethpandaops/dora/indexer/beacon.(*Indexer).StartIndexer.func2.1()
        /home/pk910/github/ethpandaops/dora/indexer/beacon/indexer.go:260 +0x108
created by github.com/ethpandaops/dora/indexer/beacon.(*Indexer).StartIndexer.func2 in goroutine 1
        /home/pk910/github/ethpandaops/dora/indexer/beacon/indexer.go:252 +0xfb
exit status 2
```

BytesToUint wasn't able to handle variable length inputs here.