### PR TITLE
show pending consolidation & withdrawal requests in UI

### DIFF
--- a/db/consolidation_request_txs.go
+++ b/db/consolidation_request_txs.go
@@ -227,7 +227,7 @@ func GetConsolidationRequestTxsFiltered(offset uint64, limit uint32, canonicalFo
 	FROM cte
 	UNION ALL SELECT * FROM (
 	SELECT * FROM cte
-	ORDER BY block_time DESC
+	ORDER BY block_time DESC, block_index DESC
 	LIMIT $%v 
 	`, len(args))
 

--- a/db/withdrawal_request_txs.go
+++ b/db/withdrawal_request_txs.go
@@ -211,7 +211,7 @@ func GetWithdrawalRequestTxsFiltered(offset uint64, limit uint32, canonicalForkI
 	FROM cte
 	UNION ALL SELECT * FROM (
 	SELECT * FROM cte
-	ORDER BY block_time DESC
+	ORDER BY block_time DESC, block_index DESC
 	LIMIT $%v 
 	`, len(args))
 

--- a/handlers/el_consolidations.go
+++ b/handlers/el_consolidations.go
@@ -145,7 +145,7 @@ func buildFilteredElConsolidationsPageData(pageIdx uint64, pageSize uint64, minS
 	if tgtVName != "" {
 		filterArgs.Add("f.tvname", tgtVName)
 	}
-	if withOrphaned != 0 {
+	if withOrphaned != 1 {
 		filterArgs.Add("f.orphaned", fmt.Sprintf("%v", withOrphaned))
 	}
 	if pubkey != "" {
@@ -197,7 +197,7 @@ func buildFilteredElConsolidationsPageData(pageIdx uint64, pageSize uint64, minS
 		},
 	}
 
-	dbElConsolidations, totalRows := services.GlobalBeaconService.GetConsolidationRequestsByFilter(consolidationRequestFilter, pageIdx-1, uint32(pageSize))
+	dbElConsolidations, totalPendingTxRows, totalRequests := services.GlobalBeaconService.GetConsolidationRequestsByFilter(consolidationRequestFilter, (pageIdx-1)*pageSize, uint32(pageSize))
 	chainState := services.GlobalBeaconService.GetChainState()
 	headBlock := services.GlobalBeaconService.GetBeaconIndexer().GetCanonicalHead(nil)
 	headBlockNum := uint64(0)
@@ -271,6 +271,7 @@ func buildFilteredElConsolidationsPageData(pageIdx uint64, pageSize uint64, minS
 		pageData.LastIndex = pageData.ElRequests[pageData.RequestCount-1].SlotNumber
 	}
 
+	totalRows := totalPendingTxRows + totalRequests
 	pageData.TotalPages = totalRows / pageSize
 	if totalRows%pageSize > 0 {
 		pageData.TotalPages++

--- a/handlers/el_withdrawals.go
+++ b/handlers/el_withdrawals.go
@@ -130,7 +130,7 @@ func buildFilteredElWithdrawalsPageData(pageIdx uint64, pageSize uint64, minSlot
 	if vname != "" {
 		filterArgs.Add("f.vname", vname)
 	}
-	if withOrphaned != 0 {
+	if withOrphaned != 1 {
 		filterArgs.Add("f.orphaned", fmt.Sprintf("%v", withOrphaned))
 	}
 	if withType != 0 {
@@ -189,7 +189,7 @@ func buildFilteredElWithdrawalsPageData(pageIdx uint64, pageSize uint64, minSlot
 		withdrawalRequestFilter.Filter.MaxAmount = &maxAmount
 	}
 
-	dbElWithdrawals, totalRows := services.GlobalBeaconService.GetWithdrawalRequestsByFilter(withdrawalRequestFilter, pageIdx-1, uint32(pageSize))
+	dbElWithdrawals, totalPendingTxRows, totalRequests := services.GlobalBeaconService.GetWithdrawalRequestsByFilter(withdrawalRequestFilter, (pageIdx-1)*pageSize, uint32(pageSize))
 	chainState := services.GlobalBeaconService.GetChainState()
 	headBlock := services.GlobalBeaconService.GetBeaconIndexer().GetCanonicalHead(nil)
 	headBlockNum := uint64(0)
@@ -257,6 +257,7 @@ func buildFilteredElWithdrawalsPageData(pageIdx uint64, pageSize uint64, minSlot
 		pageData.LastIndex = pageData.ElRequests[pageData.RequestCount-1].SlotNumber
 	}
 
+	totalRows := totalPendingTxRows + totalRequests
 	pageData.TotalPages = totalRows / pageSize
 	if totalRows%pageSize > 0 {
 		pageData.TotalPages++

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -434,13 +434,13 @@ func buildValidatorPageData(validatorIndex uint64, tabView string) (*models.Vali
 
 	// load recent withdrawal requests
 	if pageData.TabView == "withdrawalrequests" {
-		dbElWithdrawals, totalElWithdrawals := services.GlobalBeaconService.GetWithdrawalRequestsByFilter(&services.CombinedWithdrawalRequestFilter{
+		dbElWithdrawals, totalPendingWithdrawalTxs, totalWithdrawalReqs := services.GlobalBeaconService.GetWithdrawalRequestsByFilter(&services.CombinedWithdrawalRequestFilter{
 			Filter: &dbtypes.WithdrawalRequestFilter{
 				PublicKey: validator.Validator.PublicKey[:],
 			},
 		}, 0, 10)
-		if totalElWithdrawals > 10 {
-			pageData.AdditionalWithdrawalRequestCount = totalElWithdrawals - 10
+		if totalPendingWithdrawalTxs+totalWithdrawalReqs > 10 {
+			pageData.AdditionalWithdrawalRequestCount = totalPendingWithdrawalTxs + totalWithdrawalReqs - 10
 		}
 
 		// helper to load tx details for withdrawal requests
@@ -508,13 +508,13 @@ func buildValidatorPageData(validatorIndex uint64, tabView string) (*models.Vali
 
 	// load recent consolidation requests
 	if pageData.TabView == "consolidationrequests" {
-		dbConsolidations, totalConsolidations := services.GlobalBeaconService.GetConsolidationRequestsByFilter(&services.CombinedConsolidationRequestFilter{
+		dbConsolidations, totalPendingConsolidationTxs, totalConsolidationReqs := services.GlobalBeaconService.GetConsolidationRequestsByFilter(&services.CombinedConsolidationRequestFilter{
 			Filter: &dbtypes.ConsolidationRequestFilter{
 				PublicKey: validator.Validator.PublicKey[:],
 			},
 		}, 0, 10)
-		if totalConsolidations > 10 {
-			pageData.AdditionalConsolidationRequestCount = totalConsolidations - 10
+		if totalPendingConsolidationTxs+totalConsolidationReqs > 10 {
+			pageData.AdditionalConsolidationRequestCount = totalPendingConsolidationTxs + totalConsolidationReqs - 10
 		}
 
 		// helper to load tx details for consolidation requests
@@ -618,14 +618,14 @@ func buildValidatorPageData(validatorIndex uint64, tabView string) (*models.Vali
 			pageData.ExitReasonSlot = exits[0].SlotNumber
 
 			// Check for full withdrawal request
-		} else if withdrawals, totalWithdrawals := services.GlobalBeaconService.GetWithdrawalRequestsByFilter(&services.CombinedWithdrawalRequestFilter{
+		} else if withdrawals, totalPendingWithdrawalTxs, totalWithdrawalReqs := services.GlobalBeaconService.GetWithdrawalRequestsByFilter(&services.CombinedWithdrawalRequestFilter{
 			Filter: &dbtypes.WithdrawalRequestFilter{
 				PublicKey:     validator.Validator.PublicKey[:],
 				SourceAddress: pageData.WithdrawAddress,
 				MaxAmount:     &zeroAmount,
 				MaxSlot:       exitSlot,
 			},
-		}, 0, 1); totalWithdrawals > 0 && len(withdrawals) > 0 && pageData.ShowWithdrawAddress {
+		}, 0, 1); totalPendingWithdrawalTxs+totalWithdrawalReqs > 0 && len(withdrawals) > 0 && pageData.ShowWithdrawAddress {
 			withdrawal := withdrawals[0]
 			pageData.ExitReason = "Validator submitted a full withdrawal request"
 			pageData.ExitReasonWithdrawal = true
@@ -643,13 +643,13 @@ func buildValidatorPageData(validatorIndex uint64, tabView string) (*models.Vali
 				}
 			}
 			// Check for consolidation request
-		} else if consolidations, totalConsolidations := services.GlobalBeaconService.GetConsolidationRequestsByFilter(&services.CombinedConsolidationRequestFilter{
+		} else if consolidations, totalPendingConsolidationTxs, totalConsolidationReqs := services.GlobalBeaconService.GetConsolidationRequestsByFilter(&services.CombinedConsolidationRequestFilter{
 			Filter: &dbtypes.ConsolidationRequestFilter{
 				PublicKey:     validator.Validator.PublicKey[:],
 				SourceAddress: pageData.WithdrawAddress,
 				MaxSlot:       exitSlot,
 			},
-		}, 0, 1); totalConsolidations > 0 && len(consolidations) > 0 && pageData.ShowWithdrawAddress {
+		}, 0, 1); totalPendingConsolidationTxs+totalConsolidationReqs > 0 && len(consolidations) > 0 && pageData.ShowWithdrawAddress {
 			consolidation := consolidations[0]
 			pageData.ExitReason = "Validator was consolidated"
 			pageData.ExitReasonConsolidation = true

--- a/services/chainservice_blocks.go
+++ b/services/chainservice_blocks.go
@@ -754,3 +754,27 @@ func (bs *ChainService) CheckBlockOrphanedStatus(blockRoot phase0.Root) dbtypes.
 
 	return dbtypes.Missing
 }
+
+func (bs *ChainService) GetHighestElBlockNumber(overrideForkId *beacon.ForkKey) uint64 {
+	canonicalHead := bs.beaconIndexer.GetCanonicalHead(overrideForkId)
+	for {
+		if canonicalHead == nil {
+			break
+		}
+		if canonicalHead.GetBlockIndex() != nil {
+			return canonicalHead.GetBlockIndex().ExecutionNumber
+		}
+
+		parentRoot := canonicalHead.GetParentRoot()
+		if parentRoot == nil {
+			break
+		}
+
+		canonicalHead = bs.beaconIndexer.GetBlockByRoot(*parentRoot)
+		if canonicalHead == nil || canonicalHead.Slot == 0 {
+			break
+		}
+	}
+
+	return 0
+}

--- a/services/chainservice_withdrawals.go
+++ b/services/chainservice_withdrawals.go
@@ -63,12 +63,15 @@ func (cwr *CombinedWithdrawalRequest) Amount() uint64 {
 	return 0
 }
 
-func (bs *ChainService) GetWithdrawalRequestsByFilter(filter *CombinedWithdrawalRequestFilter, pageIdx uint64, pageSize uint32) ([]*CombinedWithdrawalRequest, uint64) {
-	totalResults := uint64(0)
+func (bs *ChainService) GetWithdrawalRequestsByFilter(filter *CombinedWithdrawalRequestFilter, pageOffset uint64, pageSize uint32) ([]*CombinedWithdrawalRequest, uint64, uint64) {
+	totalPendingTxResults := uint64(0)
+	totalReqResults := uint64(0)
+
 	combinedResults := make([]*CombinedWithdrawalRequest, 0)
 	canonicalForkIds := bs.GetCanonicalForkIds()
 
 	initiatedFilter := &dbtypes.WithdrawalRequestTxFilter{
+		MinDequeue:    bs.GetHighestElBlockNumber(nil) + 1,
 		PublicKey:     filter.Filter.PublicKey,
 		MinIndex:      filter.Filter.MinIndex,
 		MaxIndex:      filter.Filter.MaxIndex,
@@ -76,18 +79,9 @@ func (bs *ChainService) GetWithdrawalRequestsByFilter(filter *CombinedWithdrawal
 		WithOrphaned:  filter.Filter.WithOrphaned,
 	}
 
-	var dbOperations []*dbtypes.WithdrawalRequest
-
-	if filter.Request != 1 {
-		dbOperations, totalResults = bs.GetWithdrawalRequestOperationsByFilter(filter.Filter, pageIdx, pageSize)
-		if len(dbOperations) > 0 {
-			initiatedFilter.MinDequeue = dbOperations[0].BlockNumber + 1
-		}
-	}
-
 	if filter.Request != 2 {
-		dbTransactions, totalDbTransactions, _ := db.GetWithdrawalRequestTxsFiltered(0, 20, canonicalForkIds, initiatedFilter)
-		totalResults += totalDbTransactions
+		dbTransactions, totalDbTransactions, _ := db.GetWithdrawalRequestTxsFiltered(pageOffset, pageSize, canonicalForkIds, initiatedFilter)
+		totalPendingTxResults = totalDbTransactions
 
 		for _, withdrawal := range dbTransactions {
 			combinedResults = append(combinedResults, &CombinedWithdrawalRequest{
@@ -99,8 +93,19 @@ func (bs *ChainService) GetWithdrawalRequestsByFilter(filter *CombinedWithdrawal
 
 	if filter.Request != 1 {
 		requestTxDetailsFor := [][]byte{}
+		dbOperations := []*dbtypes.WithdrawalRequest(nil)
+		page2Offset := uint64(0)
+		if pageOffset > totalPendingTxResults {
+			page2Offset = pageOffset - totalPendingTxResults
+		}
+
+		dbOperations, totalReqResults = bs.GetWithdrawalRequestOperationsByFilter(filter.Filter, page2Offset, pageSize)
 
 		for _, dbOperation := range dbOperations {
+			if len(combinedResults) >= int(pageSize) {
+				break
+			}
+
 			combinedResult := &CombinedWithdrawalRequest{
 				Request:         dbOperation,
 				RequestOrphaned: !bs.isCanonicalForkId(dbOperation.ForkId, canonicalForkIds),
@@ -156,10 +161,10 @@ func (bs *ChainService) GetWithdrawalRequestsByFilter(filter *CombinedWithdrawal
 		}
 	}
 
-	return combinedResults, totalResults
+	return combinedResults, totalPendingTxResults, totalReqResults
 }
 
-func (bs *ChainService) GetWithdrawalRequestOperationsByFilter(filter *dbtypes.WithdrawalRequestFilter, pageIdx uint64, pageSize uint32) ([]*dbtypes.WithdrawalRequest, uint64) {
+func (bs *ChainService) GetWithdrawalRequestOperationsByFilter(filter *dbtypes.WithdrawalRequestFilter, pageOffset uint64, pageSize uint32) ([]*dbtypes.WithdrawalRequest, uint64) {
 	chainState := bs.consensusPool.GetChainState()
 	_, prunedEpoch := bs.beaconIndexer.GetBlockCacheState()
 	idxMinSlot := chainState.EpochToSlot(prunedEpoch)
@@ -199,6 +204,11 @@ func (bs *ChainService) GetWithdrawalRequestOperationsByFilter(filter *dbtypes.W
 					if filter.MaxIndex > 0 && (withdrawalRequest.ValidatorIndex == nil || *withdrawalRequest.ValidatorIndex > filter.MaxIndex) {
 						continue
 					}
+					if len(filter.SourceAddress) > 0 {
+						if !bytes.Equal(withdrawalRequest.SourceAddress[:], filter.SourceAddress) {
+							continue
+						}
+					}
 					if len(filter.PublicKey) > 0 {
 						if !bytes.Equal(withdrawalRequest.ValidatorPubkey[:], filter.PublicKey) {
 							continue
@@ -220,43 +230,37 @@ func (bs *ChainService) GetWithdrawalRequestOperationsByFilter(filter *dbtypes.W
 		}
 	}
 
-	cachedMatchesLen := uint64(len(cachedMatches))
-	cachedPages := cachedMatchesLen / uint64(pageSize)
 	resObjs := make([]*dbtypes.WithdrawalRequest, 0)
 	resIdx := 0
 
-	cachedStart := pageIdx * uint64(pageSize)
+	cachedStart := pageOffset
 	cachedEnd := cachedStart + uint64(pageSize)
+	cachedMatchesLen := uint64(len(cachedMatches))
 
-	if cachedPages > 0 && pageIdx < cachedPages {
+	if cachedEnd <= cachedMatchesLen {
 		resObjs = append(resObjs, cachedMatches[cachedStart:cachedEnd]...)
 		resIdx += int(cachedEnd - cachedStart)
-	} else if pageIdx == cachedPages {
+	} else if cachedStart < cachedMatchesLen {
 		resObjs = append(resObjs, cachedMatches[cachedStart:]...)
 		resIdx += len(cachedMatches) - int(cachedStart)
 	}
 
 	// load older objects from db
-	var dbPage uint64
-	if pageIdx > cachedPages {
-		dbPage = pageIdx - cachedPages
-	} else {
-		dbPage = 0
-	}
-	dbCacheOffset := uint64(pageSize) - (cachedMatchesLen % uint64(pageSize))
-
 	var dbObjects []*dbtypes.WithdrawalRequest
 	var dbCount uint64
 	var err error
 
-	if resIdx > int(pageSize) {
+	if cachedEnd <= cachedMatchesLen {
 		// all results from cache, just get result count from db
 		_, dbCount, err = db.GetWithdrawalRequestsFiltered(0, 1, canonicalForkIds, filter)
-	} else if dbPage == 0 {
-		// first page, load first `pagesize-cachedResults` items from db
-		dbObjects, dbCount, err = db.GetWithdrawalRequestsFiltered(0, uint32(dbCacheOffset), canonicalForkIds, filter)
 	} else {
-		dbObjects, dbCount, err = db.GetWithdrawalRequestsFiltered((dbPage-1)*uint64(pageSize)+dbCacheOffset, pageSize, canonicalForkIds, filter)
+		dbSliceStart := uint64(0)
+		if cachedStart > cachedMatchesLen {
+			dbSliceStart = cachedStart - cachedMatchesLen
+		}
+
+		dbSliceLimit := pageSize - uint32(resIdx)
+		dbObjects, dbCount, err = db.GetWithdrawalRequestsFiltered(dbSliceStart, dbSliceLimit, canonicalForkIds, filter)
 	}
 
 	if err != nil {

--- a/templates/el_consolidations/el_consolidations.html
+++ b/templates/el_consolidations/el_consolidations.html
@@ -336,7 +336,7 @@
           <div class="row">
             <div class="col-sm-12 col-md-5 table-metainfo">
               <div class="px-2">
-                <div class="table-meta" role="status" aria-live="polite">Showing consolidation requests from slot {{ .FirstIndex }} to {{ .LastIndex }}</div>
+                <div class="table-meta" role="status" aria-live="polite">Showing {{ .RequestCount }} consolidation requests from slot {{ .FirstIndex }} to {{ .LastIndex }}</div>
               </div>
             </div>
             <div class="col-sm-12 col-md-7 table-paging">

--- a/templates/el_withdrawals/el_withdrawals.html
+++ b/templates/el_withdrawals/el_withdrawals.html
@@ -318,7 +318,7 @@
           <div class="row">
             <div class="col-sm-12 col-md-5 table-metainfo">
               <div class="px-2">
-                <div class="table-meta" role="status" aria-live="polite">Showing withdrawal requests from slot {{ .FirstIndex }} to {{ .LastIndex }}</div>
+                <div class="table-meta" role="status" aria-live="polite">Showing {{ .RequestCount }} withdrawal requests from slot {{ .FirstIndex }} to {{ .LastIndex }}</div>
               </div>
             </div>
             <div class="col-sm-12 col-md-7 table-paging">


### PR DESCRIPTION
With this PR, all pending withdrawal and consolidation requests are displayed in the list of withdrawal & consolidation requests:
![image](https://github.com/user-attachments/assets/6906a2fd-c9ea-4512-b75b-abb4de3384ec)

Pending requests have been submitted to the execution layer, but have not been processed by the beacon chain yet.
These pending requests can now be viewed and filtered as for usual processed requests.