### PR TITLE
fix dequeue block calculation

### DIFF
--- a/indexer/execution/contract_indexer.go
+++ b/indexer/execution/contract_indexer.go
@@ -240,15 +240,8 @@ func (ci *contractIndexer[TxType]) processFinalizedBlocks(finalizedBlockNumber u
 		var txBlockHeader *types.Header
 
 		requestTxs := []*TxType{}
-		queueBlock := ci.state.FinalBlock
+		queueBlock := ci.state.FinalBlock + 1
 		queueLength := ci.state.FinalQueueLen
-
-		// we start crawling from the next block, so we need to decrease the queue length for the current block
-		if queueLength > ci.options.dequeueRate {
-			queueLength -= ci.options.dequeueRate
-		} else {
-			queueLength = 0
-		}
 
 		for idx := range logs {
 			log := &logs[idx]


### PR DESCRIPTION
This PR fixes the dequeue block calculation, which got out of sync with large request amounts across epoch transitions:
![image](https://github.com/user-attachments/assets/338c1ec4-faf0-41a2-be4d-ca8d76a27c98)
(tx to request mapping is off by 2 here, the tx in row 3 should be at row 1)

Looking at the DB, the issue was introduced during epoch 13->14 transition, where the algorithm assumed 3 requests got dequeued in block 469 & 470:
![image](https://github.com/user-attachments/assets/6a5fc63d-5a1e-4ea9-a684-740852cbdf52)


