### PR TITLE
fix panic on el clients page

### DIFF
--- a/handlers/clients_el.go
+++ b/handlers/clients_el.go
@@ -91,7 +91,7 @@ func buildELPeerMapData(parseEnodeRecord func(enrStr string) *enode.Node) *model
 
 	for _, client := range services.GlobalBeaconService.GetExecutionClients() {
 		nodeInfo := client.GetNodeInfo()
-		nodeID := "unknown"
+		nodeID := fmt.Sprintf("unknown-%v", client.GetIndex())
 		if nodeInfo != nil {
 			en := parseEnodeRecord(nodeInfo.Enode)
 			if en != nil {


### PR DESCRIPTION
Fixes a panic on the el clients page:
```
URL: /clients/execution
Time: 2025-01-13 19:02:06.630017121 +0000 UTC m=+28803.893680671
Version: v1.13.0 (git-45351a7)

Error:
page call 8400 panic: runtime error: invalid memory address or nil pointer dereference

Stack Trace:
goroutine 1050698 [running]:
runtime/debug.Stack()
	/opt/hostedtoolcache/go/1.22.9/x64/src/runtime/debug/stack.go:24 +0x5e
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
	/home/runner/work/dora/dora/services/frontendcache.go:131 +0xd4
panic({0x1356ac0?, 0x3599e40?})
	/opt/hostedtoolcache/go/1.22.9/x64/src/runtime/panic.go:770 +0x132
github.com/ethpandaops/dora/handlers.buildELPeerMapData(0xc007dafc28)
	/home/runner/work/dora/dora/handlers/clients_el.go:130 +0xbbb
github.com/ethpandaops/dora/handlers.buildELClientsPageData()
	/home/runner/work/dora/dora/handlers/clients_el.go:172 +0xd0
github.com/ethpandaops/dora/handlers.getELClientsPageData.func1(0xc00ab31500)
	/home/runner/work/dora/dora/handlers/clients_el.go:46 +0x14
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0xc0129e9470?)
	/home/runner/work/dora/dora/services/frontendcache.go:148 +0x1f0
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 1050015
	/home/runner/work/dora/dora/services/frontendcache.go:125 +0x347
```