### PR TITLE
fix for storing uint64 values as int64 in db

### DIFF
--- a/db/convert.go
+++ b/db/convert.go
@@ -1,0 +1,21 @@
+package db
+
+// ConvertUint64ToInt64 converts a uint64 to an int64, supporting the full range of uint64,
+// but the value is translated to the range of int64.
+func ConvertUint64ToInt64(u uint64) int64 {
+	// Subtract half of uint64 max value to center the range around 0
+	// This maps:
+	// uint64(0) -> int64.MinValue
+	// uint64.MaxValue -> int64.MaxValue
+	return int64(u - 1<<63)
+}
+
+// ConvertInt64ToUint64 converts an int64 to a uint64, supporting the full range of int64,
+// but the value is translated to the range of uint64.
+func ConvertInt64ToUint64(i int64) uint64 {
+	// Add 2^63 to shift the range back to uint64
+	// This maps:
+	// int64.MinValue -> uint64(0)
+	// int64.MaxValue -> uint64.MaxValue
+	return uint64(i) + 1<<63
+}

--- a/db/schema/pgsql/20250120215235_withdrawal-requests-fix.sql
+++ b/db/schema/pgsql/20250120215235_withdrawal-requests-fix.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+
+UPDATE public."withdrawal_requests"
+    SET "amount" = "amount" - 9223372036854775808;
+
+UPDATE public."withdrawal_request_txs"
+    SET "amount" = "amount" - 9223372036854775808;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20250120215235_withdrawal-requests-fix.sql
+++ b/db/schema/sqlite/20250120215235_withdrawal-requests-fix.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+
+UPDATE "withdrawal_requests"
+    SET "amount" = "amount" - 9223372036854775808;
+
+UPDATE "withdrawal_request_txs"
+    SET "amount" = "amount" - 9223372036854775808;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/withdrawal_request_txs.go
+++ b/db/withdrawal_request_txs.go
@@ -113,7 +113,7 @@ func GetWithdrawalRequestTxsFiltered(offset uint64, limit uint32, canonicalForkI
 	fmt.Fprint(&sql, `
 	WITH cte AS (
 		SELECT
-			block_number, block_index, block_time, block_root, fork_id, source_address, validator_pubkey, validator_index, amount, tx_hash, tx_sender, tx_target, dequeue_block
+			block_number, block_index, block_time, block_root, fork_id, source_address, validator_pubkey, validator_index, CAST(amount AS BIGINT), tx_hash, tx_sender, tx_target, dequeue_block
 		FROM withdrawal_request_txs
 	`)
 
@@ -164,12 +164,12 @@ func GetWithdrawalRequestTxsFiltered(offset uint64, limit uint32, canonicalForkI
 		filterOp = "AND"
 	}
 	if filter.MinAmount != nil {
-		args = append(args, *filter.MinAmount)
+		args = append(args, ConvertUint64ToInt64(*filter.MinAmount))
 		fmt.Fprintf(&sql, " %v amount >= $%v", filterOp, len(args))
 		filterOp = "AND"
 	}
 	if filter.MaxAmount != nil {
-		args = append(args, *filter.MaxAmount)
+		args = append(args, ConvertUint64ToInt64(*filter.MaxAmount))
 		fmt.Fprintf(&sql, " %v amount <= $%v", filterOp, len(args))
 		filterOp = "AND"
 	}
@@ -203,7 +203,7 @@ func GetWithdrawalRequestTxsFiltered(offset uint64, limit uint32, canonicalForkI
 		null AS source_address,
 		null AS validator_pubkey,
 		0 AS validator_index,
-		0 AS amount,
+		CAST(0 AS BIGINT) AS amount,
 		null AS tx_hash,
 		null AS tx_sender,
 		null AS tx_target,

--- a/db/withdrawal_requests.go
+++ b/db/withdrawal_requests.go
@@ -67,7 +67,7 @@ func GetWithdrawalRequestsFiltered(offset uint64, limit uint32, canonicalForkIds
 	fmt.Fprint(&sql, `
 	WITH cte AS (
 		SELECT
-			slot_number, slot_index, slot_root, orphaned, fork_id, source_address, validator_index, validator_pubkey, amount, tx_hash, block_number
+			slot_number, slot_index, slot_root, orphaned, fork_id, source_address, validator_index, validator_pubkey, CAST(amount AS BIGINT), tx_hash, block_number
 		FROM withdrawal_requests
 	`)
 
@@ -118,12 +118,12 @@ func GetWithdrawalRequestsFiltered(offset uint64, limit uint32, canonicalForkIds
 		filterOp = "AND"
 	}
 	if filter.MinAmount != nil {
-		args = append(args, *filter.MinAmount)
+		args = append(args, ConvertUint64ToInt64(*filter.MinAmount))
 		fmt.Fprintf(&sql, " %v amount >= $%v", filterOp, len(args))
 		filterOp = "AND"
 	}
 	if filter.MaxAmount != nil {
-		args = append(args, *filter.MaxAmount)
+		args = append(args, ConvertUint64ToInt64(*filter.MaxAmount))
 		fmt.Fprintf(&sql, " %v amount <= $%v", filterOp, len(args))
 		filterOp = "AND"
 	}
@@ -157,7 +157,7 @@ func GetWithdrawalRequestsFiltered(offset uint64, limit uint32, canonicalForkIds
 		null AS source_address,
 		0 AS validator_index,
 		null AS validator_pubkey,
-		0 AS amount,
+		CAST(0 AS BIGINT) AS amount,
 		null AS tx_hash,
 		0 AS block_number
 	FROM cte

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -292,7 +292,7 @@ type WithdrawalRequest struct {
 	SourceAddress   []byte  `db:"source_address"`
 	ValidatorIndex  *uint64 `db:"validator_index"`
 	ValidatorPubkey []byte  `db:"validator_pubkey"`
-	Amount          uint64  `db:"amount"`
+	Amount          int64   `db:"amount"`
 	TxHash          []byte  `db:"tx_hash"`
 	BlockNumber     uint64  `db:"block_number"`
 }
@@ -306,7 +306,7 @@ type WithdrawalRequestTx struct {
 	SourceAddress   []byte  `db:"source_address"`
 	ValidatorPubkey []byte  `db:"validator_pubkey"`
 	ValidatorIndex  *uint64 `db:"validator_index"`
-	Amount          uint64  `db:"amount"`
+	Amount          int64   `db:"amount"`
 	TxHash          []byte  `db:"tx_hash"`
 	TxSender        []byte  `db:"tx_sender"`
 	TxTarget        []byte  `db:"tx_target"`

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -777,7 +777,7 @@ func (dbw *dbWriter) buildDbWithdrawalRequests(block *Block, orphaned bool, over
 			ForkId:          uint64(block.forkId),
 			SourceAddress:   withdrawalRequest.SourceAddress[:],
 			ValidatorPubkey: withdrawalRequest.ValidatorPubkey[:],
-			Amount:          uint64(withdrawalRequest.Amount),
+			Amount:          db.ConvertUint64ToInt64(uint64(withdrawalRequest.Amount)),
 			BlockNumber:     blockNumber,
 		}
 		if overrideForkId != nil {

--- a/indexer/execution/withdrawal_indexer.go
+++ b/indexer/execution/withdrawal_indexer.go
@@ -186,7 +186,7 @@ func (wi *WithdrawalIndexer) parseRequestLog(log *types.Log, forkId *beacon.Fork
 		SourceAddress:   senderAddr,
 		ValidatorPubkey: validatorPubkey,
 		ValidatorIndex:  validatorIndex,
-		Amount:          amount,
+		Amount:          db.ConvertUint64ToInt64(amount),
 		TxHash:          log.TxHash[:],
 	}
 

--- a/services/chainservice_withdrawals.go
+++ b/services/chainservice_withdrawals.go
@@ -56,10 +56,10 @@ func (cwr *CombinedWithdrawalRequest) ValidatorPubkey() []byte {
 
 func (cwr *CombinedWithdrawalRequest) Amount() uint64 {
 	if cwr.Request != nil {
-		return cwr.Request.Amount
+		return db.ConvertInt64ToUint64(cwr.Request.Amount)
 	}
 	if cwr.Transaction != nil {
-		return cwr.Transaction.Amount
+		return db.ConvertInt64ToUint64(cwr.Transaction.Amount)
 	}
 	return 0
 }


### PR DESCRIPTION
Dora fails and gets stuck when trying to store uint64 values with the highest bit set into db.
This was previously not a problem, but with withdrawal requests there is now a way to put arbitrary numbers into requests, so dora needs to be prepared to handle those high values.

The background of this limitation is, that values are stored as signed 64 bit number in db, so it can only handle the lower half of the uint64 range.
To get around that limitation, the uint64 values are now converted to the int64 range for storing in db,
That means:
 uint64(0) -> int64.MinValue
 uint64.MaxValue -> int64.MaxValue

With this value translation, we can store big uint64 to the db and still filter based on min/max values, as the order of values within the range keeps stable.
