### PR TITLE
fix out of range panic in search handler

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -252,7 +252,7 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 
 			cachedBlocks := indexer.GetBlocksByExecutionBlockHash(phase0.Hash32(blockHash))
 			if len(cachedBlocks) > 0 {
-				res := make([]*models.SearchAheadExecBlocksResult, 0)
+				res := make([]*models.SearchAheadExecBlocksResult, len(cachedBlocks))
 				for idx, cachedBlock := range cachedBlocks {
 					header := cachedBlock.GetHeader()
 					index := cachedBlock.GetBlockIndex()


### PR DESCRIPTION
fix a index out of range panic in the search handler when searching for execution block hashes:
```
[negroni] PANIC: runtime error: index out of range [0] with length 0
goroutine 32817 [running]:
github.com/urfave/negroni.(*Recovery).ServeHTTP.func1()
	/home/runner/go/pkg/mod/github.com/urfave/negroni@v1.0.0/recovery.go:159 +0xad
panic({0x14261c0?, 0xc00d47d3e0?})
	/opt/hostedtoolcache/go/1.22.10/x64/src/runtime/panic.go:770 +0x132
github.com/ethpandaops/dora/handlers.SearchAhead({0x7f662469dff0, 0xc00c562628}, 0xc00d9427e0)
	/home/runner/work/dora/dora/handlers/search.go:259 +0x26ff
net/http.HandlerFunc.ServeHTTP(0xc00d9426c0?, {0x7f662469dff0?, 0xc00c562628?}, 0x3878?)
	/opt/hostedtoolcache/go/1.22.10/x64/src/net/http/server.go:2171 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00b37b200, {0x7f662469dff0, 0xc00c562628}, 0xc00d942480)
	/home/runner/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
github.com/urfave/negroni.(*Negroni).UseHandler.Wrap.func1({0x7f662469dff0, 0xc00c562628}, 0xc00d942480, 0xc00cbda480)
	/home/runner/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:46 +0x45
github.com/urfave/negroni.HandlerFunc.ServeHTTP(0x24c269decfc?, {0x7f662469dff0?, 0xc00c562628?}, 0x8?, 0x8?)
	/home/runner/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:29 +0x2d
github.com/urfave/negroni.middleware.ServeHTTP({{0x2d47320?, 0xc007859008?}, 0xc007859098?}, {0x7f662469dff0, 0xc00c562628}, 0xc00d942480)
	/home/runner/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38 +0xa8
github.com/urfave/negroni.(*Recovery).ServeHTTP(0x0?, {0x7f662469dff0?, 0xc00c562628?}, 0xc00f4e3b00?, 0x414485?)
	/home/runner/go/pkg/mod/github.com/urfave/negroni@v1.0.0/recovery.go:193 +0x7b
github.com/urfave/negroni.middleware.ServeHTTP({{0x2d46480?, 0xc000377a90?}, 0xc007859068?}, {0x7f662469dff0, 0xc00c562628}, 0xc00d942480)
	/home/runner/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38 +0xa8
github.com/urfave/negroni.(*Negroni).ServeHTTP(0xc0076b1380, {0x2d4cd10, 0xc00f6fa540}, 0xc00d942480)
	/home/runner/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:96 +0x105
net/http.serverHandler.ServeHTTP({0xc009429bf0?}, {0x2d4cd10?, 0xc00f6fa540?}, 0x6?)
	/opt/hostedtoolcache/go/1.22.10/x64/src/net/http/server.go:3142 +0x8e
net/http.(*conn).serve(0xc00e2e0a20, {0x2d51c58, 0xc00049e210})
	/opt/hostedtoolcache/go/1.22.10/x64/src/net/http/server.go:2044 +0x5e8
created by net/http.(*Server).Serve in goroutine 14
	/opt/hostedtoolcache/go/1.22.10/x64/src/net/http/server.go:3290 +0x4b4
```