### PR TITLE
speedup epoch stats restore from db for old unfinalized epochs

### DIFF
--- a/indexer/beacon/indexer.go
+++ b/indexer/beacon/indexer.go
@@ -256,8 +256,9 @@ func (indexer *Indexer) StartIndexer() {
 			}()
 
 			epochStats := indexer.epochCache.createOrGetEpochStats(phase0.Epoch(dbDuty.Epoch), phase0.Root(dbDuty.DependentRoot), false)
+			pruneStats := dbDuty.Epoch < uint64(indexer.lastPrunedEpoch)
 
-			err := epochStats.restoreFromDb(dbDuty, indexer.dynSsz, chainState)
+			err := epochStats.restoreFromDb(dbDuty, indexer.dynSsz, chainState, !pruneStats)
 			if err != nil {
 				indexer.logger.WithError(err).Errorf("failed restoring epoch stats for epoch %v (%x) from db", dbDuty.Epoch, dbDuty.DependentRoot)
 				return
@@ -266,7 +267,7 @@ func (indexer *Indexer) StartIndexer() {
 			epochStats.isInDb = true
 
 			restoredEpochStats++
-			if dbDuty.Epoch < uint64(indexer.lastPrunedEpoch) {
+			if pruneStats {
 				epochStats.pruneValues()
 			}
 		}()


### PR DESCRIPTION
This PR speeds up the epoch stats restoration from db on dora startup.
Restoring the epoch stats from db can be a time consuming operation when the chain faces long unfinality as currently seen on devnet5:
```
time="2025-01-21T16:06:15Z" level=info msg="restored 687 unfinalized epoch stats from DB (101.074 sec)" service=cl-indexer
```
already takes about 100s (1:40min) to restore and recalculate duties for 687 epochs.

With this PR,  the recalculation for attester duties gets skipped for old unfinalized epoch stats.
For old unfinalized epochs, this information is pruned right after restore anyway, so there is no point on computing these duties upfront.
Computing the attester duties is the most time consuming task, as the whole validator set needs to be shuffled for that, so this should speed up the restoration a lot.