### PR TITLE
fix performance for filtered slot requests during long unfinality

### DIFF
--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -317,7 +317,7 @@ func (block *Block) unpruneBlockBody() {
 }
 
 // GetDbBlock returns the database representation of this block.
-func (block *Block) GetDbBlock(indexer *Indexer) *dbtypes.Slot {
+func (block *Block) GetDbBlock(indexer *Indexer, isCanonical bool) *dbtypes.Slot {
 	var epochStats *EpochStats
 	chainState := indexer.consensusPool.GetChainState()
 	if dependentBlock := indexer.blockCache.getDependentBlock(chainState, block, nil); dependentBlock != nil {
@@ -329,7 +329,7 @@ func (block *Block) GetDbBlock(indexer *Indexer) *dbtypes.Slot {
 		return nil
 	}
 
-	if !indexer.IsCanonicalBlock(block, nil) {
+	if !isCanonical {
 		dbBlock.Status = dbtypes.Orphaned
 	}
 
@@ -337,36 +337,31 @@ func (block *Block) GetDbBlock(indexer *Indexer) *dbtypes.Slot {
 }
 
 // GetDbDeposits returns the database representation of the deposits in this block.
-func (block *Block) GetDbDeposits(indexer *Indexer, depositIndex *uint64) []*dbtypes.Deposit {
-	orphaned := !indexer.IsCanonicalBlock(block, nil)
-	dbDeposits := indexer.dbWriter.buildDbDeposits(block, depositIndex, orphaned, nil)
-	dbDeposits = append(dbDeposits, indexer.dbWriter.buildDbDepositRequests(block, orphaned, nil)...)
+func (block *Block) GetDbDeposits(indexer *Indexer, depositIndex *uint64, isCanonical bool) []*dbtypes.Deposit {
+	dbDeposits := indexer.dbWriter.buildDbDeposits(block, depositIndex, !isCanonical, nil)
+	dbDeposits = append(dbDeposits, indexer.dbWriter.buildDbDepositRequests(block, !isCanonical, nil)...)
 
 	return dbDeposits
 }
 
 // GetDbVoluntaryExits returns the database representation of the voluntary exits in this block.
-func (block *Block) GetDbVoluntaryExits(indexer *Indexer) []*dbtypes.VoluntaryExit {
-	orphaned := !indexer.IsCanonicalBlock(block, nil)
-	return indexer.dbWriter.buildDbVoluntaryExits(block, orphaned, nil)
+func (block *Block) GetDbVoluntaryExits(indexer *Indexer, isCanonical bool) []*dbtypes.VoluntaryExit {
+	return indexer.dbWriter.buildDbVoluntaryExits(block, !isCanonical, nil)
 }
 
 // GetDbSlashings returns the database representation of the slashings in this block.
-func (block *Block) GetDbSlashings(indexer *Indexer) []*dbtypes.Slashing {
-	orphaned := !indexer.IsCanonicalBlock(block, nil)
-	return indexer.dbWriter.buildDbSlashings(block, orphaned, nil)
+func (block *Block) GetDbSlashings(indexer *Indexer, isCanonical bool) []*dbtypes.Slashing {
+	return indexer.dbWriter.buildDbSlashings(block, !isCanonical, nil)
 }
 
 // GetDbWithdrawalRequests returns the database representation of the withdrawal requests in this block.
-func (block *Block) GetDbWithdrawalRequests(indexer *Indexer) []*dbtypes.WithdrawalRequest {
-	orphaned := !indexer.IsCanonicalBlock(block, nil)
-	return indexer.dbWriter.buildDbWithdrawalRequests(block, orphaned, nil)
+func (block *Block) GetDbWithdrawalRequests(indexer *Indexer, isCanonical bool) []*dbtypes.WithdrawalRequest {
+	return indexer.dbWriter.buildDbWithdrawalRequests(block, !isCanonical, nil)
 }
 
 // GetDbConsolidationRequests returns the database representation of the consolidation requests in this block.
-func (block *Block) GetDbConsolidationRequests(indexer *Indexer) []*dbtypes.ConsolidationRequest {
-	orphaned := !indexer.IsCanonicalBlock(block, nil)
-	return indexer.dbWriter.buildDbConsolidationRequests(block, orphaned, nil)
+func (block *Block) GetDbConsolidationRequests(indexer *Indexer, isCanonical bool) []*dbtypes.ConsolidationRequest {
+	return indexer.dbWriter.buildDbConsolidationRequests(block, !isCanonical, nil)
 }
 
 // GetForkId returns the fork ID of this block.

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -22,7 +22,7 @@ type Block struct {
 	parentRoot        *phase0.Root
 	dependentRoot     *phase0.Root
 	forkId            ForkKey
-	fokChecked        bool
+	forkChecked       bool
 	headerMutex       sync.Mutex
 	headerChan        chan bool
 	header            *phase0.SignedBeaconBlockHeader

--- a/indexer/beacon/canonical.go
+++ b/indexer/beacon/canonical.go
@@ -105,7 +105,20 @@ func (indexer *Indexer) GetChainHeads() []*ChainHead {
 
 func (indexer *Indexer) IsCanonicalBlock(block *Block, overrideForkId *ForkKey) bool {
 	canonicalHead := indexer.GetCanonicalHead(overrideForkId)
-	return canonicalHead != nil && indexer.blockCache.isCanonicalBlock(block.Root, canonicalHead.Root)
+	return indexer.IsCanonicalBlockByHead(block, canonicalHead)
+}
+
+func (indexer *Indexer) IsCanonicalBlockByHead(block *Block, headBlock *Block) bool {
+	if headBlock == nil || block == nil {
+		return false
+	}
+
+	if block.forkChecked && headBlock.forkChecked {
+		parentForkIds := indexer.forkCache.getParentForkIds(headBlock.forkId)
+		return slices.Contains(parentForkIds, block.forkId)
+	}
+
+	return indexer.blockCache.isCanonicalBlock(block.Root, headBlock.Root)
 }
 
 // computeCanonicalChain computes the canonical chain and updates the indexer's state.

--- a/indexer/beacon/forkdetection.go
+++ b/indexer/beacon/forkdetection.go
@@ -57,7 +57,7 @@ func (cache *forkCache) processBlock(block *Block) error {
 			parentIsProcessed = true
 			parentIsFinalized = parentSlot < chainState.GetFinalizedSlot()
 		}
-	} else if parentBlock.fokChecked {
+	} else if parentBlock.forkChecked {
 		parentForkId = parentBlock.forkId
 		parentSlot = parentBlock.Slot
 		parentIsProcessed = true
@@ -163,7 +163,7 @@ func (cache *forkCache) processBlock(block *Block) error {
 	// check scenario 2
 	childBlocks := make([]*Block, 0)
 	for _, child := range cache.indexer.blockCache.getBlocksByParentRoot(block.Root) {
-		if !child.fokChecked {
+		if !child.forkChecked {
 			continue
 		}
 
@@ -211,7 +211,7 @@ func (cache *forkCache) processBlock(block *Block) error {
 
 	// set detected fork id to the block
 	block.forkId = currentForkId
-	block.fokChecked = true
+	block.forkChecked = true
 
 	// update fork head block if needed
 	fork := cache.getForkById(currentForkId)
@@ -336,7 +336,7 @@ func (cache *forkCache) updateForkBlocks(startBlock *Block, forkId ForkKey, skip
 		}
 
 		nextBlock := nextBlocks[0]
-		if !nextBlock.fokChecked {
+		if !nextBlock.forkChecked {
 			break
 		}
 

--- a/indexer/beacon/indexer.go
+++ b/indexer/beacon/indexer.go
@@ -308,7 +308,7 @@ func (indexer *Indexer) StartIndexer() {
 
 		block, _ := indexer.blockCache.createOrGetBlock(phase0.Root(dbBlock.Root), phase0.Slot(dbBlock.Slot))
 		block.forkId = ForkKey(dbBlock.ForkId)
-		block.fokChecked = true
+		block.forkChecked = true
 		block.processingStatus = dbBlock.Status
 		block.isInUnfinalizedDb = true
 

--- a/services/chainservice.go
+++ b/services/chainservice.go
@@ -229,13 +229,17 @@ func (bs *ChainService) GetHeadForks(readyOnly bool) []*beacon.ForkHead {
 	return bs.beaconIndexer.GetForkHeads()
 }
 
-func (bs *ChainService) GetCanonicalForkIds() []uint64 {
+func (bs *ChainService) GetCanonicalForkKeys() []beacon.ForkKey {
 	canonicalHead := bs.beaconIndexer.GetCanonicalHead(nil)
 	if canonicalHead == nil {
-		return []uint64{0}
+		return []beacon.ForkKey{0}
 	}
 
-	parentForkKeys := bs.beaconIndexer.GetParentForkIds(canonicalHead.GetForkId())
+	return bs.beaconIndexer.GetParentForkIds(canonicalHead.GetForkId())
+}
+
+func (bs *ChainService) GetCanonicalForkIds() []uint64 {
+	parentForkKeys := bs.GetCanonicalForkKeys()
 	forkIds := make([]uint64, len(parentForkKeys))
 	for idx, forkId := range parentForkKeys {
 		forkIds[idx] = uint64(forkId)

--- a/services/chainservice_consolidations.go
+++ b/services/chainservice_consolidations.go
@@ -195,12 +195,12 @@ func (bs *ChainService) GetConsolidationRequestOperationsByFilter(filter *dbtype
 		if blocks != nil {
 			for bidx := 0; bidx < len(blocks); bidx++ {
 				block := blocks[bidx]
+				isCanonical := bs.isCanonicalForkId(uint64(block.GetForkId()), canonicalForkIds)
 				if filter.WithOrphaned != 1 {
-					isOrphaned := !bs.isCanonicalForkId(uint64(block.GetForkId()), canonicalForkIds)
-					if filter.WithOrphaned == 0 && isOrphaned {
+					if filter.WithOrphaned == 0 && !isCanonical {
 						continue
 					}
-					if filter.WithOrphaned == 2 && !isOrphaned {
+					if filter.WithOrphaned == 2 && isCanonical {
 						continue
 					}
 				}
@@ -211,7 +211,7 @@ func (bs *ChainService) GetConsolidationRequestOperationsByFilter(filter *dbtype
 					continue
 				}
 
-				consolidationRequests := block.GetDbConsolidationRequests(bs.beaconIndexer)
+				consolidationRequests := block.GetDbConsolidationRequests(bs.beaconIndexer, isCanonical)
 				slice.Reverse(consolidationRequests) // reverse as other datasources are ordered by descending block index too
 				for idx, consolidationRequest := range consolidationRequests {
 					if filter.MinSrcIndex > 0 && (consolidationRequest.SourceIndex == nil || *consolidationRequest.SourceIndex < filter.MinSrcIndex) {

--- a/services/chainservice_withdrawals.go
+++ b/services/chainservice_withdrawals.go
@@ -181,12 +181,12 @@ func (bs *ChainService) GetWithdrawalRequestOperationsByFilter(filter *dbtypes.W
 		if blocks != nil {
 			for bidx := 0; bidx < len(blocks); bidx++ {
 				block := blocks[bidx]
+				isCanonical := bs.isCanonicalForkId(uint64(block.GetForkId()), canonicalForkIds)
 				if filter.WithOrphaned != 1 {
-					isOrphaned := !bs.isCanonicalForkId(uint64(block.GetForkId()), canonicalForkIds)
-					if filter.WithOrphaned == 0 && isOrphaned {
+					if filter.WithOrphaned == 0 && !isCanonical {
 						continue
 					}
-					if filter.WithOrphaned == 2 && !isOrphaned {
+					if filter.WithOrphaned == 2 && isCanonical {
 						continue
 					}
 				}
@@ -197,7 +197,7 @@ func (bs *ChainService) GetWithdrawalRequestOperationsByFilter(filter *dbtypes.W
 					continue
 				}
 
-				withdrawalRequests := block.GetDbWithdrawalRequests(bs.beaconIndexer)
+				withdrawalRequests := block.GetDbWithdrawalRequests(bs.beaconIndexer, isCanonical)
 				slice.Reverse(withdrawalRequests) // reverse as other datasources are ordered by descending block index too
 				for idx, withdrawalRequest := range withdrawalRequests {
 					if filter.MinIndex > 0 && (withdrawalRequest.ValidatorIndex == nil || *withdrawalRequest.ValidatorIndex < filter.MinIndex) {


### PR DESCRIPTION
### PR Summary

This PR improves the performance of filtered entity lookups during extended unfinality periods. 

### Issue Description

The current implementation, as observed on **devnet-5**, times out in scenarios involving the unfinalized slot range. Examples include:
- The [validator details page](https://dora.pectra-devnet-5.ethpandaops.io/validator/1) for any validator.
- The [filtered slots page](https://dora.pectra-devnet-5.ethpandaops.io/slots/filtered?f=&f.extra=TKd56&f.missing=1&f.orphaned=1&c=50&d=1+2+3+4+5+6+7+8+9+10+11), when filters are applied that result in displaying the entire unfinalized slot range (e.g., filtering for a rarely used graffiti).

The timeouts are caused by the orphaned checks for each slot in the unfinalized range. Each check traverses the chain from the head to the block being verified, introducing nearly quadratic complexity.

### Fix

This PR resolves the issue by:
1. Eliminating recurring orphaned checks for each slot.
2. Implementing a more efficient orphaned check approach that avoids full chain traversal.

With these changes, the filtered lookups for unfinalized slots will no longer cause timeouts.

