### PR TITLE
fix fork detection for forks starting before the finalized checkpoint

### DIFF
--- a/indexer/beacon/forkdetection.go
+++ b/indexer/beacon/forkdetection.go
@@ -227,6 +227,9 @@ func (cache *forkCache) processBlock(block *Block) error {
 
 	// persist new forks and updated blocks to the database
 	if len(newForks) > 0 || len(updatedBlocks) > 0 {
+		// purge parent ids cache as the fork id tree has changed
+		cache.parentIdsCache.Purge()
+
 		err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
 			// helper function to update unfinalized block fork ids in batches
 			updateUnfinalizedBlockForkIds := func(updateRoots [][]byte, forkId ForkKey) error {


### PR DESCRIPTION
this fixes an issue in the fork detection which was recently triggered in devnet-6:
![Screenshot from 2025-02-03 23-35-09](https://github.com/user-attachments/assets/54980dc5-64d1-441c-9e16-02d69e260e7c)

Root case of the issue has been, that the orphaned chain at slot 1502 started at slot [1185](https://dora.pectra-devnet-6.ethpandaops.io/slot/ab77f6805fba7a0452cbefb7cb76165731386532422cb669a2e0aa05368ffb55) (epoch 37), and built on top of slot [1067](https://dora.pectra-devnet-6.ethpandaops.io/slot/1067) (epoch 33).
When receiving the orphaned block at slot 1185, dora had already finalized and dropped all blocks from epoch 33 from cache, so the new fork was not detected (no other block in cache building on top of the same parent).

This PR fixes the fork detection, to properly detect such forks by checking for relevant blocks in the db