### PR TITLE
fix panic in validator activity cleanup routine

### DIFF
--- a/indexer/beacon/validatoractivity.go
+++ b/indexer/beacon/validatoractivity.go
@@ -214,7 +214,7 @@ func (cache *validatorActivityCache) cleanupCache() {
 
 				// copy last element to current index
 				cutOffLength++
-				if i != activityLength-cutOffLength-1 {
+				if i != activityLength-cutOffLength-1 && cutOffLength < activityLength {
 					recentActivity[i] = recentActivity[activityLength-cutOffLength-1]
 				}
 			}


### PR DESCRIPTION
fixes a panic, seen on my holesky instance (dora-holesky.pk910.de):
```
time="2025-02-24T01:08:39Z" level=error msg="uncaught panic in indexer.beacon.validatorActivityCache.cleanupLoop subroutine: runtime error: index out of range [-1], stack: goroutine 785571 [running]:
runtime/debug.Stack()
  /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/ethpandaops/dora/indexer/beacon.(*validatorActivityCache).cleanupLoop.func1()
  /home/runner/work/dora/dora/indexer/beacon/validatoractivity.go:175 +0xb5
panic({0x14e6980?, 0xc076068738?})
  /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/panic.go:785 +0x132
github.com/ethpandaops/dora/indexer/beacon.(*validatorActivityCache).cleanupCache(0xc000123770)
  /home/runner/work/dora/dora/indexer/beacon/validatoractivity.go:218 +0x405
github.com/ethpandaops/dora/indexer/beacon.(*validatorActivityCache).cleanupLoop(0xc000123770)
  /home/runner/work/dora/dora/indexer/beacon/validatoractivity.go:184 +0x58
created by github.com/ethpandaops/dora/indexer/beacon.(*validatorActivityCache).cleanupLoop.func1 in goroutine 782869
  /home/runner/work/dora/dora/indexer/beacon/validatoractivity.go:178 +0x176
" error="runtime error: index out of range [-1]" service=cl-indexer
```