### PR TITLE
feat: improve sort buttons to be closer to the thead value

### DIFF
--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -291,7 +291,8 @@ span.validator-label {
 }
 
 .table-sorting thead .col-sorting {
-  float: right;
+  display: inline-block;
+  margin-left: 5px;
 }
 
 .table-sorting thead .sort-link {


### PR DESCRIPTION
I noticed some confusion while trying to sort these columns during todays Holesky rescue zoom call. 

This should make the UX more obvious :D 

New: 
![image](https://github.com/user-attachments/assets/687007c0-5706-41d8-920b-df52202fa9cf)

Old:
![image](https://github.com/user-attachments/assets/b825ccac-ca1c-4ca1-9585-f6dab571bbbc)
