### PR TITLE
fix(default-config): beaconapi endpoint url port

### DIFF
--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -41,7 +41,7 @@ beaconapi:
   # beacon node rpc endpoints
   endpoints:
     - name: "local"
-      url: "http://127.0.0.1:8545"
+      url: "http://127.0.0.1:5052"
 
   # local cache for page models
   localCacheSize: 100 # 100MB


### PR DESCRIPTION
mistakenly specified the execution client port

Ty for this wonderful tool :)