### PR TITLE
fix(services): ensure resolvedNamesByIndex is not nil before accessing map

### DIFF
--- a/services/validatornames.go
+++ b/services/validatornames.go
@@ -236,6 +236,10 @@ func (vn *ValidatorNames) GetValidatorName(index uint64) string {
 		return name.name
 	}
 
+	if vn.resolvedNamesByIndex == nil {
+		return ""
+	}
+
 	name = vn.resolvedNamesByIndex[index]
 	if name != nil {
 		return name.name

--- a/services/validatornames_test.go
+++ b/services/validatornames_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGetValidatorName(t *testing.T) {
+	// Create a test validator name entry
+	testEntry := &validatorNameEntry{name: "test-validator"}
+
+	tests := []struct {
+		name                string
+		index               uint64
+		setupValidatorNames func() *ValidatorNames
+		expectedResult      string
+	}{
+		{
+			name:  "returns empty when namesByIndex is nil",
+			index: 123,
+			setupValidatorNames: func() *ValidatorNames {
+				return &ValidatorNames{
+					namesMutex: sync.RWMutex{},
+				}
+			},
+			expectedResult: "",
+		},
+		{
+			name:  "returns name from namesByIndex when found",
+			index: 123,
+			setupValidatorNames: func() *ValidatorNames {
+				return &ValidatorNames{
+					namesMutex:   sync.RWMutex{},
+					namesByIndex: map[uint64]*validatorNameEntry{123: testEntry},
+				}
+			},
+			expectedResult: "test-validator",
+		},
+		{
+			name:  "returns empty when resolvedNamesByIndex is nil",
+			index: 123,
+			setupValidatorNames: func() *ValidatorNames {
+				return &ValidatorNames{
+					namesMutex:   sync.RWMutex{},
+					namesByIndex: map[uint64]*validatorNameEntry{},
+				}
+			},
+			expectedResult: "",
+		},
+		{
+			name:  "returns name from resolvedNamesByIndex when found",
+			index: 123,
+			setupValidatorNames: func() *ValidatorNames {
+				return &ValidatorNames{
+					namesMutex:           sync.RWMutex{},
+					namesByIndex:         map[uint64]*validatorNameEntry{},
+					resolvedNamesByIndex: map[uint64]*validatorNameEntry{123: testEntry},
+				}
+			},
+			expectedResult: "test-validator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vn := tt.setupValidatorNames()
+
+			result := vn.GetValidatorName(tt.index)
+
+			if result != tt.expectedResult {
+				t.Errorf("GetValidatorName() = %q, want %q", result, tt.expectedResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Raised in #interop by Nishant.

Panic occurs when trying to access `resolvedNamesByIndex` when `nil`.

```
URL: /validator/1112437
Time: 2025-03-04 04:05:33.754105335 +0000 UTC m=+20280.786045838
Version: git-7ca2b86

Error:
page call 80745 panic: runtime error: invalid memory address or nil pointer dereference

Stack Trace:
goroutine 375490 [running]:
runtime/debug.Stack()
    /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
    /home/runner/work/dora/dora/services/frontendcache.go:131 +0xd4
panic({0x1410a40?, 0x37f1f90?})
    /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/panic.go:785 +0x132
github.com/ethpandaops/dora/handlers.buildValidatorPageData(0x10f975, {0x15a230b, 0x6})
    /home/runner/work/dora/dora/handlers/validator.go:123 +0x12b
github.com/ethpandaops/dora/handlers.getValidatorPageData.func1(0xc00eca3c20)
    /home/runner/work/dora/dora/handlers/validator.go:99 +0x27
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0xc0003be180?)
    /home/runner/work/dora/dora/services/frontendcache.go:148 +0x1d3
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 375472
    /home/runner/work/dora/dora/services/frontendcache.go:125 +0x347
```