### PR TITLE
Return correct response for ApiWithdrawalCredentialsValidators

### DIFF
--- a/handlers/api/validator_withdrawalcredentials_v1.go
+++ b/handlers/api/validator_withdrawalcredentials_v1.go
@@ -84,10 +84,18 @@ func ApiWithdrawalCredentialsValidatorsV1(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	data := []*ApiWithdrawalCredentialsResponseV1{}
+	for _, validator := range relevantValidators {
+		data = append(data, &ApiWithdrawalCredentialsResponseV1{
+			PublicKey:      validator.Validator.PublicKey.String(),
+			ValidatorIndex: uint64(validator.Index),
+		})
+	}
+
 	j := json.NewEncoder(w)
 	response := &ApiResponse{}
 	response.Status = "OK"
-	response.Data = relevantValidators
+	response.Data = data
 
 	err = j.Encode(response)
 	if err != nil {


### PR DESCRIPTION
Fixes issue in https://github.com/ethpandaops/dora/pull/235#issuecomment-2701867520

This is my first time working with Go and I'm not too sure what I'm doing or how to test it but this feel corect to me 😉 