### PR TITLE
Fix for Epoch being a uint64

### DIFF
--- a/handlers/api/validator_v1.go
+++ b/handlers/api/validator_v1.go
@@ -21,14 +21,14 @@ type ApiValidatorResponseV1 struct {
 	Activationepoch            int64  `json:"activationepoch"`
 	Balance                    int64  `json:"balance"`
 	Effectivebalance           int64  `json:"effectivebalance"`
-	Exitepoch                  int64  `json:"exitepoch"`
+	Exitepoch                  uint64 `json:"exitepoch"`
 	Isonline                   bool   `json:"isonline"`
 	Name                       string `json:"name"`
 	Pubkey                     string `json:"pubkey"`
 	Slashed                    bool   `json:"slashed"`
 	Status                     string `json:"status"`
 	Validatorindex             int64  `json:"validatorindex"`
-	Withdrawableepoch          int64  `json:"withdrawableepoch"`
+	Withdrawableepoch          uint64 `json:"withdrawableepoch"`
 	Withdrawalcredentials      string `json:"withdrawalcredentials"`
 }
 
@@ -100,14 +100,14 @@ func getApiValidator(w http.ResponseWriter, r *http.Request) {
 			Activationepoch:            int64(validator.Validator.ActivationEpoch),
 			Balance:                    int64(validator.Balance),
 			Effectivebalance:           int64(validator.Validator.EffectiveBalance),
-			Exitepoch:                  int64(validator.Validator.ExitEpoch),
+			Exitepoch:                  uint64(validator.Validator.ExitEpoch),
 			Isonline:                   isOnline,
 			Name:                       services.GlobalBeaconService.GetValidatorName(uint64(validator.Index)),
 			Pubkey:                     validator.Validator.PublicKey.String(),
 			Slashed:                    validator.Validator.Slashed,
 			Status:                     validator.Status.String(),
 			Validatorindex:             int64(validator.Index),
-			Withdrawableepoch:          int64(validator.Validator.WithdrawableEpoch),
+			Withdrawableepoch:          uint64(validator.Validator.WithdrawableEpoch),
 			Withdrawalcredentials:      fmt.Sprintf("0x%x", validator.Validator.WithdrawalCredentials),
 		})
 	}


### PR DESCRIPTION
According to https://github.com/attestantio/go-eth2-client/blob/b41ce952806c2955c4182548c60293a62aa6e760/spec/phase0/types.go#L25 an Epoch is defined as a uint64 even if https://github.com/gobitfly/eth2-beaconchain-explorer/blob/2d517f4826bfb7f7c141ef642214811cd1f7575a/handlers/api.go#L1809 defines it as an int64. This should fix the issue mentioned in https://github.com/ethpandaops/dora/pull/235#issuecomment-2702481007