### PR TITLE
fix(indexer): fix panic attempt to access pruned dependentState

### DIFF
--- a/indexer/beacon/epochstats_test.go
+++ b/indexer/beacon/epochstats_test.go
@@ -1,0 +1,113 @@
+package beacon
+
+import (
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEpochStats_PrunedDependentState tests that storing a local copy of dependentState
+// at the beginning of a function protects against it being set to nil during execution.
+func TestEpochStats_PrunedDependentState(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.InfoLevel)
+
+	indexer := &Indexer{
+		logger: logrus.NewEntry(logger),
+	}
+
+	t.Run("DependentStateNil_ShouldPanic", func(t *testing.T) {
+		es := &EpochStats{
+			epoch:         phase0.Epoch(123),
+			dependentRoot: phase0.Root{0x01},
+			dependentState: &epochState{
+				stateRoot: phase0.Root{0x02},
+			},
+			values: &EpochStatsValues{
+				ActiveValidators: 100,
+			},
+		}
+
+		// Access prior to pruning is fine.
+		indexer.logger.Infof(
+			"processed epoch %v stats (root: %v / state: %v, validators: %v/%v, %v ms), %v bytes",
+			es.epoch,
+			es.dependentRoot.String(),
+			es.dependentState.stateRoot.String(),
+			es.values.ActiveValidators,
+			0,
+			0,
+			0,
+		)
+
+		// Set dependentState to nil to simulate the epoch cache pruner.
+		es.dependentState = nil
+
+		// This should panic - assert it does.
+		assert.Panics(t, func() {
+			indexer.logger.Infof(
+				"processed epoch %v stats (root: %v / state: %v, validators: %v/%v, %v ms), %v bytes",
+				es.epoch,
+				es.dependentRoot.String(),
+				es.dependentState.stateRoot.String(),
+				es.values.ActiveValidators,
+				0,
+				0,
+				0,
+			)
+		}, "Should panic when accessing es.dependentState.stateRoot after setting dependentState to nil")
+	})
+
+	t.Run("DependentStateNotNil_ShouldNotPanic", func(t *testing.T) {
+		es := &EpochStats{
+			epoch:         phase0.Epoch(123),
+			dependentRoot: phase0.Root{0x01},
+			dependentState: &epochState{
+				stateRoot: phase0.Root{0x02},
+			},
+			values: &EpochStatsValues{
+				ActiveValidators: 100,
+			},
+		}
+
+		dependentState := es.dependentState
+
+		// Access prior to pruning is fine.
+		indexer.logger.Infof(
+			"processed epoch %v stats (root: %v / state: %v, validators: %v/%v, %v ms), %v bytes",
+			es.epoch,
+			es.dependentRoot.String(),
+			dependentState.stateRoot.String(),
+			es.values.ActiveValidators,
+			0,
+			0,
+			0,
+		)
+
+		// Set es.dependentState to nil to simulate the epoch cache pruner.
+		es.dependentState = nil
+
+		assert.NotPanics(t, func() {
+			indexer.logger.Infof(
+				"processed epoch %v stats (root: %v / state: %v, validators: %v/%v, %v ms), %v bytes",
+				es.epoch,
+				es.dependentRoot.String(),
+				dependentState.stateRoot.String(),
+				es.values.ActiveValidators,
+				0,
+				0,
+				0,
+			)
+		}, "Should not panic when using local copy of dependentState")
+
+		assert.Contains(
+			t,
+			hook.LastEntry().Message,
+			"state: 0x0200000000000000000000000000000000000000000000000000000000000000",
+			"Log message should contain the correct stateRoot",
+		)
+	})
+}


### PR DESCRIPTION
```
time="2025-03-07T10:41:43Z" level=info msg="received block 118337:3786808 [0xdad90f28438644f7528de01e96c5bb70cdc880fb3c2c84c0b4bc3ed455ee0ae2] stream  (1218 ms, 3 ms, 2690 ms) fork: 19985" client=prysm-geth service=cl-indexer
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x10fc165]

goroutine 114970 [running]:
github.com/ethpandaops/dora/indexer/beacon.(*EpochStats).processState(0xc02e05cd00, 0xc00018bb00, {0xc0ffb10000, 0x1d5638, 0xc1082b0180?})
    /home/runner/work/dora/dora/indexer/beacon/epochstats.go:470 +0xf65
created by github.com/ethpandaops/dora/indexer/beacon.(*epochCache).loadEpochStats in goroutine 103300
    /home/runner/work/dora/dora/indexer/beacon/epochcache.go:472 +0xf97
```


I believe the panic happens because `es.dependentState` is being set to `nil` by the epoch pruner while the `processState` method is still running in a goroutine. 