### PR TITLE
Display ILs per slot

### DIFF
--- a/clients/consensus/client.go
+++ b/clients/consensus/client.go
@@ -52,6 +52,7 @@ type Client struct {
 	blockDispatcher         Dispatcher[*v1.BlockEvent]
 	headDispatcher          Dispatcher[*v1.HeadEvent]
 	checkpointDispatcher    Dispatcher[*v1.Finality]
+	inclusionListDispatcher Dispatcher[*v1.InclusionListEvent]
 }
 
 func (pool *Pool) newPoolClient(clientIdx uint16, endpoint *ClientConfig) (*Client, error) {
@@ -94,6 +95,10 @@ func (client *Client) SubscribeHeadEvent(capacity int, blocking bool) *Subscript
 
 func (client *Client) SubscribeFinalizedEvent(capacity int) *Subscription[*v1.Finality] {
 	return client.checkpointDispatcher.Subscribe(capacity, false)
+}
+
+func (client *Client) SubscribeInclusionListEvent(capacity int, blocking bool) *Subscription[*v1.InclusionListEvent] {
+	return client.inclusionListDispatcher.Subscribe(capacity, blocking)
 }
 
 func (client *Client) GetPool() *Pool {

--- a/indexer/beacon/inclusionlistcache.go
+++ b/indexer/beacon/inclusionlistcache.go
@@ -1,0 +1,104 @@
+package beacon
+
+import (
+	"runtime/debug"
+	"sync"
+	"time"
+
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// inclusionListCache is a cache for storing inclusion lists.
+type inclusionListCache struct {
+	indexer          *Indexer
+	cacheMutex       sync.RWMutex
+	inclusionListMap map[phase0.Slot][]*v1.SignedInclusionList
+}
+
+// newInclusionListCache creates a new instance of inclusionListCache.
+func newInclusionListCache(indexer *Indexer) *inclusionListCache {
+	cache := &inclusionListCache{
+		indexer:          indexer,
+		inclusionListMap: map[phase0.Slot][]*v1.SignedInclusionList{},
+	}
+
+	go cache.cleanupLoop()
+
+	return cache
+}
+
+// addInclusionList adds the given inclusion list to the cache.
+func (cache *inclusionListCache) addInclusionList(inclusionList *v1.SignedInclusionList) {
+	cache.cacheMutex.Lock()
+	defer cache.cacheMutex.Unlock()
+
+	for _, inclusionListCached := range cache.inclusionListMap[inclusionList.Message.Slot] {
+		if inclusionListCached.Message.ValidatorIndex != inclusionList.Message.ValidatorIndex {
+			continue
+		}
+
+		if inclusionListCached.Signature == inclusionList.Signature {
+			// This is a duplicated event possibly coming from different clients.
+			return
+		}
+
+		// This is an equivocation. We cache all of an equivocator's inclusion lists to display them in the explorer.
+		break
+	}
+
+	cache.inclusionListMap[inclusionList.Message.Slot] = append(cache.inclusionListMap[inclusionList.Message.Slot], inclusionList)
+}
+
+// getInclusionListsBySlot returns the cached inclusion lists with the given slot.
+func (cache *inclusionListCache) getInclusionListsBySlot(slot phase0.Slot) []*v1.SignedInclusionList {
+	cache.cacheMutex.RLock()
+	defer cache.cacheMutex.RUnlock()
+
+	inclusionLists := make([]*v1.SignedInclusionList, len(cache.inclusionListMap[slot]))
+	if len(inclusionLists) > 0 {
+		copy(inclusionLists, cache.inclusionListMap[slot])
+	}
+
+	return inclusionLists
+}
+
+// cleanupLoop is a loop that cleans up the cache.
+func (cache *inclusionListCache) cleanupLoop() {
+	defer func() {
+		if err := recover(); err != nil {
+			cache.indexer.logger.WithError(err.(error)).Errorf("uncaught panic in indexer.beacon.inclusionListCache.cleanupLoop subroutine: %v, stack: %v", err, string(debug.Stack()))
+			time.Sleep(10 * time.Second)
+
+			go cache.cleanupLoop()
+		}
+	}()
+
+	for {
+		time.Sleep(30 * time.Minute)
+		cache.cleanupCache()
+	}
+}
+
+// cleanupCache cleans up the cache.
+func (cache *inclusionListCache) cleanupCache() {
+	chainState := cache.indexer.consensusPool.GetChainState()
+	cutOffEpoch := chainState.CurrentEpoch() - phase0.Epoch(cache.indexer.activityHistoryLength)
+	if cutOffEpoch < 0 {
+		return
+	}
+
+	cache.cacheMutex.Lock()
+	defer cache.cacheMutex.Unlock()
+
+	deleted := 0
+	for slot, inclusionLists := range cache.inclusionListMap {
+		if chainState.EpochOfSlot(slot) < cutOffEpoch {
+			deleted += len(inclusionLists)
+			delete(cache.inclusionListMap, slot)
+			continue
+		}
+	}
+
+	cache.indexer.logger.Infof("cleaned up inclusion list cache, deleted %d entries", deleted)
+}

--- a/indexer/beacon/indexer.go
+++ b/indexer/beacon/indexer.go
@@ -38,12 +38,13 @@ type Indexer struct {
 	maxParallelStateCalls uint16
 
 	// caches
-	blockCache        *blockCache
-	epochCache        *epochCache
-	forkCache         *forkCache
-	pubkeyCache       *pubkeyCache
-	validatorCache    *validatorCache
-	validatorActivity *validatorActivityCache
+	blockCache         *blockCache
+	inclusionListCache *inclusionListCache
+	epochCache         *epochCache
+	forkCache          *forkCache
+	pubkeyCache        *pubkeyCache
+	validatorCache     *validatorCache
+	validatorActivity  *validatorActivityCache
 
 	// indexer state
 	clients               []*Client
@@ -102,6 +103,7 @@ func NewIndexer(logger logrus.FieldLogger, consensusPool *consensus.Pool) *Index
 	}
 
 	indexer.blockCache = newBlockCache(indexer)
+	indexer.inclusionListCache = newInclusionListCache(indexer)
 	indexer.epochCache = newEpochCache(indexer)
 	indexer.forkCache = newForkCache(indexer)
 	indexer.pubkeyCache = newPubkeyCache(indexer, utils.Config.Indexer.PubkeyCachePath)

--- a/indexer/beacon/indexer_getter.go
+++ b/indexer/beacon/indexer_getter.go
@@ -202,6 +202,11 @@ func (indexer *Indexer) GetOrphanedBlockByRoot(blockRoot phase0.Root) (*Block, e
 	return block, nil
 }
 
+// GetInclusionListsBySlot returns a slice of inclusion lists with the given slot.
+func (indexer *Indexer) GetInclusionListsBySlot(slot phase0.Slot) []*v1.SignedInclusionList {
+	return indexer.inclusionListCache.getInclusionListsBySlot(slot)
+}
+
 // GetEpochStats returns the epoch stats for the given epoch and optional fork ID override.
 func (indexer *Indexer) GetEpochStats(epoch phase0.Epoch, overrideForkId *ForkKey) *EpochStats {
 	epochStats := indexer.epochCache.getEpochStatsByEpoch(epoch)

--- a/templates/slot/inclusion_lists.html
+++ b/templates/slot/inclusion_lists.html
@@ -1,0 +1,102 @@
+{{ define "inclusion_lists" }}
+  {{ range $i, $inclusionList := .InclusionLists }}
+    <div class="card my-2">
+      <div class="card-body px-0 py-1">
+        <div class="row border-bottom p-1 mx-0">
+          <div class="col-md-12 text-center"><b>Inclusion List {{ $i }}</b></div>
+        </div>
+        <div class="row border-bottom p-1 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="A validator who has submitted their inclusion list">Validator:</span></div>
+          <div class="col-md-10">
+            {{ formatValidatorWithIndex $inclusionList.Validator.Index $inclusionList.Validator.Name }}
+          </div>
+        </div>
+        <div class="row border-bottom p-1 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="The hash-tree-root of the IL committee">IL Committee Root:</span></div>
+          <div class="col-md-10 text-monospace text-break">
+            0x{{ printf "%x" $inclusionList.InclusionListCommitteeRoot }}
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $inclusionList.InclusionListCommitteeRoot }}"></i>
+          </div>
+        </div>
+        <div class="row border-bottom p-1 mx-0">
+          <div class="col-md-2">Signature:</div>
+          <div class="col-md-10 text-monospace text-break">0x{{ printf "%x" $inclusionList.Signature }}</div>
+        </div>
+        <div class="row border-bottom p-1 mx-0">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Amount of transactions included in this inclusion list">Transactions:</span></div>
+          <div class="col-md-10 text-monospace text-break"><b>{{ formatAddCommas $inclusionList.TransactionsCount }}</b></div>
+        </div>
+        <div class="table-ellipsis px-0">
+          <table class="table" id="inclusion_list_transactions">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Hash</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Method</th>
+                <th>Value</th>
+                <th>Call Data</th>
+                <th>Included</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {{ range $j, $transaction := $inclusionList.Transactions }}
+                <tr>
+                  <td>{{ $j }}</td>
+                  <td>
+                    <div class="ellipsis-copy-btn">
+                      <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $transaction.Hash }}"></i>
+                    </div>
+                    0x{{ printf "%x" $transaction.Hash }}
+                  </td>
+                  <td>
+                    <div class="ellipsis-copy-btn">
+                      <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ $transaction.From }}"></i>
+                    </div>
+                    {{ $transaction.From }}
+                  </td>
+                  <td>
+                    <div class="ellipsis-copy-btn">
+                      <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ $transaction.To }}"></i>
+                    </div>
+                    {{ $transaction.To }}
+                  </td>
+                  <td>
+                    {{ if eq $transaction.FuncSigStatus 10 }}
+                      <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;">{{ $transaction.FuncName }}</span>
+                    {{ else if eq $transaction.FuncSigStatus 1 }}
+                      <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="call {{ $transaction.FuncBytes }}: {{ $transaction.FuncSig }}">{{ $transaction.FuncName }}</span>
+                    {{ else }}
+                      <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="call {{ $transaction.FuncBytes }}">{{ $transaction.FuncName }}</span>
+                    {{ end }}
+                  </td>
+                  <td>{{ $transaction.Value }} ETH</td>
+                  <td>
+                    {{ if gt $transaction.DataLen 0 }}
+                      <span class="badge rounded-pill text-bg-secondary" style="font-size: 12px; font-weight: 500;">{{ $transaction.DataLen }} B</span>
+                      <i class="fa fa-copy text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $transaction.Data }}"></i>
+                    {{ end }}
+                  </td>
+                  <td>
+                    {{ if index $inclusionList.TransactionsIncluded $j }}
+                      <span class="badge rounded-pill text-bg-success" style="font-size: 12px; font-weight: 500;">Yes</span>
+                    {{ else }}
+                      <span class="badge rounded-pill text-bg-danger" style="font-size: 12px; font-weight: 500;">No</span>
+                    {{ end }}
+                  </td>
+                  <td>
+                    <i class="fa fa-circle-info text-muted ml-2 p-1" role="button" data-bs-toggle="tooltip" data-bs-html="true" data-bs-title="{{ "" -}}
+                      TX Type: {{ $transaction.Type }}<br>
+                    {{- "" }}"></i>
+                  </td>
+                </tr>
+              {{ end }}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  {{ end }}
+{{ end }}

--- a/templates/slot/slot.html
+++ b/templates/slot/slot.html
@@ -37,6 +37,11 @@
       <li class="nav-item">
         <a class="nav-link active" id="overview-tab" data-bs-toggle="tab" href="#overview" role="tab" aria-controls="overview" aria-selected="true">Overview</a>
       </li>
+      {{ if gt .InclusionListsCount 0 }}
+      <li class="nav-item">
+        <a class="nav-link" id="inclusion-lists-tab" data-bs-toggle="tab" href="#inclusion-lists" role="tab" aria-controls="inclusion-lists" aria-selected="false">Inclusion Lists <span class="badge bg-secondary text-white">{{ .InclusionListsCount }}</span></a>
+      </li>
+      {{ end }}
       {{ if .Block }}
         {{ if gt .Block.TransactionsCount 0 }}
           <li class="nav-item">
@@ -112,6 +117,21 @@
           {{ template "block_overview" $ }}
         </div>
       </div>
+      {{ if gt .InclusionListsCount 0 }}
+        <div class="tab-pane fade show active" id="inclusion-lists" role="tabpanel" aria-labelledby="inclusion-lists-tab">
+          <div class="card block-card">
+            <div style="margin-bottom: -.25rem;" class="card-body px-0 py-1">
+              <div class="row p-1 mx-0">
+                <div class="d-none d-md-block col-md-4"></div>
+                <h3 class="h5 col-12 col-md-4 text-center">
+                  <b>Showing {{ .InclusionListsCount }} Inclusion Lists</b>
+                </h3>
+              </div>
+            </div>
+          </div>
+          {{ template "inclusion_lists" . }}
+        </div>
+      {{ end }}
       {{ if .Block }}
         {{ if gt .Block.TransactionsCount 0 }}
           <div class="tab-pane fade show active" id="transactions" role="tabpanel" aria-labelledby="transactions-tab">

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -8,19 +8,21 @@ import (
 
 // SlotPageData is a struct to hold info for the slot details page
 type SlotPageData struct {
-	Slot                   uint64                `json:"slot"`
-	Epoch                  uint64                `json:"epoch"`
-	EpochFinalized         bool                  `json:"epoch_finalized"`
-	EpochParticipationRate float64               `json:"epoch_participation_rate"`
-	Ts                     time.Time             `json:"time"`
-	NextSlot               uint64                `json:"next_slot"`
-	PreviousSlot           uint64                `json:"prev_slot"`
-	Status                 uint16                `json:"status"`
-	Future                 bool                  `json:"future"`
-	Proposer               uint64                `json:"proposer"`
-	ProposerName           string                `json:"proposer_name"`
-	Block                  *SlotPageBlockData    `json:"block"`
-	Badges                 []*SlotPageBlockBadge `json:"badges"`
+	Slot                   uint64                   `json:"slot"`
+	Epoch                  uint64                   `json:"epoch"`
+	EpochFinalized         bool                     `json:"epoch_finalized"`
+	EpochParticipationRate float64                  `json:"epoch_participation_rate"`
+	Ts                     time.Time                `json:"time"`
+	NextSlot               uint64                   `json:"next_slot"`
+	PreviousSlot           uint64                   `json:"prev_slot"`
+	Status                 uint16                   `json:"status"`
+	Future                 bool                     `json:"future"`
+	Proposer               uint64                   `json:"proposer"`
+	ProposerName           string                   `json:"proposer_name"`
+	Block                  *SlotPageBlockData       `json:"block"`
+	InclusionLists         []*SlotPageInclusionList `json:"inclusion_lists"`
+	InclusionListsCount    uint64                   `json:"inclusion_lists_count"`
+	Badges                 []*SlotPageBlockBadge    `json:"badges"`
 }
 
 type SlotPageBlockBadge struct {
@@ -114,6 +116,15 @@ type SlotPageAttestation struct {
 	SourceRoot      []byte `json:"source_root"`
 	TargetEpoch     uint64 `json:"target_epoch"`
 	TargetRoot      []byte `json:"target_root"`
+}
+
+type SlotPageInclusionList struct {
+	Validator                  types.NamedValidator   `json:"validator"`
+	InclusionListCommitteeRoot []byte                 `json:"inclusion_list_committee_root"`
+	Transactions               []*SlotPageTransaction `json:"transactions"`
+	TransactionsCount          uint64                 `json:"transactions_count"`
+	TransactionsIncluded       []bool                 `json:"transactions_included"`
+	Signature                  []byte                 `json:"signature"`
 }
 
 type SlotPageDeposit struct {


### PR DESCRIPTION
This PR make Dora to listen to IL events, store ILs and display them in the slot page.

Clients can emit events over the same IL so Dora performs the duplication check before storing ILs. When there is an equivocation, both ILs by the equivocator are stored and be displayed. Currently, ILs are stored on memory.

One thing to notice is it assumes no fork. This would be our future work and it should consider IL committee root to cope with multiple forks properly.

To run this successfully, you could use this [Kurtosis config](https://github.com/jihoonsong/local-devnet-focil/blob/main/kurtosis/kurtosis.config.registry.yaml). You should be able to see ILs after `eip7805` fork is activated as below:

<img width="1838" alt="Screenshot 2025-03-11 at 1 34 05 AM" src="https://github.com/user-attachments/assets/d90f85cd-2306-4e1f-8c6f-8fa3938fa435" />