### PR TITLE
use client side rendering for attestation details

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/ethpandaops/dora/db"
+	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/indexer/beacon"
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/templates"
@@ -324,6 +325,8 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, epochStatsV
 		Eth1dataDepositroot:    eth1Data.DepositRoot[:],
 		Eth1dataDepositcount:   eth1Data.DepositCount,
 		Eth1dataBlockhash:      eth1Data.BlockHash,
+		ValidatorNames:         make(map[uint64]string),
+		SpecValues:             make(map[string]interface{}),
 		ProposerSlashingsCount: uint64(len(proposerSlashings)),
 		AttesterSlashingsCount: uint64(len(attesterSlashings)),
 		AttestationsCount:      uint64(len(attestations)),
@@ -332,9 +335,15 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, epochStatsV
 		SlashingsCount:         uint64(len(proposerSlashings)) + uint64(len(attesterSlashings)),
 	}
 
+	pageData.SpecValues["committees_per_slot"] = specs.MaxCommitteesPerSlot
+	pageData.SpecValues["target_committee_size"] = specs.TargetCommitteeSize
+	pageData.SpecValues["slots_per_epoch"] = specs.SlotsPerEpoch
+
 	epoch := chainState.EpochOfSlot(blockData.Header.Message.Slot)
 	assignmentsMap := make(map[phase0.Epoch]*beacon.EpochStatsValues)
 	assignmentsLoaded := make(map[phase0.Epoch]bool)
+	dbEpochMap := make(map[phase0.Epoch]*dbtypes.Epoch)
+	dbEpochLoaded := make(map[phase0.Epoch]bool)
 	assignmentsMap[epoch] = epochStatsValues
 	assignmentsLoaded[epoch] = true
 
@@ -355,19 +364,38 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, epochStatsV
 			continue
 		}
 
+		totalActiveValidators := uint64(0)
+
 		attEpoch := chainState.EpochOfSlot(attData.Slot)
 		if !assignmentsLoaded[attEpoch] { // get epoch duties from cache
+			assignmentsLoaded[attEpoch] = true
 			beaconIndexer := services.GlobalBeaconService.GetBeaconIndexer()
 			if epochStats := beaconIndexer.GetEpochStats(epoch, nil); epochStats != nil {
 				epochStatsValues := epochStats.GetOrLoadValues(beaconIndexer, true, false)
 
 				assignmentsMap[attEpoch] = epochStatsValues
-				assignmentsLoaded[attEpoch] = true
+			}
+		}
+
+		if assignmentsMap[attEpoch] != nil {
+			totalActiveValidators = assignmentsMap[attEpoch].ActiveValidators
+		} else {
+			if !dbEpochLoaded[attEpoch] {
+				dbEpochLoaded[attEpoch] = true
+				dbEpochs := db.GetEpochs(uint64(attEpoch), 1)
+				if len(dbEpochs) > 0 && dbEpochs[0].Epoch == uint64(attEpoch) {
+					dbEpochMap[attEpoch] = dbEpochs[0]
+				}
+			}
+
+			if dbEpochMap[attEpoch] != nil {
+				totalActiveValidators = dbEpochMap[attEpoch].ValidatorCount
 			}
 		}
 
 		attPageData := models.SlotPageAttestation{
 			Slot:            uint64(attData.Slot),
+			TotalActive:     totalActiveValidators,
 			AggregationBits: attAggregationBits,
 			Signature:       attSignature[:],
 			BeaconBlockRoot: attData.BeaconBlockRoot[:],
@@ -437,19 +465,17 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, epochStatsV
 			attPageData.CommitteeIndex = []uint64{uint64(attData.Index)}
 		}
 
-		attPageData.Validators = make([]types.NamedValidator, len(attAssignments))
+		attPageData.Validators = attAssignments
 		for j := 0; j < len(attAssignments); j++ {
-			attPageData.Validators[j] = types.NamedValidator{
-				Index: attAssignments[j],
-				Name:  services.GlobalBeaconService.GetValidatorName(attAssignments[j]),
+			if _, found := pageData.ValidatorNames[attAssignments[j]]; !found {
+				pageData.ValidatorNames[attAssignments[j]] = services.GlobalBeaconService.GetValidatorName(attAssignments[j])
 			}
 		}
 
-		attPageData.IncludedValidators = make([]types.NamedValidator, len(includedValidators))
+		attPageData.IncludedValidators = includedValidators
 		for j := 0; j < len(includedValidators); j++ {
-			attPageData.IncludedValidators[j] = types.NamedValidator{
-				Index: includedValidators[j],
-				Name:  services.GlobalBeaconService.GetValidatorName(includedValidators[j]),
+			if _, found := pageData.ValidatorNames[includedValidators[j]]; !found {
+				pageData.ValidatorNames[includedValidators[j]] = services.GlobalBeaconService.GetValidatorName(includedValidators[j])
 			}
 		}
 

--- a/templates/slot/attestations.html
+++ b/templates/slot/attestations.html
@@ -54,7 +54,7 @@
         </div>
         <div class="col-md-10">
           {{ html "<!-- ko foreach: included_validators -->" }}
-          <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': $value}">
+          <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': $data}">
             <i class="fas fa-male mr-2"></i>
             <a data-bind="attr: {href: '/validator/' + $data}">
               <!-- ko if: $root.getValidatorName($data) -->
@@ -141,7 +141,14 @@
     self.showDetails = ko.observable(false);
     
     self.toggleDetails = function() {
-      self.showDetails(!self.showDetails());
+      var isOpen = self.showDetails();
+      self.showDetails(!isOpen);
+
+      if (!isOpen) {
+        setTimeout(function() {
+          explorer.initControls();
+        }, 100);
+      }
     };
 
     self.aggregationSummary = ko.computed(function() {

--- a/templates/slot/attestations.html
+++ b/templates/slot/attestations.html
@@ -42,14 +42,14 @@
           {{ html "<!-- ko if: showIncludedValidators -->" }}
           <div class="mt-2">
             {{ html "<!-- ko foreach: included_validators -->" }}
-            <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': index}">
+            <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': $value}">
               <i class="fas fa-male mr-2"></i>
-              <a data-bind="attr: {href: '/validator/' + index}">
-                <!-- ko if: name -->
-                <span data-bind="text: name + ' (' + index + ')'"></span>
+              <a data-bind="attr: {href: '/validator/' + $data}">
+                <!-- ko if: $root.getValidatorName($data) -->
+                <span data-bind="text: $root.getValidatorName($data) + ' (' + $data + ')'"></span>
                 <!-- /ko -->
-                <!-- ko ifnot: name -->
-                <span data-bind="text: index"></span>
+                <!-- ko ifnot: $root.getValidatorName($data) -->
+                <span data-bind="text: $data"></span>
                 <!-- /ko -->
               </a>
             </span>
@@ -100,6 +100,8 @@
 
 <script src="/js/knockout.min.js"></script>
 <script type="text/javascript">
+  var specValues = JSON.parse({{ includeJSON .Block.SpecValues false }});
+  var validatorNames = JSON.parse({{ includeJSON .Block.ValidatorNames false }});
   var attestationsData = JSON.parse({{ includeJSON .Block.Attestations false }});
   
   function base64ToBytes(base64) {
@@ -163,19 +165,22 @@
           end = bits.length * 8;
         }
 
+        if (y > 0) {
+          html += '<br/>';
+        }
+
         for (var x = start; x < end; x++) {
-          if (x % 8 === 0) {
-            if (x !== 0) {
-              html += ' ';
-            }
+          if (x % 8 === 0 && x !== start) {
+            html += ' ';
           }
 
           var validator = self.validators[x];
-          if (validator) {
-            if (validator.name) {
-              html += `<span data-bs-toggle="tooltip" data-bs-placement="top" title="${validator.name} (${validator.index})">`;
+          if (validator !== undefined) {
+            var name = validatorNames[validator];
+            if (name) {
+              html += `<span data-bs-toggle="tooltip" data-bs-placement="top" title="${name} (${validator})">`;
             } else {
-              html += `<span data-bs-toggle="tooltip" data-bs-placement="top" title="${validator.index}">`;
+              html += `<span data-bs-toggle="tooltip" data-bs-placement="top" title="${validator}">`;
             }
           }
 
@@ -196,6 +201,11 @@
 
   function AttestationsViewModel() {
     var self = this;
+
+    self.getValidatorName = function(index) {
+      return validatorNames[index];
+    }
+
     self.attestations = ko.observableArray(attestationsData.map(function(att) {
       return new AttestationViewModel(att);
     }));

--- a/templates/slot/attestations.html
+++ b/templates/slot/attestations.html
@@ -32,26 +32,33 @@
         </div>
         <div class="col-md-10" data-bind="html: formattedAggregationBits"></div>
       </div>
+      {{ html "<!-- ko if: included_validators.length > 0 -->" }}
       <div class="row border-bottom p-1 mx-0">
         <div class="col-md-2">
           <span data-bs-toggle="tooltip" data-bs-placement="top" title="Validators who have submitted their attestation and have been included by the block proposer">Included Validators:</span>
         </div>
         <div class="col-md-10">
-          {{ html "<!-- ko foreach: included_validators -->" }}
-          <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': index}">
-            <i class="fas fa-male mr-2"></i>
-            <a data-bind="attr: {href: '/validator/' + index}">
-              <!-- ko if: name -->
-              <span data-bind="text: name + ' (' + index + ')'"></span>
-              <!-- /ko -->
-              <!-- ko ifnot: name -->
-              <span data-bind="text: index"></span>
-              <!-- /ko -->
-            </a>
-          </span>
+          <button class="btn btn-sm btn-primary" data-bind="click: toggleIncludedValidators, text: showIncludedValidators() ? 'Hide Validators' : 'Show Validators (' + included_validators.length + ')'"></button>
+          {{ html "<!-- ko if: showIncludedValidators -->" }}
+          <div class="mt-2">
+            {{ html "<!-- ko foreach: included_validators -->" }}
+            <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': index}">
+              <i class="fas fa-male mr-2"></i>
+              <a data-bind="attr: {href: '/validator/' + index}">
+                <!-- ko if: name -->
+                <span data-bind="text: name + ' (' + index + ')'"></span>
+                <!-- /ko -->
+                <!-- ko ifnot: name -->
+                <span data-bind="text: index"></span>
+                <!-- /ko -->
+              </a>
+            </span>
+            {{ html "<!-- /ko -->" }}
+          </div>
           {{ html "<!-- /ko -->" }}
         </div>
       </div>
+      {{ html "<!-- /ko -->" }}
       <div class="row border-bottom p-1 mx-0">
         <div class="col-md-2">
           <span data-bs-toggle="tooltip" data-bs-placement="top" title="Points to the block to which validators are attesting">Beacon Block Root:</span>
@@ -118,6 +125,12 @@
     self.validators = data.validators;
     self.included_validators = data.included_validators;
 
+    self.showIncludedValidators = ko.observable(false);
+    
+    self.toggleIncludedValidators = function() {
+      self.showIncludedValidators(!self.showIncludedValidators());
+    };
+
     // Format hex values
     self.beaconBlockRootHex = ko.computed(function() {
       return bytesToHex(self.beacon_block_root);
@@ -138,7 +151,7 @@
     // Format aggregation bits with validator info
     self.formattedAggregationBits = ko.computed(function() {
       var bits = self.aggregation_bits;
-      var html = '<div class="text-bitfield text-monospace">';
+      var html = '<pre class="text-bitfield text-monospace text-break" style="font-size:1rem;">';
       var perLine = 8;
       
       for (var y = 0; y < bits.length; y += perLine) {
@@ -153,9 +166,8 @@
         for (var x = start; x < end; x++) {
           if (x % 8 === 0) {
             if (x !== 0) {
-              html += '</span> ';
+              html += ' ';
             }
-            html += '<span>';
           }
 
           var validator = self.validators[x];
@@ -176,9 +188,8 @@
             html += '</span>';
           }
         }
-        html += '</span><br/>';
       }
-      html += '</div>';
+      html += '</pre>';
       return html;
     });
   }

--- a/templates/slot/attestations.html
+++ b/templates/slot/attestations.html
@@ -1,57 +1,211 @@
 {{ define "block_attestations" }}
-  {{ range $i, $attestation := .Block.Attestations }}
-    <div class="card my-2">
-      <div class="card-body px-0 py-1">
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-12 text-center"><b>Attestation {{ $i }}</b></div>
-        </div>
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Slot number to which the validator is attesting">Slot:</span></div>
-          <div class="col-md-10"><a href="/slot/{{ $attestation.Slot }}">{{ $attestation.Slot }}</a></div>
-        </div>
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="An identifier for a specific committee during a slot">Committee Index:</span></div>
-          <div class="col-md-10">
-            {{ range $index := $attestation.CommitteeIndex }}
-              <span class="badge bg-secondary mx-2">{{ $index }}</span>
-            {{ end }}
-          </div>
-        </div>
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the aggregated attestation of all participating validators in this attestation">Aggregation Bits:</span></div>
-          <div class="col-md-10">{{ formatBitlist $attestation.AggregationBits $attestation.Validators }}</div>
-        </div>
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Validators who have submitted their attestation and have been included by the block proposer">Included Validators:</span></div>
-          <div class="col-md-10">
-            {{ range $validator := $attestation.IncludedValidators }}
-              {{ formatValidator $validator.Index $validator.Name }}
-            {{ end }}
-          </div>
-        </div>
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Points to the block to which validators are attesting">Beacon Block Root:</span></div>
-          <div class="col-md-10 text-monospace text-break"><a href="/slot/{{ printf "%x" $attestation.BeaconBlockRoot }}">0x{{ printf "%x" $attestation.BeaconBlockRoot }}</a></div>
-        </div>
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Points to the latest justified epoch">Source:</span></div>
-          <div class="col-md-10">
-            Epoch <a href="/epoch/{{ $attestation.SourceEpoch }}">{{ $attestation.SourceEpoch }}</a> 
-            <span class="text-monospace text-break">(<a href="{{ printf "%x" $attestation.SourceRoot }}">0x{{ printf "%x" $attestation.SourceRoot }}</a>)</span>
-          </div>
-        </div>
-        <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Points to the latest epoch boundary">Target:</span></div>
-          <div class="col-md-10">
-            Epoch <a href="/epoch/{{ $attestation.TargetEpoch }}">{{ $attestation.TargetEpoch }}</a> 
-            <span class="text-monospace text-break">(<a href="{{ printf "%x" $attestation.TargetRoot }}">0x{{ printf "%x" $attestation.TargetRoot }}</a>)</span>
-          </div>
-        </div>
-        <div class="row p-1 mx-0">
-          <div class="col-md-2">Signature:</div>
-          <div class="col-md-10 text-monospace text-break">0x{{ printf "%x" $attestation.Signature }}</div>
+<div id="attestationsData" class="attestations-container">
+  {{ html "<!-- ko foreach: attestations -->" }}
+  <div class="card my-2">
+    <div class="card-body px-0 py-1">
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-12 text-center">
+          <b>Attestation <span data-bind="text: slot"></span></b>
         </div>
       </div>
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="Slot number to which the validator is attesting">Slot:</span>
+        </div>
+        <div class="col-md-10">
+          <a data-bind="attr: {href: '/slot/' + slot}, text: slot"></a>
+        </div>
+      </div>
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="An identifier for a specific committee during a slot">Committee Index:</span>
+        </div>
+        <div class="col-md-10">
+          {{ html "<!-- ko foreach: committee_index -->" }}
+          <span class="badge bg-secondary mx-2" data-bind="text: $data"></span>
+          {{ html "<!-- /ko -->" }}
+        </div>
+      </div>
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the aggregated attestation of all participating validators in this attestation">Aggregation Bits:</span>
+        </div>
+        <div class="col-md-10" data-bind="html: formattedAggregationBits"></div>
+      </div>
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="Validators who have submitted their attestation and have been included by the block proposer">Included Validators:</span>
+        </div>
+        <div class="col-md-10">
+          {{ html "<!-- ko foreach: included_validators -->" }}
+          <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': index}">
+            <i class="fas fa-male mr-2"></i>
+            <a data-bind="attr: {href: '/validator/' + index}">
+              <!-- ko if: name -->
+              <span data-bind="text: name + ' (' + index + ')'"></span>
+              <!-- /ko -->
+              <!-- ko ifnot: name -->
+              <span data-bind="text: index"></span>
+              <!-- /ko -->
+            </a>
+          </span>
+          {{ html "<!-- /ko -->" }}
+        </div>
+      </div>
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="Points to the block to which validators are attesting">Beacon Block Root:</span>
+        </div>
+        <div class="col-md-10 text-monospace text-break">
+          <a data-bind="attr: {href: '/slot/0x' + beaconBlockRootHex()}, text: '0x' + beaconBlockRootHex()"></a>
+        </div>
+      </div>
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="Points to the latest justified epoch">Source:</span>
+        </div>
+        <div class="col-md-10">
+          Epoch <a data-bind="attr: {href: '/epoch/' + source_epoch}, text: source_epoch"></a>
+          <span class="text-monospace text-break">
+            (<a data-bind="attr: {href: '/block/0x' + sourceRootHex()}, text: '0x' + sourceRootHex()"></a>)
+          </span>
+        </div>
+      </div>
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="Points to the latest epoch boundary">Target:</span>
+        </div>
+        <div class="col-md-10">
+          Epoch <a data-bind="attr: {href: '/epoch/' + target_epoch}, text: target_epoch"></a>
+          <span class="text-monospace text-break">
+            (<a data-bind="attr: {href: '/block/0x' + targetRootHex()}, text: '0x' + targetRootHex()"></a>)
+          </span>
+        </div>
+      </div>
+      <div class="row p-1 mx-0">
+        <div class="col-md-2">Signature:</div>
+        <div class="col-md-10 text-monospace text-break" data-bind="text: '0x' + signatureHex()"></div>
+      </div>
     </div>
-  {{ end }}
+  </div>
+  {{ html "<!-- /ko -->" }}
+</div>
+
+<script src="/js/knockout.min.js"></script>
+<script type="text/javascript">
+  var attestationsData = JSON.parse({{ includeJSON .Block.Attestations false }});
+  
+  function base64ToBytes(base64) {
+    const binString = atob(base64);
+    return Uint8Array.from(binString, (m) => m.charCodeAt(0));
+  }
+
+  function bytesToHex(bytes) {
+    return Array.from(bytes).map(b => b.toString(16).padStart(2,'0')).join('');
+  }
+
+  function AttestationViewModel(data) {
+    var self = this;
+    self.slot = data.slot;
+    self.committee_index = data.committeeindex;
+    self.aggregation_bits = base64ToBytes(data.aggregationbits);
+    self.beacon_block_root = base64ToBytes(data.beaconblockroot);
+    self.source_epoch = data.source_epoch;
+    self.source_root = base64ToBytes(data.source_root);
+    self.target_epoch = data.target_epoch;
+    self.target_root = base64ToBytes(data.target_root);
+    self.signature = base64ToBytes(data.signature);
+    self.validators = data.validators;
+    self.included_validators = data.included_validators;
+
+    // Format hex values
+    self.beaconBlockRootHex = ko.computed(function() {
+      return bytesToHex(self.beacon_block_root);
+    });
+    
+    self.sourceRootHex = ko.computed(function() {
+      return bytesToHex(self.source_root);
+    });
+    
+    self.targetRootHex = ko.computed(function() {
+      return bytesToHex(self.target_root);
+    });
+
+    self.signatureHex = ko.computed(function() {
+      return bytesToHex(self.signature);
+    });
+
+    // Format aggregation bits with validator info
+    self.formattedAggregationBits = ko.computed(function() {
+      var bits = self.aggregation_bits;
+      var html = '<div class="text-bitfield text-monospace">';
+      var perLine = 8;
+      
+      for (var y = 0; y < bits.length; y += perLine) {
+        var start = y * 8;
+        var end = (y + perLine) * 8;
+        if (self.validators.length > 0 && end >= self.validators.length) {
+          end = self.validators.length;
+        } else if (self.validators.length === 0 && end >= bits.length * 8) {
+          end = bits.length * 8;
+        }
+
+        for (var x = start; x < end; x++) {
+          if (x % 8 === 0) {
+            if (x !== 0) {
+              html += '</span> ';
+            }
+            html += '<span>';
+          }
+
+          var validator = self.validators[x];
+          if (validator) {
+            if (validator.name) {
+              html += `<span data-bs-toggle="tooltip" data-bs-placement="top" title="${validator.name} (${validator.index})">`;
+            } else {
+              html += `<span data-bs-toggle="tooltip" data-bs-placement="top" title="${validator.index}">`;
+            }
+          }
+
+          var byteIndex = Math.floor(x / 8);
+          var bitIndex = x % 8;
+          var isSet = (bits[byteIndex] & (1 << bitIndex)) !== 0;
+          html += isSet ? '1' : '0';
+
+          if (validator) {
+            html += '</span>';
+          }
+        }
+        html += '</span><br/>';
+      }
+      html += '</div>';
+      return html;
+    });
+  }
+
+  function AttestationsViewModel() {
+    var self = this;
+    self.attestations = ko.observableArray(attestationsData.map(function(att) {
+      return new AttestationViewModel(att);
+    }));
+  }
+
+  ko.applyBindings(new AttestationsViewModel(), document.getElementById('attestationsData'));
+</script>
+
+<style>
+.validator-label {
+  margin-right: 0.5rem;
+}
+.validator-label.validator-index {
+  white-space: nowrap;
+}
+.validator-label.validator-name {
+  white-space: nowrap;
+}
+.text-bitfield > span > span {
+  width: 8px;
+  display: inline-block;
+}
+</style>
 {{ end }}

--- a/templates/slot/attestations.html
+++ b/templates/slot/attestations.html
@@ -28,9 +28,24 @@
       </div>
       <div class="row border-bottom p-1 mx-0">
         <div class="col-md-2">
+          <span data-bs-toggle="tooltip" data-bs-placement="top" title="Summary of validator participation">Aggregation:</span>
+        </div>
+        <div class="col-md-10 d-flex justify-content-between">
+          <span data-bind="text: aggregationSummary"></span>
+          <i class="fas fa-chevron-down cursor-pointer" 
+             data-bind="click: toggleDetails, 
+                       css: { 'fa-chevron-down': !showDetails(), 'fa-chevron-up': showDetails() }">
+          </i>
+        </div>
+      </div>
+      {{ html "<!-- ko if: showDetails -->" }}
+      <div class="row border-bottom p-1 mx-0">
+        <div class="col-md-2">
           <span data-bs-toggle="tooltip" data-bs-placement="top" title="Represents the aggregated attestation of all participating validators in this attestation">Aggregation Bits:</span>
         </div>
-        <div class="col-md-10" data-bind="html: formattedAggregationBits"></div>
+        <div class="col-md-10">
+          <div data-bind="html: formattedAggregationBits"></div>
+        </div>
       </div>
       {{ html "<!-- ko if: included_validators.length > 0 -->" }}
       <div class="row border-bottom p-1 mx-0">
@@ -38,26 +53,22 @@
           <span data-bs-toggle="tooltip" data-bs-placement="top" title="Validators who have submitted their attestation and have been included by the block proposer">Included Validators:</span>
         </div>
         <div class="col-md-10">
-          <button class="btn btn-sm btn-primary" data-bind="click: toggleIncludedValidators, text: showIncludedValidators() ? 'Hide Validators' : 'Show Validators (' + included_validators.length + ')'"></button>
-          {{ html "<!-- ko if: showIncludedValidators -->" }}
-          <div class="mt-2">
-            {{ html "<!-- ko foreach: included_validators -->" }}
-            <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': $value}">
-              <i class="fas fa-male mr-2"></i>
-              <a data-bind="attr: {href: '/validator/' + $data}">
-                <!-- ko if: $root.getValidatorName($data) -->
-                <span data-bind="text: $root.getValidatorName($data) + ' (' + $data + ')'"></span>
-                <!-- /ko -->
-                <!-- ko ifnot: $root.getValidatorName($data) -->
-                <span data-bind="text: $data"></span>
-                <!-- /ko -->
-              </a>
-            </span>
-            {{ html "<!-- /ko -->" }}
-          </div>
+          {{ html "<!-- ko foreach: included_validators -->" }}
+          <span class="validator-label validator-name" data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': $value}">
+            <i class="fas fa-male mr-2"></i>
+            <a data-bind="attr: {href: '/validator/' + $data}">
+              <!-- ko if: $root.getValidatorName($data) -->
+              <span data-bind="text: $root.getValidatorName($data) + ' (' + $data + ')'"></span>
+              <!-- /ko -->
+              <!-- ko ifnot: $root.getValidatorName($data) -->
+              <span data-bind="text: $data"></span>
+              <!-- /ko -->
+            </a>
+          </span>
           {{ html "<!-- /ko -->" }}
         </div>
       </div>
+      {{ html "<!-- /ko -->" }}
       {{ html "<!-- /ko -->" }}
       <div class="row border-bottom p-1 mx-0">
         <div class="col-md-2">
@@ -127,11 +138,25 @@
     self.validators = data.validators;
     self.included_validators = data.included_validators;
 
-    self.showIncludedValidators = ko.observable(false);
+    self.showDetails = ko.observable(false);
     
-    self.toggleIncludedValidators = function() {
-      self.showIncludedValidators(!self.showIncludedValidators());
+    self.toggleDetails = function() {
+      self.showDetails(!self.showDetails());
     };
+
+    self.aggregationSummary = ko.computed(function() {
+      var total = self.aggregation_bits.length * 8;
+      var set = 0;
+      for (var i = 0; i < self.aggregation_bits.length; i++) {
+        for (var j = 0; j < 8; j++) {
+          if (self.aggregation_bits[i] & (1 << j)) {
+            set++;
+          }
+        }
+      }
+      var percentage = ((set / total) * 100).toFixed(2);
+      return set + " validators attesting, " + (total - set) + " not attesting (" + percentage + "%)";
+    });
 
     // Format hex values
     self.beaconBlockRootHex = ko.computed(function() {
@@ -227,6 +252,9 @@
 .text-bitfield > span > span {
   width: 8px;
   display: inline-block;
+}
+.cursor-pointer {
+  cursor: pointer;
 }
 </style>
 {{ end }}

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -52,6 +52,8 @@ type SlotPageBlockData struct {
 	SyncAggregateSignature     []byte                 `json:"syncaggregate_signature"`
 	SyncAggParticipation       float64                `json:"syncaggregate_participation"`
 	SyncAggCommittee           []types.NamedValidator `json:"syncaggregate_committee"`
+	ValidatorNames             map[uint64]string      `json:"validator_names"`
+	SpecValues                 map[string]interface{} `json:"spec_values"`
 	ProposerSlashingsCount     uint64                 `json:"proposer_slashings_count"`
 	AttesterSlashingsCount     uint64                 `json:"attester_slashings_count"`
 	AttestationsCount          uint64                 `json:"attestations_count"`
@@ -101,11 +103,11 @@ type SlotPageExecutionData struct {
 type SlotPageAttestation struct {
 	Slot           uint64   `json:"slot"`
 	CommitteeIndex []uint64 `json:"committeeindex"`
+	TotalActive    uint64   `json:"total_active"`
 
-	AggregationBits []byte                 `json:"aggregationbits"`
-	Validators      []types.NamedValidator `json:"validators"`
-
-	IncludedValidators []types.NamedValidator `json:"included_validators"`
+	AggregationBits    []byte   `json:"aggregationbits"`
+	Validators         []uint64 `json:"validators"`
+	IncludedValidators []uint64 `json:"included_validators"`
 
 	Signature []byte `json:"signature"`
 


### PR DESCRIPTION
This PR makes the attestations on the block details page client side rendered.
Resource heavy features like the attestation bitlist or validators list are hidden by default, but can be shown when needed:
![image](https://github.com/user-attachments/assets/dc07ae2a-7f39-4b04-ab38-31e7ab3e1eb9)

This heavily reduces the number of DOM elements for large networks with huge attestations and makes the page "usable" again without crashing the browser