### PR TITLE
fix warnings for possible invalid consolidations/withdrawals

### DIFF
--- a/handlers/submit_consolidation.go
+++ b/handlers/submit_consolidation.go
@@ -135,7 +135,7 @@ func handleSubmitConsolidationPageDataAjax(w http.ResponseWriter, r *http.Reques
 			}
 
 			consolidable := false
-			if validator.Validator.ActivationEpoch < beacon.FarFutureEpoch && validator.Validator.ActivationEpoch+phase0.Epoch(chainSpecs.ShardCommitteePeriod) > chainState.CurrentEpoch() {
+			if validator.Validator.ActivationEpoch < beacon.FarFutureEpoch && validator.Validator.ActivationEpoch+phase0.Epoch(chainSpecs.ShardCommitteePeriod) < chainState.CurrentEpoch() {
 				consolidable = true
 			}
 

--- a/handlers/submit_withdrawal.go
+++ b/handlers/submit_withdrawal.go
@@ -136,7 +136,7 @@ func handleSubmitWithdrawalPageDataAjax(w http.ResponseWriter, r *http.Request) 
 			}
 
 			withdrawable := false
-			if validator.Validator.ActivationEpoch < beacon.FarFutureEpoch && validator.Validator.ActivationEpoch+phase0.Epoch(chainSpecs.ShardCommitteePeriod) > chainState.CurrentEpoch() {
+			if validator.Validator.ActivationEpoch < beacon.FarFutureEpoch && validator.Validator.ActivationEpoch+phase0.Epoch(chainSpecs.ShardCommitteePeriod) < chainState.CurrentEpoch() {
 				withdrawable = true
 			}
 

--- a/ui-package/src/components/SubmitConsolidationsForm/ConsolidationReview.tsx
+++ b/ui-package/src/components/SubmitConsolidationsForm/ConsolidationReview.tsx
@@ -174,7 +174,7 @@ const ConsolidationReview = (props: IConsolidationReviewProps) => {
               This consolidation will fail because the source validator is not withdrawable yet. The validator must be withdrawable before it can be consolidated.
             </div>
           )}
-          {props.targetValidator.credtype !== "0x02" && props.targetValidator.index != props.sourceValidator.index && (
+          {props.targetValidator.credtype !== "02" && props.targetValidator.index != props.sourceValidator.index && (
             <div className="alert alert-warning" role="alert">
               <i className="fa-solid fa-triangle-exclamation me-2"></i>
               This consolidation will fail because the target validator does not have 0x02 withdrawal credentials. The target validator must first perform a self-consolidation to update its withdrawal credentials to 0x02.


### PR DESCRIPTION
This PR fixes the conditions for some warnings that were shown on the consolidation / withdrawal submission pages.

Also reported by the Obol Collective