### PR TITLE
implement block root blacklist to exclude certain bad chains

### DIFF
--- a/indexer/beacon/indexer.go
+++ b/indexer/beacon/indexer.go
@@ -65,6 +65,7 @@ type Indexer struct {
 	canonicalHead        *Block
 	canonicalComputation phase0.Root
 	cachedChainHeads     []*ChainHead
+	badChainRoots        []phase0.Root
 }
 
 // NewIndexer creates a new instance of the Indexer.
@@ -108,6 +109,13 @@ func NewIndexer(logger logrus.FieldLogger, consensusPool *consensus.Pool) *Index
 	indexer.validatorCache = newValidatorCache(indexer)
 	indexer.validatorActivity = newValidatorActivityCache(indexer)
 	indexer.dbWriter = newDbWriter(indexer)
+
+	badChainRoots := utils.Config.Indexer.BadChainRoots
+	if len(badChainRoots) > 0 {
+		for _, root := range badChainRoots {
+			indexer.badChainRoots = append(indexer.badChainRoots, phase0.Root(utils.MustParseHex(root)))
+		}
+	}
 
 	return indexer
 }

--- a/types/config.go
+++ b/types/config.go
@@ -94,6 +94,8 @@ type Config struct {
 		SyncEpochCooldown               uint   `yaml:"syncEpochCooldown" envconfig:"INDEXER_SYNC_EPOCH_COOLDOWN"`
 		MaxParallelValidatorSetRequests uint   `yaml:"maxParallelValidatorSetRequests" envconfig:"INDEXER_MAX_PARALLEL_VALIDATOR_SET_REQUESTS"`
 		PubkeyCachePath                 string `yaml:"pubkeyCachePath" envconfig:"INDEXER_PUBKEY_CACHE_PATH"`
+
+		BadChainRoots []string `yaml:"badChainRoots" envconfig:"INDEXER_BAD_CHAIN_ROOTS"`
 	} `yaml:"indexer"`
 
 	TxSignature struct {


### PR DESCRIPTION
This PR adds an optional block root blacklist to dora, which prevents a chain that includes that block from being selected as the canonical chain.
This is useful for situations where a bad chain has more participation than the chain that's seen as canonical by social consensus (as recently seen on holesky)