### PR TITLE
fix fallback for canonical head selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The repository contains a script that simplifies spinning up a development envir
 
 Follow these steps to spin up a full ethereum testnet with the locally build dora instance:
 
-1. Ensure docker & (kurtosis)[https://docs.kurtosis.com/install] are installed on your machine.
+1. Ensure docker & [kurtosis](https://docs.kurtosis.com/install) are installed on your machine.
 2. Clone the repository
 3. Run `make devnet-run`
 


### PR DESCRIPTION
small fix for canonical head selection.

#277 introduced a regression in the canonical head block selection.
The for loop introduced in the PR to consider multiple heads as fallback candidates added a new `headBlock` variable, which broke the intended behavior to set the `headBlock` in the function scope to a block till end of the function. 
The parent `headBlock` was effectively hidden due to using the same variable name as index for the `for`-loop.

This was causing issues like this: (reported on #interop)
![image](https://github.com/user-attachments/assets/ebdcf66a-1ffc-42e9-ad78-a9f251941f1f)
The regression is also present in the holesky-rescue branch for longer time already, but was rarely kicking in as it's only triggered in the fallback code path in the canonical head selection under certain bad conditions.
