### PR TITLE
fix(build): move .dockerignore to properly ignore node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+ui-package/node_modules

--- a/ui-package/.dockerignore
+++ b/ui-package/.dockerignore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
Should fix https://github.com/ethpandaops/dora/issues/290 

As @pk910 figured out, it could be that a local `node_modules` is being copied and overriding it during docker build.

The problem is that the current `.dockerignore` is in the wrong place. To fix this I've moved the .dockerignore file close to the Dockerfile. 