### PR TITLE
chore(deps): enable automatic updates for GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,28 @@
-version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      "dependencies":
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    directory: "/ui-package"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      "ui-package dependencies":
-        patterns:
-          - "*"
+- directory: /
+  groups:
+    dependencies:
+      patterns:
+      - '*'
+  open-pull-requests-limit: 10
+  package-ecosystem: gomod
+  schedule:
+    interval: weekly
+- directory: /ui-package
+  groups:
+    ui-package dependencies:
+      patterns:
+      - '*'
+  open-pull-requests-limit: 10
+  package-ecosystem: npm
+  schedule:
+    interval: weekly
+- directory: /
+  groups:
+    actions:
+      patterns:
+      - '*'
+  package-ecosystem: github-actions
+  schedule:
+    interval: monthly
+version: 2


### PR DESCRIPTION

### 💚 Dependabot automatic updates
This PR enables automatic updates for GitHub Actions via [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

Dependabot will periodically check for new versions of the actions and create a PR to update the version used in the repository.

This should help keeping your GitHub Actions up to date with the latest versions of the actions.

#### 🔍 How was this detected and generated?
This PR was generated using [ethpandaops/github-actions-checker](https://github.com/ethpandaops/github-actions-checker).
