### PR TITLE
consolidation logic change (allow consolidations to any target validator)

### DIFF
--- a/db/schema/pgsql/20250404004511_fix-valid-consolidations.sql
+++ b/db/schema/pgsql/20250404004511_fix-valid-consolidations.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+
+UPDATE "consolidation_requests"
+    SET "result" = 1 WHERE "result" = 32;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/schema/sqlite/20250404004511_fix-valid-consolidations.sql
+++ b/db/schema/sqlite/20250404004511_fix-valid-consolidations.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+
+UPDATE "consolidation_requests"
+    SET "result" = 1 WHERE "result" = 32;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'NOT SUPPORTED';
+-- +goose StatementEnd

--- a/db/validators.go
+++ b/db/validators.go
@@ -227,10 +227,21 @@ func buildValidatorFilterSql(filter dbtypes.ValidatorFilter, currentEpoch uint64
 		fmt.Fprintf(sql, " %v validator_index IN (%s)", filterOp, strings.Join(indices, ","))
 		filterOp = "AND"
 	}
-	if filter.PubKey != nil {
-		args = append(args, filter.PubKey)
-		fmt.Fprintf(sql, " %v pubkey = $%v", filterOp, len(args))
-		filterOp = "AND"
+	if len(filter.PubKey) > 0 {
+		pubkeylen := len(filter.PubKey)
+		if pubkeylen > 48 {
+			pubkeylen = 48
+		}
+
+		if pubkeylen == 48 {
+			args = append(args, filter.PubKey)
+			fmt.Fprintf(sql, " %v pubkey = $%v", filterOp, len(args))
+			filterOp = "AND"
+		} else {
+			args = append(args, filter.PubKey)
+			fmt.Fprintf(sql, " %v SUBSTRING(pubkey, 1, %v) = $%v", filterOp, pubkeylen, len(args))
+			filterOp = "AND"
+		}
 	}
 	if filter.WithdrawalAddress != nil {
 		wdcreds1 := make([]byte, 32)

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -270,7 +270,6 @@ const (
 	// target validator errors
 	ConsolidationRequestResultTgtNotFound           uint8 = 30
 	ConsolidationRequestResultTgtInvalidCredentials uint8 = 31
-	ConsolidationRequestResultTgtInvalidSender      uint8 = 32
 	ConsolidationRequestResultTgtNotCompounding     uint8 = 33
 	ConsolidationRequestResultTgtNotActive          uint8 = 34
 )

--- a/handlers/el_consolidations.go
+++ b/handlers/el_consolidations.go
@@ -320,8 +320,6 @@ func getConsolidationResultMessage(result uint8, specs *consensus.ChainSpec) str
 		return "Error: Target validator not found"
 	case dbtypes.ConsolidationRequestResultTgtInvalidCredentials:
 		return "Error: Target validator has invalid credentials"
-	case dbtypes.ConsolidationRequestResultTgtInvalidSender:
-		return "Error: Target validator withdrawal address does not match tx sender"
 	case dbtypes.ConsolidationRequestResultTgtNotCompounding:
 		return "Error: Target validator is not compounding"
 	case dbtypes.ConsolidationRequestResultTgtNotActive:

--- a/indexer/beacon/state_sim.go
+++ b/indexer/beacon/state_sim.go
@@ -179,10 +179,6 @@ func (sim *stateSimulator) applyConsolidation(consolidation *electra.Consolidati
 		return dbtypes.ConsolidationRequestResultTgtInvalidCredentials
 	}
 
-	if !bytes.Equal(tgtWithdrawalCreds[12:], consolidation.SourceAddress[:]) {
-		return dbtypes.ConsolidationRequestResultTgtInvalidSender
-	}
-
 	if srcValidator == tgtValidator {
 		// self consolidation, set withdrawal credentials to 0x02
 		if srcValidator.WithdrawalCredentials[0] == 0x01 {

--- a/services/chainservice_validators.go
+++ b/services/chainservice_validators.go
@@ -102,6 +102,15 @@ func (bs *ChainService) GetFilteredValidatorSet(filter *dbtypes.ValidatorFilter,
 		if len(filter.Indices) > 0 && !slices.Contains(filter.Indices, index) {
 			return nil
 		}
+		if len(filter.PubKey) > 0 {
+			pubkeylen := len(filter.PubKey)
+			if pubkeylen > 48 {
+				pubkeylen = 48
+			}
+			if !bytes.Equal(validator.PublicKey[:pubkeylen], filter.PubKey) {
+				return nil
+			}
+		}
 		if filter.WithdrawalAddress != nil {
 			if validator.WithdrawalCredentials[0] != 0x01 && validator.WithdrawalCredentials[0] != 0x02 {
 				return nil

--- a/templates/submit_consolidation/submit_consolidation.html
+++ b/templates/submit_consolidation/submit_consolidation.html
@@ -58,6 +58,14 @@
                 console.log(data);
                 return data;
               });
+          },
+          searchValidatorsCallback: function(searchTerm) {
+            return fetch(`?ajax=search_validators&search=${searchTerm}`)
+              .then(response => response.json())
+              .then(data => {
+                console.log(data);
+                return data;
+              });
           }
         }
       }

--- a/ui-package/src/components/SubmitConsolidationsForm/SubmitConsolidationsForm.tsx
+++ b/ui-package/src/components/SubmitConsolidationsForm/SubmitConsolidationsForm.tsx
@@ -76,6 +76,7 @@ const SubmitConsolidationsForm = (props: ISubmitConsolidationsFormProps): React.
             </div>
             <div className="col-12 col-lg-11">
               <ValidatorSelector
+                placeholder="Select a validator"
                 validators={validators}
                 onChange={(validator) => {
                   console.log("source validator", validator);
@@ -138,12 +139,15 @@ const SubmitConsolidationsForm = (props: ISubmitConsolidationsFormProps): React.
             </div>
             <div className="col-12 col-lg-11">
               <ValidatorSelector
-                validators={validators}
+                placeholder="Search for a validator by index or pubkey"
+                validators={[]}
                 onChange={(validator) => {
                   console.log("target validator", validator);
                   setTargetValidator(validator);
                 }}
                 value={targetValidator}
+                isLazyLoaded={true}
+                searchValidatorsCallback={props.searchValidatorsCallback}
               />
             </div>
           </div>

--- a/ui-package/src/components/SubmitConsolidationsForm/SubmitConsolidationsFormProps.ts
+++ b/ui-package/src/components/SubmitConsolidationsForm/SubmitConsolidationsFormProps.ts
@@ -2,6 +2,7 @@ export interface ISubmitConsolidationsFormProps {
   consolidationContract: string;
   explorerUrl: string;
   loadValidatorsCallback: (address: string) => Promise<IValidator[]>;
+  searchValidatorsCallback: (searchTerm: string) => Promise<IValidator[]>;
 }
 
 export interface IValidator {


### PR DESCRIPTION
This PR updates the consolidation logic in dora:
1. Remove the "Target validator withdrawal address does not match tx sender"-Error in consolidation result simulation
2. Update all existing consolidation request with the error above to "Success"
3. Update the submit_consolidations page to allow searching for any target validator by pubkey or index
![image](https://github.com/user-attachments/assets/ce358197-54c9-42bf-9a8d-ad5cc4d325d3)
