### PR TITLE
fix panic on various pages when deposit queue is empty

### DIFF
--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -507,7 +507,7 @@ func (bs *ChainService) GetIndexedDepositQueue(headBlock *beacon.Block) *Indexed
 
 	indexedQueue.QueueEstimation = queueEpoch
 
-	if !bytes.Equal(indexedQueue.Queue[len(indexedQueue.Queue)-1].PendingDeposit.Pubkey[:], lastIncludedDeposit.PublicKey[:]) {
+	if len(indexedQueue.Queue) > 0 && !bytes.Equal(indexedQueue.Queue[len(indexedQueue.Queue)-1].PendingDeposit.Pubkey[:], lastIncludedDeposit.PublicKey[:]) {
 		// something is bad, return nil
 		return &IndexedDepositQueue{
 			Queue: []*IndexedDepositQueueEntry{},


### PR DESCRIPTION
fix panic:
```
URL: /validator/1270
Time: 2025-04-04 17:53:17.643701518 +0000 UTC m=+207.959597165
Version: git-15930ef

Error:
page call 6 panic: runtime error: index out of range [-1]

Stack Trace:
goroutine 957 [running]:
runtime/debug.Stack()
	/opt/hostedtoolcache/go/1.24.2/x64/src/runtime/debug/stack.go:26 +0x5e
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
	/home/runner/work/dora/dora/services/frontendcache.go:131 +0xd4
panic({0x1aed520?, 0xc00117b710?})
	/opt/hostedtoolcache/go/1.24.2/x64/src/runtime/panic.go:792 +0x132
github.com/ethpandaops/dora/services.(*ChainService).GetIndexedDepositQueue(0xc00047bd40, 0x0?)
	/home/runner/work/dora/dora/services/chainservice_deposits.go:510 +0x695
github.com/ethpandaops/dora/services.(*ChainService).GetFilteredQueuedDeposits(0xc00047bd40, 0xc00e1c7e50)
	/home/runner/work/dora/dora/services/chainservice_deposits.go:621 +0x45
github.com/ethpandaops/dora/handlers.buildValidatorPageData(0x4f6, {0x1bd6ab3, 0x6})
	/home/runner/work/dora/dora/handlers/validator.go:140 +0x3c7
github.com/ethpandaops/dora/handlers.getValidatorPageData.func1(0xc00e3feea0)
	/home/runner/work/dora/dora/handlers/validator.go:102 +0x25
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0xc00011a8d0?)
	/home/runner/work/dora/dora/services/frontendcache.go:148 +0x1d3
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 955
	/home/runner/work/dora/dora/services/frontendcache.go:125 +0x348
```