### PR TITLE
fix nil pointer on slot details page when cached block isn't fully loaded

### DIFF
--- a/services/chainservice_blocks.go
+++ b/services/chainservice_blocks.go
@@ -101,11 +101,15 @@ func (bs *ChainService) GetSlotDetailsByBlockroot(ctx context.Context, blockroot
 
 	// try loading from cache
 	if blockInfo := bs.beaconIndexer.GetBlockByRoot(blockroot); blockInfo != nil {
-		result = &CombinedBlockResponse{
-			Root:     blockInfo.Root,
-			Header:   blockInfo.GetHeader(),
-			Block:    blockInfo.GetBlock(),
-			Orphaned: !bs.beaconIndexer.IsCanonicalBlock(blockInfo, nil),
+		blockHeader := blockInfo.GetHeader()
+		blockBody := blockInfo.GetBlock()
+		if blockHeader != nil && blockBody != nil {
+			result = &CombinedBlockResponse{
+				Root:     blockInfo.Root,
+				Header:   blockInfo.GetHeader(),
+				Block:    blockInfo.GetBlock(),
+				Orphaned: !bs.beaconIndexer.IsCanonicalBlock(blockInfo, nil),
+			}
 		}
 	} else if blockInfo, err := bs.beaconIndexer.GetOrphanedBlockByRoot(blockroot); blockInfo != nil || err != nil {
 		// try loading from orphaned block db
@@ -225,11 +229,16 @@ func (bs *ChainService) GetSlotDetailsBySlot(ctx context.Context, slot phase0.Sl
 			cachedBlock = cachedBlocks[0]
 			isOrphaned = true
 		}
-		result = &CombinedBlockResponse{
-			Root:     cachedBlock.Root,
-			Header:   cachedBlock.GetHeader(),
-			Block:    cachedBlock.GetBlock(),
-			Orphaned: isOrphaned,
+
+		blockHeader := cachedBlock.GetHeader()
+		blockBody := cachedBlock.GetBlock()
+		if blockHeader != nil && blockBody != nil {
+			result = &CombinedBlockResponse{
+				Root:     cachedBlock.Root,
+				Header:   blockHeader,
+				Block:    blockBody,
+				Orphaned: isOrphaned,
+			}
 		}
 	}
 


### PR DESCRIPTION
```
URL: /slot/3
Time: 2025-04-08 15:35:42.357788371 +0000 UTC m=+21.588255813
Version: git-9fc172e

Error:
page call 5 panic: runtime error: invalid memory address or nil pointer dereference

Stack Trace:
goroutine 253 [running]:
runtime/debug.Stack()
    /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/debug/stack.go:26 +0x64
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
    /home/runner/work/dora/dora/services/frontendcache.go:131 +0x9c
panic({0x1792860?, 0x3e524d0?})
    /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/panic.go:792 +0x124
github.com/attestantio/go-eth2-client/spec.(*VersionedSignedBeaconBlock).Graffiti(0x40000eac60?)
    /home/runner/go/pkg/mod/github.com/pk910/go-eth2-client@v0.0.0-20250207131221-7db107ca35a6/spec/versionedsignedbeaconblock.go:256 +0x20
github.com/ethpandaops/dora/handlers.getSlotPageBlockData(0x40007a8080, 0x4000b27680)
    /home/runner/work/dora/dora/handlers/slot.go:303 +0x78
github.com/ethpandaops/dora/handlers.buildSlotPageData({0x3250890, 0x40001c7450}, 0x3, {0x3f54100, 0x0, 0x0?})
    /home/runner/work/dora/dora/handlers/slot.go:273 +0x478
github.com/ethpandaops/dora/handlers.getSlotPageData.func1(0x4002422d80)
    /home/runner/work/dora/dora/handlers/slot.go:174 +0x3c
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0x4000b69bc0?)
    /home/runner/work/dora/dora/services/frontendcache.go:148 +0x194
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 144
    /home/runner/work/dora/dora/services/frontendcache.go:125 +0x30c
```