### PR TITLE
Add missing deposits API for launchpad support

### DIFF
--- a/cmd/dora-explorer/main.go
+++ b/cmd/dora-explorer/main.go
@@ -233,5 +233,6 @@ func startApi(router *mux.Router) {
 	router.HandleFunc("/v1/validator", api.ApiValidatorPostV1).Methods("POST", "OPTIONS")
 	router.HandleFunc("/v1/validator/eth1/{eth1address}", api.ApiValidatorByEth1AddressV1).Methods("GET", "OPTIONS")
 	router.HandleFunc("/v1/validator/withdrawalCredentials/{withdrawalCredentialsOrEth1address}", api.ApiWithdrawalCredentialsValidatorsV1).Methods("GET", "OPTIONS")
+	router.HandleFunc("/v1/validator/{indexOrPubkey}/deposits", api.ApiValidatorDepositsV1).Methods("GET", "OPTIONS")
 	router.HandleFunc("/v1/epoch/{epoch}", api.ApiEpochV1).Methods("GET", "OPTIONS")
 }

--- a/handlers/api/general.go
+++ b/handlers/api/general.go
@@ -1,15 +1,53 @@
 package api
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"math"
 	"net/http"
+	"strconv"
+	"strings"
 
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/dora/services"
 	"github.com/sirupsen/logrus"
 )
 
 type ApiResponse struct {
 	Status string      `json:"status"`
 	Data   interface{} `json:"data"`
+}
+
+func parseValidatorParamsToIndices(origParam string, limit int) (indices []phase0.ValidatorIndex, err error) {
+	params := strings.Split(origParam, ",")
+	if len(params) > limit {
+		return nil, fmt.Errorf("only a maximum of %d query parameters are allowed", limit)
+	}
+	for _, param := range params {
+		if strings.Contains(param, "0x") || len(param) == 96 {
+			pubkey, err := hex.DecodeString(strings.Replace(param, "0x", "", -1))
+			if err != nil {
+				return nil, fmt.Errorf("invalid validator-parameter")
+			}
+
+			indice, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(pubkey))
+			if !found {
+				return nil, fmt.Errorf("validator pubkey %s not found", param)
+			}
+			indices = append(indices, indice)
+		} else {
+			index, err := strconv.ParseUint(param, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid validator-parameter: %v", param)
+			}
+			if index < math.MaxInt64 {
+				indices = append(indices, phase0.ValidatorIndex(index))
+			}
+		}
+	}
+
+	return
 }
 
 func sendBadRequestResponse(w http.ResponseWriter, route, message string) {

--- a/handlers/api/general.go
+++ b/handlers/api/general.go
@@ -9,7 +9,9 @@ import (
 	"strconv"
 	"strings"
 
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/services"
 	"github.com/sirupsen/logrus"
 )

--- a/handlers/api/validator_deposits_v1.go
+++ b/handlers/api/validator_deposits_v1.go
@@ -46,19 +46,6 @@ func ApiValidatorDepositsV1(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
 		// Get the validators from the URL
 		param = vars["indexOrPubkey"]
-	} else {
-		// Get the validators from the request body
-		decoder := json.NewDecoder(r.Body)
-		req := &struct {
-			IndicesOrPubKey string `json:"indicesOrPubkey"`
-		}{}
-
-		err := decoder.Decode(req)
-		if err != nil {
-			sendBadRequestResponse(w, r.URL.String(), "error decoding request body")
-			return
-		}
-		param = req.IndicesOrPubKey
 	}
 
 	pubkeys, err := parseValidatorParamsToPubkeys(param, 100)

--- a/handlers/api/validator_deposits_v1.go
+++ b/handlers/api/validator_deposits_v1.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethpandaops/dora/db"
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/services"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+type ApiValidatorDepositsResponseV1 struct {
+	Amount                uint64 `json:"amount"`
+	BlockNumber           uint64 `json:"block_number"`
+	BlockTS               uint64 `json:"block_ts"`
+	FromAddress           string `json:"from_address"`
+	MerkleTreeIndex       string `json:"merkletree_index"`
+	PublicKey             string `json:"publickey"`
+	Removed               bool   `json:"removed"`
+	Signature             string `json:"signature"`
+	TxHash                string `json:"tx_hash"`
+	TxIndex               uint64 `json:"tx_index"`
+	TxInput               string `json:"tx_input"`
+	ValidSignature        bool   `json:"valid_signature"`
+	WithdrawalCredentials string `json:"withdrawal_credentials"`
+}
+
+// ApiValidatorDepositsV1 godoc
+// @Summary Get validator execution layer deposits
+// @Description Get all eth1 deposits for up to 100 validators
+// @Tags Validators
+// @Produce  json
+// @Param  indexOrPubkey path string true "Up to 100 validator indicesOrPubkeys, comma separated"
+// @Success 200 {object} types.ApiResponse{data=[]types.ApiValidatorDepositsResponseV1}
+// @Failure 400 {object} types.ApiResponse
+// @Router /api/v1/validator/{indexOrPubkey}/deposits [get]
+func ApiValidatorDepositsV1(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	vars := mux.Vars(r)
+	var param string
+	if r.Method == http.MethodGet {
+		// Get the validators from the URL
+		param = vars["indexOrPubkey"]
+	} else {
+		// Get the validators from the request body
+		decoder := json.NewDecoder(r.Body)
+		req := &struct {
+			IndicesOrPubKey string `json:"indicesOrPubkey"`
+		}{}
+
+		err := decoder.Decode(req)
+		if err != nil {
+			sendBadRequestResponse(w, r.URL.String(), "error decoding request body")
+			return
+		}
+		param = req.IndicesOrPubKey
+	}
+
+	queryIndices, err := parseValidatorParamsToIndices(param, 100)
+	if err != nil {
+		sendBadRequestResponse(w, r.URL.String(), err.Error())
+		return
+	}
+
+	relevantValidators, _ := services.GlobalBeaconService.GetFilteredValidatorSet(&dbtypes.ValidatorFilter{
+		Indices: queryIndices,
+	}, true)
+
+	pubkeys := make([][]byte, 0, len(relevantValidators))
+	for _, relevantValidator := range relevantValidators {
+		pubkey := relevantValidator.Validator.PublicKey[:]
+
+		pubkeys = append(pubkeys, pubkey)
+	}
+
+	canonicalForkIds := services.GlobalBeaconService.GetCanonicalForkIds()
+
+	deposits, _, err := db.GetDepositTxsFiltered(0, 1000, canonicalForkIds, &dbtypes.DepositTxFilter{
+		PublicKeys:   pubkeys,
+		WithOrphaned: 0,
+	})
+	if err != nil {
+		sendServerErrorResponse(w, r.URL.String(), err.Error())
+		return
+	}
+
+	data := []*ApiValidatorDepositsResponseV1{}
+	for _, deposit := range deposits {
+		data = append(data, &ApiValidatorDepositsResponseV1{
+			Amount:                uint64(deposit.Amount),
+			BlockNumber:           uint64(deposit.BlockNumber),
+			BlockTS:               uint64(deposit.BlockTime),
+			FromAddress:           common.Address(deposit.TxSender).Hex(),
+			MerkleTreeIndex:       fmt.Sprintf("0x%x", deposit.BlockRoot),
+			PublicKey:             fmt.Sprintf("0x%x", deposit.PublicKey),
+			Removed:               deposit.Orphaned,
+			Signature:             fmt.Sprintf("0x%x", deposit.Signature),
+			TxHash:                fmt.Sprintf("0x%x", deposit.TxHash),
+			TxIndex:               uint64(deposit.Index),
+			TxInput:               fmt.Sprintf("0x%x", deposit.TxTarget),
+			ValidSignature:        deposit.ValidSignature != 0,
+			WithdrawalCredentials: fmt.Sprintf("0x%x", deposit.WithdrawalCredentials),
+		})
+	}
+
+	j := json.NewEncoder(w)
+	response := &ApiResponse{}
+	response.Status = "OK"
+	response.Data = data
+
+	err = j.Encode(response)
+	if err != nil {
+		sendServerErrorResponse(w, r.URL.String(), "could not serialize data results")
+		logrus.Errorf("error serializing json data for API %v route: %v", r.URL, err)
+	}
+}

--- a/handlers/api/validator_deposits_v1.go
+++ b/handlers/api/validator_deposits_v1.go
@@ -61,7 +61,7 @@ func ApiValidatorDepositsV1(w http.ResponseWriter, r *http.Request) {
 		param = req.IndicesOrPubKey
 	}
 
-	queryIndices, err := parseValidatorParamsToIndices(param, 100)
+	pubkeys, err := parseValidatorParamsToPubkeys(param, 100)
 	if err != nil {
 		sendBadRequestResponse(w, r.URL.String(), err.Error())
 		return

--- a/handlers/api/validator_deposits_v1.go
+++ b/handlers/api/validator_deposits_v1.go
@@ -67,17 +67,6 @@ func ApiValidatorDepositsV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	relevantValidators, _ := services.GlobalBeaconService.GetFilteredValidatorSet(&dbtypes.ValidatorFilter{
-		Indices: queryIndices,
-	}, true)
-
-	pubkeys := make([][]byte, 0, len(relevantValidators))
-	for _, relevantValidator := range relevantValidators {
-		pubkey := relevantValidator.Validator.PublicKey[:]
-
-		pubkeys = append(pubkeys, pubkey)
-	}
-
 	canonicalForkIds := services.GlobalBeaconService.GetCanonicalForkIds()
 
 	deposits, _, err := db.GetDepositTxsFiltered(0, 1000, canonicalForkIds, &dbtypes.DepositTxFilter{

--- a/handlers/api/validator_v1.go
+++ b/handlers/api/validator_v1.go
@@ -1,15 +1,10 @@
 package api
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
-	"strconv"
-	"strings"
 
-	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/services"
 	"github.com/gorilla/mux"
@@ -127,35 +122,4 @@ func getApiValidator(w http.ResponseWriter, r *http.Request) {
 		sendServerErrorResponse(w, r.URL.String(), "could not serialize data results")
 		logrus.Errorf("error serializing json data for API %v route: %v", r.URL, err)
 	}
-}
-
-func parseValidatorParamsToIndices(origParam string, limit int) (indices []phase0.ValidatorIndex, err error) {
-	params := strings.Split(origParam, ",")
-	if len(params) > limit {
-		return nil, fmt.Errorf("only a maximum of %d query parameters are allowed", limit)
-	}
-	for _, param := range params {
-		if strings.Contains(param, "0x") || len(param) == 96 {
-			pubkey, err := hex.DecodeString(strings.Replace(param, "0x", "", -1))
-			if err != nil {
-				return nil, fmt.Errorf("invalid validator-parameter")
-			}
-
-			indice, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(pubkey))
-			if !found {
-				return nil, fmt.Errorf("validator pubkey %s not found", param)
-			}
-			indices = append(indices, indice)
-		} else {
-			index, err := strconv.ParseUint(param, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid validator-parameter: %v", param)
-			}
-			if index < math.MaxInt64 {
-				indices = append(indices, phase0.ValidatorIndex(index))
-			}
-		}
-	}
-
-	return
 }


### PR DESCRIPTION
This adds a compatible missing validator deposits api to the one offered by beaconcha.in on https://beaconcha.in/api/v1/docs#tag/validators/GET/api/v1/validator/{indexOrPubkey}/deposits to support the launchpad project.

I didn't test this much and I'm not sure how to do it properly but it seems good from a code point of view.