### PR TITLE
add `offline_validators` page

### DIFF
--- a/cmd/dora-explorer/main.go
+++ b/cmd/dora-explorer/main.go
@@ -178,6 +178,7 @@ func startFrontend(router *mux.Router) {
 	router.HandleFunc("/search/{type}", handlers.SearchAhead).Methods("GET")
 	router.HandleFunc("/validators", handlers.Validators).Methods("GET")
 	router.HandleFunc("/validators/activity", handlers.ValidatorsActivity).Methods("GET")
+	router.HandleFunc("/validators/offline", handlers.ValidatorsOffline).Methods("GET")
 	router.HandleFunc("/validators/deposits", handlers.Deposits).Methods("GET")
 	router.HandleFunc("/validators/deposits/submit", handlers.SubmitDeposit).Methods("GET", "POST")
 	router.HandleFunc("/validators/initiated_deposits", handlers.InitiatedDeposits).Methods("GET")

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -406,6 +406,7 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, epochStatsV
 
 		var attAssignments []uint64
 		includedValidators := []uint64{}
+		attEpochStatsValues := assignmentsMap[attEpoch]
 
 		if attVersioned.Version >= spec.DataVersionElectra {
 			// EIP-7549 attestation
@@ -424,19 +425,20 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, epochStatsV
 				}
 
 				attPageData.CommitteeIndex = append(attPageData.CommitteeIndex, uint64(committee))
-				if assignmentsMap[attEpoch] != nil {
+				if attEpochStatsValues != nil {
 					slotIndex := int(chainState.SlotToSlotIndex(attData.Slot))
-					committeeAssignments := assignmentsMap[attEpoch].AttesterDuties[slotIndex][uint64(committee)]
+					committeeAssignments := attEpochStatsValues.AttesterDuties[slotIndex][uint64(committee)]
 					if len(committeeAssignments) == 0 {
 						break
 					}
 
 					committeeAssignmentsInt := make([]uint64, 0)
 					for j := 0; j < len(committeeAssignments); j++ {
+						validatorIndex := attEpochStatsValues.ActiveIndices[committeeAssignments[j]]
 						if attAggregationBits.BitAt(attBitsOffset + uint64(j)) {
-							includedValidators = append(includedValidators, uint64(committeeAssignments[j]))
+							includedValidators = append(includedValidators, uint64(validatorIndex))
 						}
-						committeeAssignmentsInt = append(committeeAssignmentsInt, uint64(committeeAssignments[j]))
+						committeeAssignmentsInt = append(committeeAssignmentsInt, uint64(validatorIndex))
 					}
 
 					attBitsOffset += uint64(len(committeeAssignments))
@@ -445,15 +447,16 @@ func getSlotPageBlockData(blockData *services.CombinedBlockResponse, epochStatsV
 			}
 		} else {
 			// pre-electra attestation
-			if assignmentsMap[attEpoch] != nil {
+			if attEpochStatsValues != nil {
 				slotIndex := int(chainState.SlotToSlotIndex(attData.Slot))
-				committeeAssignments := assignmentsMap[attEpoch].AttesterDuties[slotIndex][uint64(attData.Index)]
+				committeeAssignments := attEpochStatsValues.AttesterDuties[slotIndex][uint64(attData.Index)]
 				committeeAssignmentsInt := make([]uint64, 0)
 				for j := 0; j < len(committeeAssignments); j++ {
+					validatorIndex := attEpochStatsValues.ActiveIndices[committeeAssignments[j]]
 					if attAggregationBits.BitAt(uint64(j)) {
-						includedValidators = append(includedValidators, uint64(committeeAssignments[j]))
+						includedValidators = append(includedValidators, uint64(validatorIndex))
 					}
-					committeeAssignmentsInt = append(committeeAssignmentsInt, uint64(committeeAssignments[j]))
+					committeeAssignmentsInt = append(committeeAssignmentsInt, uint64(validatorIndex))
 				}
 
 				attAssignments = committeeAssignmentsInt

--- a/handlers/validators_offline.go
+++ b/handlers/validators_offline.go
@@ -1,0 +1,307 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/indexer/beacon"
+	"github.com/ethpandaops/dora/services"
+	"github.com/ethpandaops/dora/templates"
+	"github.com/ethpandaops/dora/types/models"
+	"github.com/sirupsen/logrus"
+)
+
+// ValidatorsOffline will return the filtered "validators offline" page using a go template
+func ValidatorsOffline(w http.ResponseWriter, r *http.Request) {
+	var pageTemplateFiles = append(layoutTemplateFiles,
+		"validators_offline/validators_offline.html",
+		"_svg/professor.html",
+	)
+
+	var pageTemplate = templates.GetTemplate(pageTemplateFiles...)
+	data := InitPageData(w, r, "validators", "/validators/offline", "Offline Validators", pageTemplateFiles)
+
+	urlArgs := r.URL.Query()
+	var pageSize uint64 = 50
+	if urlArgs.Has("c") {
+		pageSize, _ = strconv.ParseUint(urlArgs.Get("c"), 10, 64)
+	}
+	var pageIdx uint64 = 0
+	if urlArgs.Has("s") {
+		pageIdx, _ = strconv.ParseUint(urlArgs.Get("s"), 10, 64)
+	}
+
+	var sortOrder string
+	if urlArgs.Has("o") {
+		sortOrder = urlArgs.Get("o")
+	}
+	if sortOrder == "" {
+		sortOrder = "index"
+	}
+
+	var groupBy uint64
+	if urlArgs.Has("group") {
+		groupBy, _ = strconv.ParseUint(urlArgs.Get("group"), 10, 64)
+	}
+	if groupBy == 0 {
+		if services.GlobalBeaconService.GetValidatorNamesCount() > 0 {
+			groupBy = 3
+		} else {
+			groupBy = 1
+		}
+	}
+
+	var groupKey string
+	if urlArgs.Has("key") {
+		groupKey = urlArgs.Get("key")
+	}
+
+	var pageError error
+	pageError = services.GlobalCallRateLimiter.CheckCallLimit(r, 2)
+	if pageError == nil {
+		data.Data, pageError = getValidatorsOfflinePageData(pageIdx, pageSize, sortOrder, groupBy, groupKey)
+	}
+	if pageError != nil {
+		handlePageError(w, r, pageError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html")
+	if handleTemplateError(w, r, "validators_offline.go", "ValidatorsOffline", "", pageTemplate.ExecuteTemplate(w, "layout", data)) != nil {
+		return // an error has occurred and was processed
+	}
+}
+
+func getValidatorsOfflinePageData(pageIdx uint64, pageSize uint64, sortOrder string, groupBy uint64, groupKey string) (*models.ValidatorsOfflinePageData, error) {
+	pageData := &models.ValidatorsOfflinePageData{}
+	pageCacheKey := fmt.Sprintf("validators_offline:%v:%v:%v:%v:%v", pageIdx, pageSize, sortOrder, groupBy, groupKey)
+	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(processingPage *services.FrontendCacheProcessingPage) interface{} {
+		processingPage.CacheTimeout = 10 * time.Second
+		return buildValidatorsOfflinePageData(pageIdx, pageSize, sortOrder, groupBy, groupKey)
+	})
+	if pageErr == nil && pageRes != nil {
+		resData, resOk := pageRes.(*models.ValidatorsOfflinePageData)
+		if !resOk {
+			return nil, ErrInvalidPageModel
+		}
+		pageData = resData
+	}
+	return pageData, pageErr
+}
+
+func buildValidatorsOfflinePageData(pageIdx uint64, pageSize uint64, sortOrder string, groupBy uint64, groupKey string) *models.ValidatorsOfflinePageData {
+	chainState := services.GlobalBeaconService.GetChainState()
+
+	filterArgs := url.Values{}
+	filterArgs.Add("group", fmt.Sprintf("%v", groupBy))
+	filterArgs.Add("key", groupKey)
+
+	pageData := &models.ValidatorsOfflinePageData{
+		ViewOptionGroupBy: groupBy,
+		GroupKey:          groupKey,
+	}
+	logrus.Debugf("validators_offline page called: %v:%v [%v:%v]", pageIdx, pageSize, groupBy, groupKey)
+	if pageIdx == 0 {
+		pageData.IsDefaultPage = true
+	}
+
+	if pageSize > 100 {
+		pageSize = 100
+	}
+	pageData.PageSize = pageSize
+	pageData.CurrentPageIndex = pageIdx + 1
+	if pageIdx >= 1 {
+		pageData.PrevPageIndex = pageIdx
+	}
+	pageData.LastPageIndex = 0
+
+	// get group name
+	var groupName string
+	switch groupBy {
+	case 1:
+		groupIdx, _ := strconv.ParseUint(groupKey, 10, 64)
+		groupName = fmt.Sprintf("%v - %v", groupIdx*100000, (groupIdx+1)*100000)
+	case 2:
+		groupIdx, _ := strconv.ParseUint(groupKey, 10, 64)
+		groupName = fmt.Sprintf("%v - %v", groupIdx*10000, (groupIdx+1)*10000)
+	case 3:
+		groupName = groupKey
+	}
+	pageData.GroupName = groupName
+
+	// collect offline validators
+	offlineIndices := []phase0.ValidatorIndex{}
+	currentEpoch := services.GlobalBeaconService.GetChainState().CurrentEpoch()
+
+	services.GlobalBeaconService.StreamActiveValidatorData(true, func(index phase0.ValidatorIndex, validatorFlags uint16, activeData *beacon.ValidatorData, validator *phase0.Validator) error {
+		var validatorGroupKey string
+
+		switch groupBy {
+		case 1:
+			groupIdx := index / 100000
+			validatorGroupKey = fmt.Sprintf("%06d", groupIdx)
+		case 2:
+			groupIdx := index / 10000
+			validatorGroupKey = fmt.Sprintf("%06d", groupIdx)
+		case 3:
+			validatorGroupKey = strings.ToLower(services.GlobalBeaconService.GetValidatorName(uint64(index)))
+		}
+
+		if validatorGroupKey != groupKey {
+			return nil
+		}
+
+		if validatorFlags&beacon.ValidatorStatusSlashed != 0 {
+			return nil
+		}
+
+		if activeData != nil && activeData.ActivationEpoch <= currentEpoch {
+			if activeData.ExitEpoch > currentEpoch {
+				votingActivity := services.GlobalBeaconService.GetValidatorLiveness(index, 3)
+
+				if votingActivity == 0 {
+					// This is an offline validator
+					offlineIndices = append(offlineIndices, index)
+				}
+			}
+		}
+
+		return nil
+	})
+
+	// load validator set for offline indices
+	validatorFilter := dbtypes.ValidatorFilter{
+		Limit:   pageSize,
+		Offset:  pageIdx * pageSize,
+		Indices: offlineIndices,
+	}
+	// apply sort order
+	switch sortOrder {
+	case "index-d":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderIndexDesc
+	case "pubkey":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderPubKeyAsc
+	case "pubkey-d":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderPubKeyDesc
+	case "balance":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderBalanceAsc
+	case "balance-d":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderBalanceDesc
+	case "activation":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderActivationEpochAsc
+	case "activation-d":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderActivationEpochDesc
+	case "exit":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderExitEpochAsc
+	case "exit-d":
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderExitEpochDesc
+	default:
+		validatorFilter.OrderBy = dbtypes.ValidatorOrderIndexAsc
+		pageData.IsDefaultSorting = true
+		sortOrder = "index"
+	}
+	pageData.Sorting = sortOrder
+
+	// get validator set
+	var validatorSet []v1.Validator
+	validatorSetRsp, validatorSetLen := services.GlobalBeaconService.GetFilteredValidatorSet(&validatorFilter, true)
+	if len(validatorSetRsp) == 0 {
+		validatorSet = []v1.Validator{}
+	} else {
+		validatorSet = validatorSetRsp
+	}
+
+	pageData.Validators = make([]*models.ValidatorsPageDataValidator, 0)
+
+	for _, validator := range validatorSet {
+		if validator.Validator == nil {
+			continue
+		}
+
+		validatorData := &models.ValidatorsPageDataValidator{
+			Index:            uint64(validator.Index),
+			Name:             services.GlobalBeaconService.GetValidatorName(uint64(validator.Index)),
+			PublicKey:        validator.Validator.PublicKey[:],
+			Balance:          uint64(validator.Balance),
+			EffectiveBalance: uint64(validator.Validator.EffectiveBalance),
+		}
+		if strings.HasPrefix(validator.Status.String(), "pending") {
+			validatorData.State = "Pending"
+		} else if validator.Status == v1.ValidatorStateActiveOngoing {
+			validatorData.State = "Active"
+			validatorData.ShowUpcheck = true
+		} else if validator.Status == v1.ValidatorStateActiveExiting {
+			validatorData.State = "Exiting"
+			validatorData.ShowUpcheck = true
+		} else if validator.Status == v1.ValidatorStateActiveSlashed {
+			validatorData.State = "Slashed"
+			validatorData.ShowUpcheck = true
+		} else if validator.Status == v1.ValidatorStateExitedUnslashed {
+			validatorData.State = "Exited"
+		} else if validator.Status == v1.ValidatorStateExitedSlashed {
+			validatorData.State = "Slashed"
+		} else {
+			validatorData.State = validator.Status.String()
+		}
+
+		if validatorData.ShowUpcheck {
+			validatorData.UpcheckActivity = 0
+			validatorData.UpcheckMaximum = uint8(3)
+		}
+
+		if validator.Validator.ActivationEpoch < 18446744073709551615 {
+			validatorData.ShowActivation = true
+			validatorData.ActivationEpoch = uint64(validator.Validator.ActivationEpoch)
+			validatorData.ActivationTs = chainState.EpochToTime(validator.Validator.ActivationEpoch)
+		}
+		if validator.Validator.ExitEpoch < 18446744073709551615 {
+			validatorData.ShowExit = true
+			validatorData.ExitEpoch = uint64(validator.Validator.ExitEpoch)
+			validatorData.ExitTs = chainState.EpochToTime(validator.Validator.ExitEpoch)
+		}
+		if validator.Validator.WithdrawalCredentials[0] == 0x01 || validator.Validator.WithdrawalCredentials[0] == 0x02 {
+			validatorData.ShowWithdrawAddress = true
+			validatorData.WithdrawAddress = validator.Validator.WithdrawalCredentials[12:]
+		}
+
+		pageData.Validators = append(pageData.Validators, validatorData)
+	}
+
+	pageData.ValidatorCount = validatorSetLen
+	pageData.TotalPages = validatorSetLen / pageSize
+	if validatorSetLen%pageSize != 0 {
+		pageData.TotalPages++
+	}
+	pageData.FirstValidator = pageIdx * pageSize
+	pageData.LastValidator = pageData.FirstValidator + uint64(len(pageData.Validators))
+
+	if pageData.LastValidator < validatorSetLen {
+		pageData.NextPageIndex = pageIdx + 1
+	}
+	if pageData.TotalPages > 1 && pageData.LastValidator < validatorSetLen {
+		pageData.LastPageIndex = pageData.TotalPages - 1
+	}
+
+	if pageIdx > 0 {
+		pageData.PrevPageIndex = pageIdx - 1
+	}
+
+	sortingArg := ""
+	if sortOrder != "index" {
+		sortingArg = fmt.Sprintf("&o=%v", sortOrder)
+	}
+
+	pageData.ViewPageLink = fmt.Sprintf("/validators/offline?%v&c=%v", filterArgs.Encode(), pageData.PageSize)
+	pageData.FirstPageLink = fmt.Sprintf("/validators/offline?%v%v&c=%v", filterArgs.Encode(), sortingArg, pageData.PageSize)
+	pageData.PrevPageLink = fmt.Sprintf("/validators/offline?%v%v&c=%v&s=%v", filterArgs.Encode(), sortingArg, pageData.PageSize, pageData.PrevPageIndex)
+	pageData.NextPageLink = fmt.Sprintf("/validators/offline?%v%v&c=%v&s=%v", filterArgs.Encode(), sortingArg, pageData.PageSize, pageData.NextPageIndex)
+	pageData.LastPageLink = fmt.Sprintf("/validators/offline?%v%v&c=%v&s=%v", filterArgs.Encode(), sortingArg, pageData.PageSize, pageData.LastPageIndex)
+
+	return pageData
+}

--- a/indexer/beacon/validatoractivity.go
+++ b/indexer/beacon/validatoractivity.go
@@ -203,10 +203,11 @@ func (cache *validatorActivityCache) cleanupCache() {
 				deleted++
 
 				// copy last element to current index
-				cutOffLength++
-				if i != activityLength-cutOffLength-1 && cutOffLength < activityLength {
+				if i < activityLength-cutOffLength-1 {
 					recentActivity[i] = recentActivity[activityLength-cutOffLength-1]
 				}
+
+				cutOffLength++
 			}
 		}
 

--- a/indexer/beacon/validatoractivity.go
+++ b/indexer/beacon/validatoractivity.go
@@ -83,7 +83,6 @@ func (cache *validatorActivityCache) updateValidatorActivity(validatorIndex phas
 	}
 
 	chainState := cache.indexer.consensusPool.GetChainState()
-	replaceIndex := -1
 	cutOffLength := 0
 	activityLength := len(recentActivity)
 	for i := activityLength - 1; i >= 0; i-- {
@@ -100,27 +99,22 @@ func (cache *validatorActivityCache) updateValidatorActivity(validatorIndex phas
 
 		if chainState.EpochOfSlot(dutySlot) < cutOffEpoch {
 			recentActivity[i].VoteBlock = nil // clear for gc
-			if replaceIndex == -1 {
-				replaceIndex = i
-			} else if replaceIndex == activityLength-cutOffLength-1 {
-				cutOffLength++
-				replaceIndex = i
-			} else {
+			if i < activityLength-cutOffLength-1 {
 				// copy last element to current index
-				cutOffLength++
 				recentActivity[i] = recentActivity[activityLength-cutOffLength-1]
 			}
+			cutOffLength++
 		}
 	}
 
-	if replaceIndex != -1 {
-		recentActivity[replaceIndex] = ValidatorActivity{
+	if cutOffLength > 0 {
+		recentActivity[activityLength-cutOffLength] = ValidatorActivity{
 			VoteBlock: voteBlock,
 			VoteDelay: uint16(voteBlock.Slot - dutySlot),
 		}
 
-		if cutOffLength > 0 {
-			recentActivity = recentActivity[:activityLength-cutOffLength]
+		if cutOffLength > 1 {
+			recentActivity = recentActivity[:activityLength-(cutOffLength-1)]
 		}
 	} else {
 		recentActivity = append(recentActivity, ValidatorActivity{

--- a/templates/validators_activity/validators_activity.html
+++ b/templates/validators_activity/validators_activity.html
@@ -143,7 +143,7 @@
                     <td>{{ $group.Validators }}</td>
                     <td>{{ $group.Activated }}</td>
                     <td>{{ $group.Online }}</td>
-                    <td>{{ $group.Offline }}</td>
+                    <td><a href="/validators/offline?group={{ $groupBy }}&key={{ $group.GroupLower }}">{{ $group.Offline }}</a></td>
                     <td>{{ $group.Exited }}</td>
                     <td>{{ $group.Slashed }}</td>
                   </tr>

--- a/templates/validators_offline/validators_offline.html
+++ b/templates/validators_offline/validators_offline.html
@@ -1,0 +1,197 @@
+{{ define "page" }}
+  <div class="container mt-2">
+    <div class="d-md-flex py-2 justify-content-md-between">
+      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-exclamation-triangle mx-2"></i>Offline Validators - {{ .GroupName }}</h1>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
+          <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
+          <li class="breadcrumb-item"><a href="/validators" title="Validators">Validators</a></li>
+          <li class="breadcrumb-item"><a href="/validators/activity" title="Activity">Activity</a></li>
+          <li class="breadcrumb-item active" aria-current="page">Offline</li>
+        </ol>
+      </nav>
+    </div>
+
+    <div id="header-placeholder" style="height:35px;"></div>
+    <form action="/validators/offline" method="get" id="validatorsOfflineFilterForm">
+      <input type="hidden" name="group" value="{{ .ViewOptionGroupBy }}">
+      <input type="hidden" name="key" value="{{ .GroupKey }}">
+      {{ if not .IsDefaultSorting }}<input type="hidden" name="o" value="{{ .Sorting }}">{{ end }}
+      <div class="card mt-2">
+        <div class="card-header">
+          View Options
+        </div>
+        <div class="card-body p-2">
+          <div class="row mt-3">
+            <div class="col-8 col-md-6 table-pagesize">
+              <label class="px-2">
+                <span>Show </span>
+                <select name="c" aria-controls="pagesize" class="custom-select custom-select-sm form-control form-control-sm">
+                  <option value="{{ .PageSize }}" selected>{{ .PageSize }}</option>
+                  <option value="10">10</option>
+                  <option value="25">25</option>
+                  <option value="50">50</option>
+                  <option value="100">100</option>
+                </select>
+                <span> validators per page</span>
+              </label>
+            </div>
+            <div class="col-4 col-md-6">
+              <div class="container text-end">
+                <button type="submit" class="btn btn-primary">Apply Settings</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+    <script type="text/javascript">
+      $('#validatorsOfflineFilterForm').submit(function () {
+        $(this).find('input[type="text"],input[type="number"]').filter(function () { return !this.value; }).prop('name', '');
+      });
+    </script>
+
+    <div class="card mt-2">
+      <div class="card-body px-0 py-3">
+        <div class="table-responsive table-sorting px-0 py-1">
+          <table class="table table-nobr" id="validators">
+            <thead>
+              <tr>
+                <th>
+                  Index
+                  <div class="col-sorting">
+                    <a href="{{ .ViewPageLink }}&o=index" class="sort-link {{ if eq .Sorting "index" }}active{{ end }}"><i class="fas fa-arrow-up"></i></a>
+                    <a href="{{ .ViewPageLink }}&o=index-d" class="sort-link {{ if eq .Sorting "index-d" }}active{{ end }}"><i class="fas fa-arrow-down"></i></a>
+                  </div>
+                </th>
+                <th>
+                  Public Key
+                  <div class="col-sorting">
+                    <a href="{{ .ViewPageLink }}&o=pubkey" class="sort-link {{ if eq .Sorting "pubkey" }}active{{ end }}"><i class="fas fa-arrow-up"></i></a>
+                    <a href="{{ .ViewPageLink }}&o=pubkey-d" class="sort-link {{ if eq .Sorting "pubkey-d" }}active{{ end }}"><i class="fas fa-arrow-down"></i></a>
+                  </div>
+                </th>
+                <th>
+                  Balance
+                  <div class="col-sorting">
+                    <a href="{{ .ViewPageLink }}&o=balance" class="sort-link {{ if eq .Sorting "balance" }}active{{ end }}"><i class="fas fa-arrow-up"></i></a>
+                    <a href="{{ .ViewPageLink }}&o=balance-d" class="sort-link {{ if eq .Sorting "balance-d" }}active{{ end }}"><i class="fas fa-arrow-down"></i></a>
+                  </div>
+                </th>
+                <th>State</th>
+                <th>
+                  Activation
+                  <div class="col-sorting">
+                    <a href="{{ .ViewPageLink }}&o=activation" class="sort-link {{ if eq .Sorting "activation" }}active{{ end }}"><i class="fas fa-arrow-up"></i></a>
+                    <a href="{{ .ViewPageLink }}&o=activation-d" class="sort-link {{ if eq .Sorting "activation-d" }}active{{ end }}"><i class="fas fa-arrow-down"></i></a>
+                  </div>
+                </th>
+                <th>
+                  Exit
+                  <div class="col-sorting">
+                    <a href="{{ .ViewPageLink }}&o=exit" class="sort-link {{ if eq .Sorting "exit" }}active{{ end }}"><i class="fas fa-arrow-up"></i></a>
+                    <a href="{{ .ViewPageLink }}&o=exit-d" class="sort-link {{ if eq .Sorting "exit-d" }}active{{ end }}"><i class="fas fa-arrow-down"></i></a>
+                  </div>
+                </th>
+                <th>W/address</th>
+              </tr>
+            </thead>
+            {{ if gt .ValidatorCount 0 }}
+              <tbody>
+                {{ range $i, $validator := .Validators }}
+                  <tr>
+                    <td><a href="/validator/{{ $validator.Index }}">{{ formatValidatorNameWithIndex $validator.Index $validator.Name }}</a></td>
+                    <td><a href="/validator/0x{{ printf "%x" $validator.PublicKey }}" class="text-truncate d-inline-block" style="max-width: 200px">0x{{ printf "%x" $validator.PublicKey }}</a></td>
+                    <td>{{ formatEthFromGwei $validator.Balance }} ({{ formatEthAddCommasFromGwei $validator.EffectiveBalance }} ETH)</td>
+                    <td>
+                      {{- $validator.State -}}
+                      {{- if $validator.ShowUpcheck -}}
+                        {{- if eq $validator.UpcheckActivity $validator.UpcheckMaximum }}
+                          <i class="fas fa-power-off fa-sm text-success" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
+                        {{- else if gt $validator.UpcheckActivity 0 }}
+                          <i class="fas fa-power-off fa-sm text-warning" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
+                        {{- else }}
+                          <i class="fas fa-power-off fa-sm text-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.UpcheckActivity }}/{{ $validator.UpcheckMaximum }}"></i>
+                        {{- end -}}
+                      {{- end -}}
+                    </td>
+                    <td>
+                      {{- if $validator.ShowActivation -}}
+                        <span data-timer="{{ $validator.ActivationTs.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.ActivationTs }}">{{ formatRecentTimeShort $validator.ActivationTs }}</span>
+                        (<a href="/epoch/{{ $validator.ActivationEpoch }}">Epoch {{ formatAddCommas $validator.ActivationEpoch }}</a>)
+                      {{- else -}}
+                        -
+                      {{- end -}}
+                    </td>
+                    <td>
+                      {{- if $validator.ShowExit -}}
+                        <span data-timer="{{ $validator.ExitTs.Unix }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $validator.ExitTs }}">{{ formatRecentTimeShort $validator.ExitTs }}</span>
+                        (<a href="/epoch/{{ $validator.ExitEpoch }}">Epoch {{ formatAddCommas $validator.ExitEpoch }}</a>)
+                      {{- else -}}
+                        -
+                      {{- end -}}
+                    </td>
+                    <td>
+                      {{- if .ShowWithdrawAddress -}}
+                        {{ ethAddressLink .WithdrawAddress }}
+                      {{- else -}}
+                        -
+                      {{- end -}}
+                    </td>
+                  </tr>
+                {{ end }}
+              </tbody>
+            {{ else }}
+              <tbody>
+                <tr style="height: 430px;">
+                  <td class="d-none d-md-table-cell"></td>
+                  <td style="vertical-align: middle;" colspan="8">
+                    <div class="img-fluid mx-auto p-3 d-flex align-items-center" style="max-height: 400px; max-width: 400px; overflow: hidden;">
+                      {{ template "professor_svg" }}
+                    </div>
+                  </td>
+                  <td class="d-none d-md-table-cell"></td>
+                </tr>
+              </tbody>
+            {{ end }}
+          </table>
+        </div>
+        {{ if gt .TotalPages 1 }}
+          <div class="row">
+            <div class="col-sm-12 col-md-5 table-metainfo">
+              <div class="px-2">
+                <div class="table-meta" role="status" aria-live="polite">Showing validator {{ .FirstValidator }} to {{ .LastValidator }}</div>
+              </div>
+            </div>
+            <div class="col-sm-12 col-md-7 table-paging">
+              <div class="d-inline-block px-2">
+                <ul class="pagination">
+                  <li class="first paginate_button page-item {{ if le .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
+                    <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
+                  </li>
+                  <li class="previous paginate_button page-item {{ if eq .PrevPageIndex 0 }}disabled{{ end }}" id="tpg_previous">
+                    <a tab-index="1" aria-controls="tpg_previous" class="page-link" href="{{ .PrevPageLink }}"><i class="fas fa-chevron-left"></i></a>
+                  </li>
+                  <li class="page-item disabled">
+                    <a class="page-link" style="background-color: transparent;">{{ .CurrentPageIndex }} of {{ .TotalPages }}</a>
+                  </li>
+                  <li class="next paginate_button page-item {{ if eq .NextPageIndex 0 }}disabled{{ end }}" id="tpg_next">
+                    <a tab-index="1" aria-controls="tpg_next" class="page-link" href="{{ .NextPageLink }}"><i class="fas fa-chevron-right"></i></a>
+                  </li>
+                  <li class="last paginate_button page-item {{ if eq .LastPageIndex 0 }}disabled{{ end }}" id="tpg_last">
+                    <a tab-index="1" aria-controls="tpg_last" class="page-link" href="{{ .LastPageLink }}">Last</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        {{ end }}
+      </div>
+      <div id="footer-placeholder" style="height:71px;"></div>
+    </div>
+  </div>
+{{ end }}
+{{ define "js" }}
+{{ end }}
+{{ define "css" }}
+{{ end }} 

--- a/types/models/validators_activity.go
+++ b/types/models/validators_activity.go
@@ -31,7 +31,7 @@ type ValidatorsActivityPageData struct {
 
 type ValidatorsActiviyPageDataGroup struct {
 	Group      string `json:"group"`
-	GroupLower string `json:"-"`
+	GroupLower string `json:"group_lower"`
 	Validators uint64 `json:"validators"`
 	Activated  uint64 `json:"activated"`
 	Online     uint64 `json:"online"`

--- a/types/models/validators_offline.go
+++ b/types/models/validators_offline.go
@@ -1,0 +1,28 @@
+package models
+
+// ValidatorsOfflinePageData is a struct to hold info for the validators offline page
+type ValidatorsOfflinePageData struct {
+	ViewOptionGroupBy uint64 `json:"vopt_groupby"`
+	GroupKey          string `json:"group_key"`
+	GroupName         string `json:"group_name"`
+
+	Validators       []*ValidatorsPageDataValidator `json:"validators"`
+	ValidatorCount   uint64                         `json:"validator_count"`
+	FirstValidator   uint64                         `json:"first_validx"`
+	LastValidator    uint64                         `json:"last_validx"`
+	Sorting          string                         `json:"sorting"`
+	IsDefaultSorting bool                           `json:"default_sorting"`
+	IsDefaultPage    bool                           `json:"default_page"`
+	TotalPages       uint64                         `json:"total_pages"`
+	PageSize         uint64                         `json:"page_size"`
+	CurrentPageIndex uint64                         `json:"page_index"`
+	PrevPageIndex    uint64                         `json:"prev_page_index"`
+	NextPageIndex    uint64                         `json:"next_page_index"`
+	LastPageIndex    uint64                         `json:"last_page_index"`
+
+	FirstPageLink string `json:"first_page_link"`
+	PrevPageLink  string `json:"prev_page_link"`
+	NextPageLink  string `json:"next_page_link"`
+	LastPageLink  string `json:"last_page_link"`
+	ViewPageLink  string `json:"view_page_link"`
+}


### PR DESCRIPTION
This PR [fixes a bug](https://github.com/ethpandaops/dora/pull/328/files#diff-d1eb061fd6a26d316d2d826601fae507afae36c6caa4af8638067278cd692a9f) in the validator activity tracking.
Some activity entries were falsely removed or overwritten, leading to gaps in the activity tracking, which might even show validators as completely offline in rare situations.

The PR also adds a new "offline-validators" page, which is linked from the validator activity page and shows the individual offline validators for the selected group:
![image](https://github.com/user-attachments/assets/3b22c98c-dcef-4310-b351-da6074f4ce22)

This is already live on the hoodi instance:
https://light-hoodi.beaconcha.in/validators/activity