### PR TITLE
fix: deposit view

### DIFF
--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -84,10 +84,13 @@ func (bs *ChainService) GetDepositRequestsByFilter(filter *CombinedDepositReques
 
 	canonicalHead := bs.beaconIndexer.GetCanonicalHead(nil)
 	if canonicalHead != nil {
-		for _, queueEntry := range bs.GetIndexedDepositQueue(canonicalHead).Queue {
-			depositIndex := queueEntry.DepositIndex
-			if depositIndex != nil {
-				pendingDepositPositions[*depositIndex] = queueEntry
+		indexedQueue := bs.GetIndexedDepositQueue(canonicalHead)
+		if indexedQueue != nil {
+			for _, queueEntry := range indexedQueue.Queue {
+				depositIndex := queueEntry.DepositIndex
+				if depositIndex != nil {
+					pendingDepositPositions[*depositIndex] = queueEntry
+				}
 			}
 		}
 	}


### PR DESCRIPTION
```
URL: /validators/deposits
Time: 2025-04-23 12:39:08.482154668 +0000 UTC m=+398.060664718
Version: v1.15.1 (git-a642e90)

Error:
page call 23 panic: runtime error: invalid memory address or nil pointer dereference

Stack Trace:
goroutine 840 [running]:
runtime/debug.Stack()
    /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/debug/stack.go:26 +0x64
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
    /home/runner/work/dora/dora/services/frontendcache.go:131 +0x9c
panic({0x1799ea0?, 0x3e624d0?})
    /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/panic.go:792 +0x124
github.com/ethpandaops/dora/services.(*ChainService).GetDepositRequestsByFilter(0x40000a83c0, 0x40007a3e20, 0x0, 0x14)
    /home/runner/work/dora/dora/services/chainservice_deposits.go:87 +0xa8
github.com/ethpandaops/dora/handlers.buildDepositsPageData(0x4001d25ed8?, 0x32, {0x19c5801, 0x8})
    /home/runner/work/dora/dora/handlers/deposits.go:211 +0x4f8
github.com/ethpandaops/dora/handlers.getDepositsPageData.func1(0x40024c24e0)
    /home/runner/work/dora/dora/handlers/deposits.go:72 +0x30
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0x40020cd9e0?)
    /home/runner/work/dora/dora/services/frontendcache.go:148 +0x194
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 810
    /home/runner/work/dora/dora/services/frontendcache.go:125 +0x30c
    ```