### PR TITLE
Add publicRpcUrl in default config example

### DIFF
--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -36,6 +36,7 @@ frontend:
   showPeerDASInfos: false
   showSubmitDeposit: false
   showSubmitElRequests: false
+  publicRpcUrl: "http://127.0.0.1:8545"
   
 beaconapi:
   # beacon node rpc endpoints


### PR DESCRIPTION
use default config to deploy dora and Submit withdrawal requests will failed, checked codespace, add example publicRpcUrl config for newby.

```
Error loading queue length from withdrawal contract.
No URL was provided to the Transport. Please provide a valid RPC URL to the Transport. Docs: https://viem.sh/docs/clients/intro Version: viem@2.26.5
```
