### PR TITLE
fix: set ClientsCLPageData node ENR from node identity

### DIFF
--- a/handlers/clients_cl.go
+++ b/handlers/clients_cl.go
@@ -258,21 +258,20 @@ func buildCLClientsPageData() (*models.ClientsCLPageData, time.Duration) {
 				Alias:  client.GetName(),
 				Type:   "internal",
 			}
-			if id != nil {
-				if node.ENR == "" {
-					node.ENR = id.Enr
-				} else if node.ENR != "" {
-					// Need to compare `seq` field from ENRs and only store highest
-					nodeENR := parseEnrRecord(node.ENR)
-					idENR := parseEnrRecord(id.Enr)
-					if nodeENR != nil && idENR != nil && idENR.Seq() > nodeENR.Seq() {
-						node.ENR = id.Enr // idENR has higher sequence number, so override.
-					}
-				}
-
-				node.ENR = id.Enr
-			}
 			pageData.Nodes[peerId] = node
+		}
+
+		if id != nil {
+			if node.ENR == "" {
+				node.ENR = id.Enr
+			} else if node.ENR != "" {
+				// Need to compare `seq` field from ENRs and only store highest
+				nodeENR := parseEnrRecord(node.ENR)
+				idENR := parseEnrRecord(id.Enr)
+				if nodeENR != nil && idENR != nil && idENR.Seq() > nodeENR.Seq() {
+					node.ENR = id.Enr // idENR has higher sequence number, so override.
+				}
+			}
 		}
 
 		peers := client.GetNodePeers()


### PR DESCRIPTION
use the node's identity from 'node/identity' to set ENR if the ENR earlier returned from a peer (i.e., 'node/peers') is empty or outdated

fix empty ENR on Consensus clients page for nodes with ENR available at 'node/identity'

Closes #339 

<img width="910" alt="image" src="https://github.com/user-attachments/assets/3bf61ae8-fb23-44a4-b3a4-3e1efa8f3f75" />
