### PR TITLE
fix: included_deposits panic

### DIFF
--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -109,6 +109,15 @@ func (bs *ChainService) GetDepositRequestsByFilter(filter *CombinedDepositReques
 		}
 	*/
 
+	// Check if filter is nil or filter.Filter is nil, if so, initialize with an empty filter
+	if filter == nil {
+		filter = &CombinedDepositRequestFilter{
+			Filter: &dbtypes.DepositTxFilter{},
+		}
+	} else if filter.Filter == nil {
+		filter.Filter = &dbtypes.DepositTxFilter{}
+	}
+
 	operationFilter := &dbtypes.DepositFilter{
 		MinIndex:      filter.Filter.MinIndex,
 		MaxIndex:      filter.Filter.MaxIndex,


### PR DESCRIPTION
```sh
URL: /validators/included_deposits
Time: 2025-05-07 13:49:59.026112046 +0000 UTC m=+6346.780882895
Version: git-c49ceed

Error:
page call 996 panic: runtime error: invalid memory address or nil pointer dereference

Stack Trace:
goroutine 19550 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1.1()
    /src/services/frontendcache.go:131 +0xd4
panic({0x19b2b40?, 0x46044c0?})
    /usr/local/go/src/runtime/panic.go:787 +0x132
github.com/ethpandaops/dora/services.(*ChainService).GetDepositRequestsByFilter(0xc000111800, 0xc088a69bf8, 0x0, 0x32)
    /src/services/chainservice_deposits.go:140 +0x3a0
github.com/ethpandaops/dora/handlers.buildFilteredIncludedDepositsPageData(0x1, 0x32, 0x0, 0x0, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, ...)
    /src/handlers/included_deposits.go:192 +0x1025
github.com/ethpandaops/dora/handlers.getFilteredIncludedDepositsPageData.func1(0xc000114018?)
    /src/handlers/included_deposits.go:105 +0x70
github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall.func1(0xc045056fb0?)
    /src/services/frontendcache.go:148 +0x1d3
created by github.com/ethpandaops/dora/services.(*FrontendCacheService).processPageCall in goroutine 19548
    /src/services/frontendcache.go:125 +0x348
    ```