### PR TITLE
add validator topup form & enhance ux of consolidation target selection

### DIFF
--- a/handlers/submit_deposit.go
+++ b/handlers/submit_deposit.go
@@ -1,12 +1,17 @@
 package handlers
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
+	v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sirupsen/logrus"
 
@@ -91,12 +96,15 @@ func buildSubmitDepositPageData() (*models.SubmitDepositPageData, time.Duration)
 	specs := chainState.GetSpecs()
 
 	pageData := &models.SubmitDepositPageData{
-		NetworkName:         specs.ConfigName,
-		DepositContract:     specs.DepositContractAddress,
-		PublicRPCUrl:        utils.Config.Frontend.PublicRPCUrl,
-		RainbowkitProjectId: utils.Config.Frontend.RainbowkitProjectId,
-		ChainId:             specs.DepositChainId,
-		GenesisForkVersion:  specs.GenesisForkVersion[:],
+		NetworkName:                specs.ConfigName,
+		DepositContract:            specs.DepositContractAddress,
+		PublicRPCUrl:               utils.Config.Frontend.PublicRPCUrl,
+		RainbowkitProjectId:        utils.Config.Frontend.RainbowkitProjectId,
+		ChainId:                    specs.DepositChainId,
+		GenesisForkVersion:         specs.GenesisForkVersion[:],
+		ExplorerUrl:                utils.Config.Frontend.EthExplorerLink,
+		MaxEffectiveBalance:        fmt.Sprintf("%d", specs.MaxEffectiveBalance),
+		MaxEffectiveBalanceElectra: fmt.Sprintf("%d", specs.MaxEffectiveBalanceElectra),
 	}
 
 	return pageData, 1 * time.Hour
@@ -158,6 +166,117 @@ func handleSubmitDepositPageDataAjax(w http.ResponseWriter, r *http.Request) err
 		}
 
 		pageData = result
+
+	case "load_validators":
+		address := query.Get("address")
+		addressBytes := common.HexToAddress(address)
+		validators, _ := services.GlobalBeaconService.GetFilteredValidatorSet(&dbtypes.ValidatorFilter{
+			WithdrawalAddress: addressBytes[:],
+		}, true)
+
+		result := []models.SubmitDepositPageDataValidator{}
+		for _, validator := range validators {
+			var status string
+			if strings.HasPrefix(validator.Status.String(), "pending") {
+				status = "Pending"
+			} else if validator.Status == v1.ValidatorStateActiveOngoing {
+				status = "Active"
+			} else if validator.Status == v1.ValidatorStateActiveExiting {
+				status = "Exiting"
+			} else if validator.Status == v1.ValidatorStateActiveSlashed {
+				status = "Slashed"
+			} else if validator.Status == v1.ValidatorStateExitedUnslashed {
+				status = "Exited"
+			} else if validator.Status == v1.ValidatorStateExitedSlashed {
+				status = "Slashed"
+			} else {
+				status = validator.Status.String()
+			}
+
+			result = append(result, models.SubmitDepositPageDataValidator{
+				Index:    uint64(validator.Index),
+				Pubkey:   validator.Validator.PublicKey.String(),
+				Balance:  uint64(validator.Balance),
+				CredType: fmt.Sprintf("%02x", validator.Validator.WithdrawalCredentials[0]),
+				Status:   status,
+			})
+		}
+
+		pageData = result
+
+	case "search_validators":
+		searchTerm := query.Get("search")
+		limit := 50
+		if query.Has("limit") {
+			limit, _ = strconv.Atoi(query.Get("limit"))
+			if limit > 100 {
+				limit = 100
+			}
+		}
+
+		var validators []v1.Validator
+		// Check if search term is a pubkey or index
+		if searchTerm == "" {
+			// If no search term, return empty result
+			validators = []v1.Validator{}
+		} else if index, err := strconv.ParseUint(searchTerm, 10, 64); err == nil {
+			// Search by index
+			validators, _ = services.GlobalBeaconService.GetFilteredValidatorSet(&dbtypes.ValidatorFilter{
+				MinIndex: &index,
+				MaxIndex: &index,
+				Limit:    uint64(limit),
+			}, true)
+		} else if regexp.MustCompile(`^(0x)?[0-9a-fA-F]+$`).MatchString(searchTerm) {
+			// Search by pubkey
+			pubkey := searchTerm
+			if !strings.HasPrefix(pubkey, "0x") {
+				pubkey = "0x" + pubkey
+			}
+			pubkeyBytes, err := hex.DecodeString(strings.TrimPrefix(pubkey, "0x"))
+			if err == nil {
+				validators, _ = services.GlobalBeaconService.GetFilteredValidatorSet(&dbtypes.ValidatorFilter{
+					PubKey: pubkeyBytes,
+					Limit:  uint64(limit),
+				}, true)
+			}
+		} else {
+			// Search by name
+			validators, _ = services.GlobalBeaconService.GetFilteredValidatorSet(&dbtypes.ValidatorFilter{
+				ValidatorName: searchTerm,
+				Limit:         uint64(limit),
+			}, true)
+		}
+
+		result := []models.SubmitDepositPageDataValidator{}
+		for _, validator := range validators {
+			var status string
+			if strings.HasPrefix(validator.Status.String(), "pending") {
+				status = "Pending"
+			} else if validator.Status == v1.ValidatorStateActiveOngoing {
+				status = "Active"
+			} else if validator.Status == v1.ValidatorStateActiveExiting {
+				status = "Exiting"
+			} else if validator.Status == v1.ValidatorStateActiveSlashed {
+				status = "Slashed"
+			} else if validator.Status == v1.ValidatorStateExitedUnslashed {
+				status = "Exited"
+			} else if validator.Status == v1.ValidatorStateExitedSlashed {
+				status = "Slashed"
+			} else {
+				status = validator.Status.String()
+			}
+
+			result = append(result, models.SubmitDepositPageDataValidator{
+				Index:    uint64(validator.Index),
+				Pubkey:   validator.Validator.PublicKey.String(),
+				Balance:  uint64(validator.Balance),
+				CredType: fmt.Sprintf("%02x", validator.Validator.WithdrawalCredentials[0]),
+				Status:   status,
+			})
+		}
+
+		pageData = result
+
 	default:
 		return errors.New("invalid ajax request")
 	}

--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -154,7 +154,7 @@ func (bs *ChainService) GetDepositRequestsByFilter(filter *CombinedDepositReques
 			combinedResult.TransactionOrphaned = combinedResult.RequestOrphaned
 		}
 
-		if dbOperation.Index != nil {
+		if dbOperation.BlockNumber != nil && dbOperation.Index != nil {
 			combinedResult.Transaction.Index = *dbOperation.Index
 			if queueEntry, ok := pendingDepositPositions[*dbOperation.Index]; ok {
 				combinedResult.IsQueued = true

--- a/templates/submit_deposit/submit_deposit.html
+++ b/templates/submit_deposit/submit_deposit.html
@@ -51,6 +51,9 @@
         submitDepositConfig: {
           genesisForkVersion: "0x{{ printf "%x" .GenesisForkVersion }}",
           depositContract: "0x{{ printf "%x" .DepositContract }}",
+          explorerLink: "{{ .ExplorerUrl }}",
+          maxEffectiveBalance: "{{ .MaxEffectiveBalance }}",
+          maxEffectiveBalanceElectra: "{{ .MaxEffectiveBalanceElectra }}",
           loadDepositTxs: function(pubkeys) {
             return fetch("?ajax=load_deposits", {
               method: "POST",
@@ -58,14 +61,28 @@
                 "Content-Type": "application/json"
               },
               body: JSON.stringify(pubkeys)
-            }).then((response) => {
+            }).then(function(response) {
               if (!response.ok) {
                 throw new Error("Failed to load deposits: " + response.statusText);
               }
               return response;
-            }).then((response) => {
+            }).then(function(response) {
               return response.json();
             });
+          },
+          loadValidators: function(address) {
+            return fetch(`?ajax=load_validators&address=${address}`)
+              .then(response => response.json())
+              .then(data => {
+                return data;
+              });
+          },
+          searchValidators: function(searchTerm) {
+            return fetch(`?ajax=search_validators&search=${searchTerm}`)
+              .then(response => response.json())
+              .then(data => {
+                return data;
+              });
           }
         }
       }

--- a/types/models/submit_deposit.go
+++ b/types/models/submit_deposit.go
@@ -1,12 +1,15 @@
 package models
 
 type SubmitDepositPageData struct {
-	NetworkName         string `json:"netname"`
-	PublicRPCUrl        string `json:"pubrpc"`
-	RainbowkitProjectId string `json:"rainbowkit"`
-	ChainId             uint64 `json:"chainid"`
-	GenesisForkVersion  []byte `json:"genesisforkversion"`
-	DepositContract     []byte `json:"depositcontract"`
+	NetworkName                string `json:"netname"`
+	PublicRPCUrl               string `json:"pubrpc"`
+	RainbowkitProjectId        string `json:"rainbowkit"`
+	ChainId                    uint64 `json:"chainid"`
+	GenesisForkVersion         []byte `json:"genesisforkversion"`
+	DepositContract            []byte `json:"depositcontract"`
+	ExplorerUrl                string `json:"explorer"`
+	MaxEffectiveBalance        string `json:"maxeffectivebalance"`
+	MaxEffectiveBalanceElectra string `json:"maxeffectivebalanceelectra"`
 }
 
 type SubmitDepositPageDataDeposits struct {
@@ -24,4 +27,12 @@ type SubmitDepositPageDataDeposit struct {
 	TxOrigin    string `json:"tx_origin"`
 	TxTarget    string `json:"tx_target"`
 	TxHash      string `json:"tx_hash"`
+}
+
+type SubmitDepositPageDataValidator struct {
+	Index    uint64 `json:"index"`
+	Pubkey   string `json:"pubkey"`
+	Balance  uint64 `json:"balance"`
+	CredType string `json:"credtype"`
+	Status   string `json:"status"`
 }

--- a/ui-package/src/components/SubmitConsolidationsForm/SubmitConsolidationsForm.tsx
+++ b/ui-package/src/components/SubmitConsolidationsForm/SubmitConsolidationsForm.tsx
@@ -139,8 +139,8 @@ const SubmitConsolidationsForm = (props: ISubmitConsolidationsFormProps): React.
             </div>
             <div className="col-12 col-lg-11">
               <ValidatorSelector
-                placeholder="Search for a validator by index or pubkey"
-                validators={[]}
+                placeholder="Select or search for a validator by index or pubkey"
+                validators={validators}
                 onChange={(validator) => {
                   console.log("target validator", validator);
                   setTargetValidator(validator);

--- a/ui-package/src/components/SubmitConsolidationsForm/ValidatorSelector.tsx
+++ b/ui-package/src/components/SubmitConsolidationsForm/ValidatorSelector.tsx
@@ -15,33 +15,43 @@ interface IValidatorSelectorProps {
 const ValidatorSelector = (props: IValidatorSelectorProps): React.ReactElement => {
   const [inputValue, setInputValue] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [searchResults, setSearchResults] = useState<IValidator[]>([]);
   const [options, setOptions] = useState<IValidator[]>(props.validators);
+  const [isSearching, setIsSearching] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!props.isLazyLoaded) {
-      setOptions(props.validators);
-    }
-  }, [props.validators, props.isLazyLoaded]);
+    setOptions(props.validators);
+  }, [props.validators]);
 
   const handleInputChange = (newValue: string) => {
     setInputValue(newValue);
     
     if (props.isLazyLoaded && props.searchValidatorsCallback) {
-      setIsLoading(true);
-      props.searchValidatorsCallback(newValue)
-        .then(results => {
-          setOptions(results);
-          setIsLoading(false);
-        })
-        .catch(() => {
-          setIsLoading(false);
-        });
+      const searchTerm = newValue.trim();
+      
+      if (searchTerm.length > 0) {
+        setIsLoading(true);
+        setIsSearching(true);
+        props.searchValidatorsCallback(searchTerm)
+          .then(results => {
+            setSearchResults(results);
+            setOptions(results);
+            setIsLoading(false);
+          })
+          .catch(() => {
+            setIsLoading(false);
+          });
+      } else {
+        // Reset to original validators list when search is cleared
+        setIsSearching(false);
+        setOptions(props.validators);
+      }
     }
   };
 
   const filterOptions = (option: FilterOptionOption<IValidator>, inputValue: string) => {
-    if (props.isLazyLoaded) {
-      return true; // Server-side filtering
+    if (props.isLazyLoaded && isSearching) {
+      return true; // Server-side filtering when actively searching
     }
     
     inputValue = inputValue.trim();
@@ -56,37 +66,52 @@ const ValidatorSelector = (props: IValidatorSelectorProps): React.ReactElement =
   };
 
   return (
-    <Select<IValidator, false>
-      className="validator-selector"
-      options={options}
-      placeholder={props.placeholder}
-      components={{
-        Option: ({ children, ...props }) => (
-          <ValidatorOption {...props}>
-            {children}
-          </ValidatorOption>
-        )
-      }}
-      onChange={(e) => {
-        props.onChange(e);
-      }}
-      filterOption={filterOptions}
-      isMulti={false}
-      isOptionSelected={(o, v) => v.some((i) => i.index === o.index)}
-      getOptionLabel={(o) => "Selected validator: [" + o.index + "] " + o.pubkey}
-      getOptionValue={(o) => o.pubkey}
-      value={props.value}
-      onInputChange={handleInputChange}
-      isLoading={isLoading}
-      classNames={{
-        control: () => "validator-selector-control",
-        container: () => "validator-selector-container",
-        menu: () => "validator-selector-menu",
-        option: () => "validator-selector-option",
-        singleValue: () => "validator-selector-single-value",
-        input: () => "validator-selector-input"
-      }}
-    />
+    <div>
+      {props.isLazyLoaded && (
+        <div className="search-info mb-1 text-muted small">
+          <span>
+            {isSearching 
+              ? "Showing search results. " 
+              : "Showing your validators. "}
+            {inputValue.trim() 
+              ? inputValue.length < 3 
+                ? "Type at least 3 characters to search external validators." 
+                : "" 
+              : "Type to search for any validator by index or pubkey."}
+          </span>
+        </div>
+      )}
+      <Select<IValidator, false>
+        className="validator-selector"
+        options={options}
+        placeholder={props.placeholder}
+        components={{
+          Option: ({ children, ...props }) => (
+            <ValidatorOption {...props}>
+              {children}
+            </ValidatorOption>
+          )
+        }}
+        onChange={(e) => {
+          props.onChange(e);
+        }}
+        filterOption={filterOptions}
+        isMulti={false}
+        getOptionValue={(o) => o.pubkey}
+        getOptionLabel={(o) => "Selected validator: [" + o.index + "] " + o.pubkey}
+        value={props.value}
+        onInputChange={handleInputChange}
+        isLoading={isLoading}
+        classNames={{
+          control: () => "validator-selector-control",
+          container: () => "validator-selector-container",
+          menu: () => "validator-selector-menu",
+          option: () => "validator-selector-option",
+          singleValue: () => "validator-selector-single-value",
+          input: () => "validator-selector-input"
+        }}
+      />
+    </div>
   );
 }
 

--- a/ui-package/src/components/SubmitDepositsForm/DepositContract.ts
+++ b/ui-package/src/components/SubmitDepositsForm/DepositContract.ts
@@ -1,0 +1,117 @@
+export const DepositContractAbi = [
+    {
+        "inputs": [],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "pubkey",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "withdrawal_credentials",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "amount",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "index",
+                "type": "bytes"
+            }
+        ],
+        "name": "DepositEvent",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "pubkey",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "withdrawal_credentials",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes",
+                "name": "signature",
+                "type": "bytes"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "deposit_data_root",
+                "type": "bytes32"
+            }
+        ],
+        "name": "deposit",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "get_deposit_count",
+        "outputs": [
+            {
+                "internalType": "bytes",
+                "name": "",
+                "type": "bytes"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "get_deposit_root",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes4",
+                "name": "interfaceId",
+                "type": "bytes4"
+            }
+        ],
+        "name": "supportsInterface",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    }
+];

--- a/ui-package/src/components/SubmitDepositsForm/DepositEntry.tsx
+++ b/ui-package/src/components/SubmitDepositsForm/DepositEntry.tsx
@@ -5,14 +5,13 @@ import { Modal } from 'react-bootstrap';
 
 import { IDeposit } from './DepositsTable';
 import { toReadableAmount } from '../../utils/ReadableAmount';
+import { DepositContractAbi } from './DepositContract';
 
 interface IDepositEntryProps {
   deposit: IDeposit;
   depositContract: string;
   explorerUrl?: string;
 }
-
-const DepositContractAbi = [{"inputs":[],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"bytes","name":"pubkey","type":"bytes"},{"indexed":false,"internalType":"bytes","name":"withdrawal_credentials","type":"bytes"},{"indexed":false,"internalType":"bytes","name":"amount","type":"bytes"},{"indexed":false,"internalType":"bytes","name":"signature","type":"bytes"},{"indexed":false,"internalType":"bytes","name":"index","type":"bytes"}],"name":"DepositEvent","type":"event"},{"inputs":[{"internalType":"bytes","name":"pubkey","type":"bytes"},{"internalType":"bytes","name":"withdrawal_credentials","type":"bytes"},{"internalType":"bytes","name":"signature","type":"bytes"},{"internalType":"bytes32","name":"deposit_data_root","type":"bytes32"}],"name":"deposit","outputs":[],"stateMutability":"payable","type":"function"},{"inputs":[],"name":"get_deposit_count","outputs":[{"internalType":"bytes","name":"","type":"bytes"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"get_deposit_root","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes4","name":"interfaceId","type":"bytes4"}],"name":"supportsInterface","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"pure","type":"function"}];
 
 const DepositEntry = (props: IDepositEntryProps): React.ReactElement => {
   const { address: walletAddress, chain, isConnected } = useAccount();

--- a/ui-package/src/components/SubmitDepositsForm/SubmitDepositsForm.scss
+++ b/ui-package/src/components/SubmitDepositsForm/SubmitDepositsForm.scss
@@ -1,4 +1,3 @@
-
 .submit-deposit-modal {
     .deposit-error {
         text-wrap: wrap;
@@ -10,5 +9,99 @@
     .tx-details-label {
         width: 150px;
         font-weight: bold;
+    }
+}
+
+.submit-deposits {
+    .nav-tabs {
+        margin-bottom: 1rem;
+        margin-left: -4px;
+        margin-right: -4px;
+        padding-left: 12px;
+        padding-right: 12px;
+        
+        .nav-link {
+            cursor: pointer;
+            
+            &.active {
+                font-weight: 600;
+            }
+        }
+    }
+
+    // Validator Selector Styles
+    .validator-selector {
+        .validator-item {
+            display: flex;
+        }
+      
+        .validator-index {
+            width: 80px;
+        }
+      
+        .validator-pubkey {
+            width: 200px;
+            flex-grow: 1;
+        }
+      
+        .validator-balance {
+            padding-left: 10px;
+            width: 100px;
+        }
+      
+        .validator-status {
+            width: 60px;
+        }
+      
+      
+        .validator-selector-control {
+            background-color: transparent;
+        }
+      
+        .validator-selector-menu {
+            background-color: var(--bs-body-bg);
+        }
+      
+        .validator-selector-option {
+            cursor: default;
+            display: block;
+            font-size: inherit;
+            width: 100%;
+            user-select: none;
+            -webkit-tap-highlight-color: rgba(128, 128, 128, 0.1);
+            background-color: transparent;
+            color: inherit;
+            padding: 8px 12px;
+            box-sizing: border-box;
+        }
+      
+        .validator-selector-option.selected {
+            color: var(--bs-body-color);
+            background-color: rgba(var(--bs-primary-rgb), 0.3);
+        }
+      
+        .validator-selector-option:hover, .validator-selector-option.focused {
+            color: var(--bs-body-color);
+            background-color: var(--bs-tertiary-bg);
+        }
+      
+        .validator-selector-option.selected:hover, .validator-selector-option.selected.focused {
+            color: var(--bs-body-color);
+            background-color: rgba(var(--bs-primary-rgb), 0.4);
+        }
+      
+        .validator-selector-single-value {
+            color: var(--bs-body-color);
+        }
+      
+        .validator-selector-input {
+            color: var(--bs-body-color);
+        }
+       
+    }
+
+    // Topup Deposit Styles
+    .withdrawal-details {
+        align-items: center;
     }
 }

--- a/ui-package/src/components/SubmitDepositsForm/SubmitDepositsForm.tsx
+++ b/ui-package/src/components/SubmitDepositsForm/SubmitDepositsForm.tsx
@@ -5,14 +5,15 @@ import { useState } from 'react';
 
 import { ISubmitDepositsFormProps } from './SubmitDepositsFormProps';
 import DepositsTable from './DepositsTable';
+import TopupDepositForm from './TopupDepositForm';
 import './SubmitDepositsForm.scss';
 
 const SubmitDepositsForm = (props: ISubmitDepositsFormProps): React.ReactElement => {
-  const { address: walletAddress, isConnected, chain } = useAccount();
+  const { isConnected, chain } = useAccount();
   
   const [file, setFile] = useState<File | null>(null);
   const [refreshIdx, setRefreshIdx] = useState<number>(0);
-
+  const [activeTab, setActiveTab] = useState<'initial' | 'topup'>('initial');
 
   return (
     <div className="submit-deposits">
@@ -20,12 +21,43 @@ const SubmitDepositsForm = (props: ISubmitDepositsFormProps): React.ReactElement
         <div className="col-12">
           <h3>Submit validator deposits</h3>
           <p>This tool can be used to submit validator deposits to the deposit contract.</p>
-          <p>You can find instructions on how to generate deposits at the <a href="https://launchpad.ethereum.org/en/overview" target="_blank" rel="noreferrer">Staking Launchpad</a>.</p>
-          <div className="alert alert-warning">
-            <b>Don't provide your keystore or mnemonic to us or any other website</b>
-          </div>
         </div>
       </div>
+
+      {/* Tab navigation */}
+      <div className="row">
+        <div className="col-12 px-0">
+          <ul className="nav nav-tabs">
+            <li className="nav-item">
+              <button 
+                className={`nav-link ${activeTab === 'initial' ? 'active' : ''}`} 
+                onClick={() => setActiveTab('initial')}
+              >
+                Initial Deposit
+              </button>
+            </li>
+            <li className="nav-item">
+              <button 
+                className={`nav-link ${activeTab === 'topup' ? 'active' : ''}`} 
+                onClick={() => setActiveTab('topup')}
+              >
+                Topup Deposit
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {activeTab === 'initial' && (
+        <div className="row mt-3">
+          <div className="col-12">
+            <p>You can find instructions on how to generate deposits at the <a href="https://launchpad.ethereum.org/en/overview" target="_blank" rel="noreferrer">Staking Launchpad</a>.</p>
+            <div className="alert alert-warning">
+              <b>Don't provide your keystore or mnemonic to us or any other website</b>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="row mt-3">
         <div className="col-12">
@@ -38,35 +70,48 @@ const SubmitDepositsForm = (props: ISubmitDepositsFormProps): React.ReactElement
         </div>
       </div>
 
-      <div className="row mt-3">
-        <div className="col-12">
-          <label htmlFor="formFile" className="form-label">
-            <b>Step 2: Upload deposit data file</b>
-          </label>
-          <input 
-            type="file" 
-            className="form-control" 
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              if (e.target.files) {
-                setFile(e.target.files[0]);
-                setRefreshIdx(refreshIdx + 1);
-              }
-            }} 
-          />
-          <p className="text-secondary-emphasis mt-2">The deposit data file is usually called <code>deposit_data-[timestamp].json</code> and is located in your <code>/staking-deposit-cli/validator_keys</code> directory.</p>
+      {/* Initial Deposit Form */}
+      {activeTab === 'initial' && (
+        <div className="row mt-3">
+          <div className="col-12">
+            <label htmlFor="formFile" className="form-label">
+              <b>Step 2: Upload deposit data file</b>
+            </label>
+            <input 
+              type="file" 
+              className="form-control" 
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                if (e.target.files) {
+                  setFile(e.target.files[0]);
+                  setRefreshIdx(refreshIdx + 1);
+                }
+              }} 
+            />
+            <p className="text-secondary-emphasis mt-2">The deposit data file is usually called <code>deposit_data-[timestamp].json</code> and is located in your <code>/staking-deposit-cli/validator_keys</code> directory.</p>
+          </div>
+
+          {file ?
+            <DepositsTable
+              key={refreshIdx}
+              file={file}
+              genesisForkVersion={props.genesisForkVersion}
+              depositContract={props.depositContract}
+              loadDepositTxs={props.loadDepositTxs}
+            />
+          : null}
         </div>
-      </div>
+      )}
 
-      {file ?
-        <DepositsTable
-          key={refreshIdx}
-          file={file}
-          genesisForkVersion={props.genesisForkVersion}
+      {/* Topup Deposit Form */}
+      {activeTab === 'topup' && isConnected && (
+        <TopupDepositForm 
+          loadValidators={props.loadValidators}
+          searchValidators={props.searchValidators}
           depositContract={props.depositContract}
-          loadDepositTxs={props.loadDepositTxs}
+          maxEffectiveBalance={props.maxEffectiveBalance}
+          maxEffectiveBalanceElectra={props.maxEffectiveBalanceElectra}
         />
-      : null}
-
+      )}
     </div>
   );
 }

--- a/ui-package/src/components/SubmitDepositsForm/SubmitDepositsFormProps.ts
+++ b/ui-package/src/components/SubmitDepositsForm/SubmitDepositsFormProps.ts
@@ -1,3 +1,4 @@
+import { IValidator } from '../SubmitConsolidationsForm/SubmitConsolidationsFormProps';
 
 export interface ISubmitDepositsFormProps {
   chainId: number;
@@ -8,7 +9,12 @@ export interface ISubmitDepositsFormProps {
   explorerLink?: string;
   genesisForkVersion: string;
   depositContract: string;
+  maxEffectiveBalance: string;
+  maxEffectiveBalanceElectra: string;
   loadDepositTxs(pubkeys: string[]): Promise<{deposits: IDepositTx[], count: number, havemore: boolean}>;
+  // Properties for topup deposit functionality
+  loadValidators?: (address: string) => Promise<IValidator[]>;
+  searchValidators?: (searchTerm: string) => Promise<IValidator[]>;
 }
 
 export interface IDepositTx {

--- a/ui-package/src/components/SubmitDepositsForm/TopUpRoot.ts
+++ b/ui-package/src/components/SubmitDepositsForm/TopUpRoot.ts
@@ -1,0 +1,55 @@
+
+export async function topupRoot(pubkeyHex: string, amountGwei: bigint) {
+  function hexToBytes(hex: string) {
+    if (hex.startsWith("0x")) hex = hex.slice(2);
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return bytes;
+  }
+
+  const pubkey = hexToBytes(pubkeyHex);
+  if (pubkey.length !== 48) throw new Error("pubkey must be 48 bytes");
+
+  const withdrawal_credentials = new Uint8Array(32);
+
+  function toLittleEndian64(value) {
+    const buffer = new ArrayBuffer(8);
+    const view = new DataView(buffer);
+    view.setBigUint64(0, BigInt(value), true);
+    return new Uint8Array(buffer);
+  }
+
+  function concat(...arrays) {
+    const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (let arr of arrays) {
+      result.set(arr, offset);
+      offset += arr.length;
+    }
+    return result;
+  }
+
+  async function sha256(data) {
+    const hash = await crypto.subtle.digest("SHA-256", data);
+    return new Uint8Array(hash);
+  }
+
+  const amountBytes = toLittleEndian64(amountGwei);
+  const pubkeyRoot = await sha256(concat(pubkey, new Uint8Array(16)));
+
+  const zero32 = new Uint8Array(32);
+  const signatureRoot = await sha256(concat(
+    await sha256(concat(zero32, zero32)),
+    await sha256(concat(zero32, zero32))
+  ));
+
+  const depositDataRoot = await sha256(concat(
+    await sha256(concat(pubkeyRoot, withdrawal_credentials)),
+    await sha256(concat(amountBytes, new Uint8Array(24), signatureRoot))
+  ));
+
+  return depositDataRoot;
+}

--- a/ui-package/src/components/SubmitDepositsForm/TopupDepositForm.tsx
+++ b/ui-package/src/components/SubmitDepositsForm/TopupDepositForm.tsx
@@ -1,0 +1,369 @@
+import React, { useState, useEffect } from 'react';
+import { useAccount, useWriteContract } from 'wagmi';
+import { Modal } from 'react-bootstrap';
+import { ContainerType, ByteVectorType, UintNumberType, ValueOf } from '@chainsafe/ssz';
+
+import { IValidator } from '../SubmitConsolidationsForm/SubmitConsolidationsFormProps';
+import ValidatorSelector from '../SubmitConsolidationsForm/ValidatorSelector';
+import { formatBalance, formatStatus } from '../SubmitConsolidationsForm/ValidatorSelector';
+import { DepositContractAbi } from './DepositContract';
+import { toReadableAmount } from '../../utils/ReadableAmount';
+import { topupRoot } from './TopUpRoot';
+
+// Define SSZ types for deposit data root calculation
+const DepositMessage = new ContainerType({
+  pubkey: new ByteVectorType(48),
+  withdrawal_credentials: new ByteVectorType(32),
+  amount: new UintNumberType(8),
+});
+type DepositMessage = ValueOf<typeof DepositMessage>;
+
+// Constants for unit conversions
+const GWEI_PER_ETH = BigInt(1e9);
+
+interface ITopupDepositFormProps {
+  loadValidators?: (address: string) => Promise<IValidator[]>;
+  searchValidators?: (searchTerm: string) => Promise<IValidator[]>;
+  depositContract: string;
+  maxEffectiveBalance?: string;
+  maxEffectiveBalanceElectra?: string;
+}
+
+const TopupDepositForm = (props: ITopupDepositFormProps): React.ReactElement => {
+  const { address: walletAddress, isConnected, chain } = useAccount();
+  
+  const [validators, setValidators] = useState<IValidator[]>([]);
+  const [loadingError, setLoadingError] = useState<string | null>(null);
+  const [selectedValidator, setSelectedValidator] = useState<IValidator | null>(null);
+  const [topupAmount, setTopupAmount] = useState<number>(1); // UI input in ETH (float)
+  const [topupAmountGwei, setTopupAmountGwei] = useState<bigint>(BigInt(1e9)); // Actual amount in Gwei (BigInt)
+  const [maxTopupAmount, setMaxTopupAmount] = useState<number>(0); // UI max in ETH (float)
+  const [walletBalance, setWalletBalance] = useState<bigint>(BigInt(100) * GWEI_PER_ETH); // Wallet balance in Gwei
+  const [errorModal, setErrorModal] = useState<string | null>(null);
+
+  // Parse max effective balance from props
+  const maxEffectiveBalance = BigInt(props.maxEffectiveBalance);
+  
+  const maxEffectiveBalanceElectra = BigInt(props.maxEffectiveBalanceElectra);
+
+  // Use wagmi's useWriteContract hook
+  const topupRequest = useWriteContract();
+
+  useEffect(() => {
+    if (walletAddress && props.loadValidators) {
+      // Load user's validators
+      props.loadValidators(walletAddress).then(setValidators).catch(setLoadingError);
+    }
+  }, [walletAddress, props.loadValidators]);
+
+  // Initialize tooltips
+  useEffect(() => {
+    // Check if we're in a browser environment (window exists)
+    if (typeof window !== 'undefined' && selectedValidator) {
+      // Initialize Bootstrap tooltips
+      const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+      
+      // Use the type assertion to access bootstrap property
+      const bootstrapInstance = (window as any).bootstrap;
+      
+      if (bootstrapInstance && tooltipTriggerList.length > 0) {
+        Array.from(tooltipTriggerList).forEach(tooltipTriggerEl => {
+          new bootstrapInstance.Tooltip(tooltipTriggerEl);
+        });
+      } else {
+        // Fallback for when bootstrap isn't available in the window
+        setTimeout(() => {
+          // This fallback assumes a global function might be available to initialize tooltips
+          if (typeof (window as any).explorer !== 'undefined' && (window as any).explorer.initControls) {
+            (window as any).explorer.initControls();
+          }
+        }, 100);
+      }
+    }
+  }, [selectedValidator]);
+
+  useEffect(() => {
+    if (selectedValidator) {
+      // Determine max effective balance based on validator's withdrawal credential type
+      const effectiveMaxBalance = selectedValidator.credtype === "02" 
+        ? maxEffectiveBalanceElectra 
+        : maxEffectiveBalance;
+      
+      // Convert validator balance to BigInt
+      const validatorBalanceGwei = BigInt(selectedValidator.balance);
+      
+      // Calculate remaining balance in Gwei
+      const remainingBalanceGwei = effectiveMaxBalance > validatorBalanceGwei
+        ? effectiveMaxBalance - validatorBalanceGwei
+        : BigInt(0);
+      
+      // Calculate max topup amount in ETH for UI (limited by wallet balance)
+      const maxTopupEth = Number(remainingBalanceGwei / GWEI_PER_ETH);
+      
+      // Set max topup amount for UI slider/input
+      setMaxTopupAmount(maxTopupEth);
+      
+      // Reset topup amount to 1 ETH when validator changes
+      setTopupAmount(1);
+      setTopupAmountGwei(GWEI_PER_ETH); // 1 ETH in Gwei
+    }
+  }, [selectedValidator, walletBalance, maxEffectiveBalance, maxEffectiveBalanceElectra]);
+
+  const handleTopupSubmit = async () => {
+    if (!selectedValidator || topupAmountGwei < GWEI_PER_ETH) return;
+    
+    console.log(selectedValidator.pubkey, topupAmountGwei);
+    const hashTreeRoot = await topupRoot(selectedValidator.pubkey, topupAmountGwei);
+    const depositDataRoot = '0x' + Array.from(hashTreeRoot)
+      .map(byte => byte.toString(16).padStart(2, '0'))
+      .join('');
+
+    // Prepare arguments for deposit contract call
+    const args = [
+      selectedValidator.pubkey,
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      depositDataRoot
+    ];
+
+    // Calculate amount in wei (gwei * 10^9)
+    const amountWei = topupAmountGwei * BigInt(10 ** 9);
+
+    // Submit transaction
+    topupRequest.writeContractAsync({
+      address: props.depositContract as `0x${string}`,
+      account: walletAddress,
+      abi: DepositContractAbi,
+      chain: chain,
+      functionName: "deposit",
+      args: args,
+      value: amountWei,
+      gas: 150000n,
+    }).then(tx => {
+      console.log(tx);
+    }).catch(error => {
+      setErrorModal(error.message);
+    });
+  };
+
+  const handleAmountInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const valueEth = parseFloat(e.target.value);
+    if (!isNaN(valueEth) && valueEth >= 1 && valueEth <= maxTopupAmount) {
+      // Update UI display value
+      setTopupAmount(valueEth);
+      
+      // Convert to Gwei and store as BigInt
+      const valueGwei = BigInt(Math.floor(valueEth * 1e9));
+      setTopupAmountGwei(valueGwei);
+    }
+  };
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const valueEth = parseFloat(e.target.value);
+    setTopupAmount(valueEth);
+    
+    // Convert to Gwei and store as BigInt
+    const valueGwei = BigInt(Math.floor(valueEth * 1e9));
+    setTopupAmountGwei(valueGwei);
+  };
+
+  // Get the appropriate max effective balance based on validator's credential type
+  const getMaxEffectiveBalance = (): bigint => {
+    if (!selectedValidator) return maxEffectiveBalance;
+    return selectedValidator.credtype === "02" ? maxEffectiveBalanceElectra : maxEffectiveBalance;
+  };
+
+  return (
+    <>
+      <div className="row mt-3">
+        <div className="col-12">
+          <label className="form-label">
+            <b>Step 2: Select validator to top up</b>
+          </label>
+        </div>
+        <div className="col-12">
+          <div className="form-text">
+            Select the validator you want to add more ETH to. The validator must be active on the network.
+          </div>
+        </div>
+        <div className="col-12 col-lg-11">
+          <ValidatorSelector
+            placeholder="Select or search for a validator by index or pubkey"
+            validators={validators}
+            onChange={setSelectedValidator}
+            value={selectedValidator}
+            isLazyLoaded={true}
+            searchValidatorsCallback={props.searchValidators}
+          />
+        </div>
+      </div>
+      
+      {selectedValidator && (
+        <>
+          <div className="ms-2 mt-1">
+            <div className="row">
+              <div className="col-3 col-lg-2">
+                <b>Index:</b>
+              </div>
+              <div className="col-9 col-lg-10">
+                {selectedValidator.index}
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-3 col-lg-2">
+                <b>Pubkey:</b>
+              </div>
+              <div className="col-9 col-lg-10">
+                <a href={`/validator/${selectedValidator.pubkey}`} target="_blank" rel="noreferrer">
+                  {selectedValidator.pubkey}
+                </a>
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-3 col-lg-2">
+                <b>Status:</b>
+              </div>
+              <div className="col-9 col-lg-10">
+                {formatStatus(selectedValidator.status)}
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-3 col-lg-2">
+                <b>Balance:</b>
+              </div>
+              <div className="col-9 col-lg-10">
+                {formatBalance(selectedValidator.balance, "ETH")}
+              </div>
+            </div>
+            <div className="row">
+              <div className="col-3 col-lg-2">
+                <b>Withdrawal Credentials:</b>
+              </div>
+              <div className="col-9 col-lg-10">
+                <span className={`badge rounded-pill ${selectedValidator.credtype === '02' ? 'bg-success' : 'bg-warning'}`}>
+                  0x{selectedValidator.credtype}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="row mt-3">
+            <div className="col-12">
+              <label className="form-label">
+                <b>Step 3: Select withdrawal amount</b>
+              </label>
+            </div>
+            <div className="col-12">
+              <div className="form-text">
+                Enter an amount of at least 1 ETH. Maximum amount is limited by your wallet balance and the validator's remaining space up to the effective balance limit.
+              </div>
+
+              <div className="row mt-3 withdrawal-details">
+                <div className="col-5 col-md-3 col-lg-2">
+                  Max Effective Balance:
+                </div>
+                <div className="col-7 col-md-6 col-lg-4">
+                  {toReadableAmount(Number(getMaxEffectiveBalance()), 9, "ETH", 0)}
+                  {selectedValidator && selectedValidator.credtype !== "02" && (
+                    <span 
+                      className="text-info ms-2" 
+                      style={{fontSize: "0.9em", cursor: "help"}} 
+                      data-bs-toggle="tooltip" 
+                      data-bs-placement="top" 
+                      title={`This validator can be upgraded to the higher Electra limit of ${toReadableAmount(Number(maxEffectiveBalanceElectra), 9, "ETH", 0)} by switching to a compounding validator (0x02 credentials) via self-consolidation.`}
+                    >
+                      <i className="fa fa-info-circle"></i>
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="row mt-1 withdrawal-details">
+                <div className="col-5 col-md-3 col-lg-2">
+                  Max Topup Possible:
+                </div>
+                <div className="col-7 col-md-6 col-lg-4">
+                  {toReadableAmount(Number(maxTopupAmount), 0, "ETH", 3)}
+                </div>
+              </div>
+              <div className="row mt-1 withdrawal-details">
+                <div className="col-5 col-md-3 col-lg-2">
+                  Topup Amount:
+                </div>
+                <div className="col-6 col-md-3 col-lg-2">
+                  <input
+                    type="number"
+                    className="form-control"
+                    id="topupAmount"
+                    min={1}
+                    max={maxTopupAmount}
+                    step={0.1}
+                    value={topupAmount}
+                    onChange={handleAmountInputChange}
+                  />
+                </div>
+                <div className="col-1">
+                  ETH
+                </div>
+                <div className="col-4 col-md-3 d-lg-none"></div>
+                <div className="col-6 col-md-5 col-lg-3">
+                  <input 
+                    type="range" 
+                    className="form-range"
+                    min={1}
+                    max={maxTopupAmount}
+                    step={0.1}
+                    onChange={handleSliderChange}
+                    value={topupAmount}
+                  />
+                </div>
+              </div>
+              
+              <div className="mt-3">
+                <button 
+                  className="btn btn-primary"
+                  disabled={!selectedValidator || topupAmount < 1 || topupAmount > maxTopupAmount || topupRequest.isPending || topupRequest.isSuccess}
+                  onClick={handleTopupSubmit}
+                >
+                  {topupRequest.isSuccess ?
+                    <span>Submitted</span> :
+                    topupRequest.isPending ? (
+                      <span className="text-nowrap"><div className="spinner-border spinner-border-sm me-1" role="status"></div>Pending...</span>
+                      ) : (
+                        topupRequest.isError ? (
+                          <span className="text-nowrap"><i className="fa-solid fa-repeat me-1"></i> Retry</span>
+                        ) : (
+                          "Submit Topup"
+                        )
+                      )
+                  }
+                </button>
+                {topupAmount < 1 && (
+                  <div className="text-danger mt-1">Amount must be at least 1 ETH</div>
+                )}
+                {topupAmount > maxTopupAmount && (
+                  <div className="text-danger mt-1">Amount exceeds available limit</div>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+      
+      {errorModal && (
+        <Modal show={true} onHide={() => setErrorModal(null)} size="lg" className="submit-deposit-modal">
+          <Modal.Header closeButton>
+            <Modal.Title>Deposit Transaction Failed</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <pre className="m-0 deposit-error">{errorModal}</pre>
+          </Modal.Body>
+          <Modal.Footer>
+            <button className="btn btn-primary" onClick={() => setErrorModal(null)}>Close</button>
+          </Modal.Footer>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default TopupDepositForm; 

--- a/ui-package/src/utils/ReadableAmount.ts
+++ b/ui-package/src/utils/ReadableAmount.ts
@@ -1,10 +1,22 @@
-
-
+/**
+ * Converts a raw amount to a decimal unit
+ * @param amount The amount to convert
+ * @param decimals The number of decimals (default: 18)
+ * @returns The amount in decimal units
+ */
 export function toDecimalUnit(amount: number, decimals?: number): number {
   let factor = Math.pow(10, typeof decimals === "number" ? decimals : 18);
   return amount / factor;
 }
 
+/**
+ * Converts a raw amount to a human-readable string with proper decimal places and optional unit
+ * @param amount The amount to format
+ * @param decimals The number of decimal places in the raw amount (default: 18 for ETH)
+ * @param unit Optional unit to append to the result (e.g., "ETH", "GWEI")
+ * @param precision Number of decimal places to show in the result
+ * @returns Formatted string with the readable amount
+ */
 export function toReadableAmount(amount: number | bigint, decimals?: number, unit?: string, precision?: number): string {
   if(typeof decimals !== "number")
     decimals = 18;


### PR DESCRIPTION
This PR adds a validator topup form that allows topping up arbitrary validators:
![image](https://github.com/user-attachments/assets/2e3edee2-b75d-422e-8079-3f44a5d99b98)

In addition, this PR improves the validator selector for arbitrary target validators:
![image](https://github.com/user-attachments/assets/46450c94-a463-408a-898a-b995fcb59c19)
Instead of fully relying on the search input, the control now shows the validators owned by the current wallet by default.