### PR TITLE
fix links in attestation template

### DIFF
--- a/templates/slot/attestations.html
+++ b/templates/slot/attestations.html
@@ -85,7 +85,7 @@
         <div class="col-md-10">
           Epoch <a data-bind="attr: {href: '/epoch/' + source_epoch}, text: source_epoch"></a>
           <span class="text-monospace text-break">
-            (<a data-bind="attr: {href: '/block/0x' + sourceRootHex()}, text: '0x' + sourceRootHex()"></a>)
+            (<a data-bind="attr: {href: '/slot/0x' + sourceRootHex()}, text: '0x' + sourceRootHex()"></a>)
           </span>
         </div>
       </div>
@@ -96,7 +96,7 @@
         <div class="col-md-10">
           Epoch <a data-bind="attr: {href: '/epoch/' + target_epoch}, text: target_epoch"></a>
           <span class="text-monospace text-break">
-            (<a data-bind="attr: {href: '/block/0x' + targetRootHex()}, text: '0x' + targetRootHex()"></a>)
+            (<a data-bind="attr: {href: '/slot/0x' + targetRootHex()}, text: '0x' + targetRootHex()"></a>)
           </span>
         </div>
       </div>


### PR DESCRIPTION
Dora currently links to a non-existent page (`block/{hex}`) instead of the correct one (`slot/{hex}`) from the Slot -> Attestations view (see e.g. https://dora.hoodi.ethpandaops.io/slot/496243)