### PR TITLE
feat: add decimal value on hover for cgc

### DIFF
--- a/static/js/explorer.js
+++ b/static/js/explorer.js
@@ -12,6 +12,7 @@
     initControls: initControls,
     renderRecentTime: renderRecentTime,
     tooltipDict: tooltipDict,
+    hexToDecimal: hexToDecimal,
   };
 
   function modalFixes() {
@@ -83,6 +84,13 @@
     setTimeout(function () {
       tooltip.setContent({ '.tooltip-inner': title });
     }, 1000);
+  }
+
+  function hexToDecimal(hexValue) {
+    if (typeof hexValue !== 'string') return '';
+    var cleanHex = hexValue.replace(/^0x/i, '');
+    var decimal = parseInt(cleanHex, 16);
+    return isNaN(decimal) ? '' : decimal.toString();
   }
 
   function updateTimers() {

--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -340,7 +340,12 @@
                 <tr>
                   <td data-bind="text: key"></td>
                   <td>
+                    {{ html "<!-- ko if: key === 'cgc' -->" }}
+                    <code data-bind="text: value, attr: {'data-bs-toggle': 'tooltip', 'data-bs-placement': 'right', 'data-bs-title': 'Decimal: ' + window.explorer.hexToDecimal(value)}"></code>
+                    {{ html "<!-- /ko -->" }}
+                    {{ html "<!-- ko if: key !== 'cgc' -->" }}
                     <code data-bind="text: value"></code>
+                    {{ html "<!-- /ko -->" }}
                     <i class="fa fa-copy text-muted p-1" role="button" data-placement="right" data-toggle="tooltip" data-bind="attr: {'data-clipboard-text': $data.value, title: 'Copy ' + $data.key + ' to clipboard'}" ></i>
                   </td>
                 </tr>
@@ -534,7 +539,7 @@
                       </tr>
                       <tr>
                         <td>CGC</td>
-                        <td><code data-bind="text: peer_das().cgc"></code></td>
+                        <td><code data-bind="text: peer_das().cgc, attr: {'data-bs-toggle': 'tooltip', 'data-bs-placement': 'right', 'data-bs-title': 'Decimal: ' + peer_das().cgc}"></code></td>
                       </tr>
                       <tr>
                         <td>Columns</td>


### PR DESCRIPTION
As not all of us are machines, its bit easier to visually parse: 
<img width="500" alt="Screenshot 2025-06-19 at 11 40 35" src="https://github.com/user-attachments/assets/ef6628f8-75ff-41fd-b686-e39b3f9c06c1" />
