### PR TITLE
feat: peerdas cell no duplicated fields & center align peers

### DIFF
--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -359,26 +359,19 @@
             <table class="table table-borderless table-sm client-table-info" style="margin-top:10px">
               <tbody>
                   <tr>
-                    <td>Custody columns</td>
+                    <td data-bind="text: 'Custody columns/subnets (' + peer_das().columns.length + ')'"></td>
                     <td>
                       <code class="enr-text-container" data-bind="text: peer_das().columns.join(', ')"></code>
                       <i class="fa fa-copy text-muted p-1" role="button" data-placement="right" data-toggle="tooltip" data-bind="attr: {'data-clipboard-text': peer_das().columns.join(', ')}" title="Copy custody columns to clipboard"></i>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Custody subnets</td>
-                    <td>
-                      <code class="enr-text-container" data-bind="text: peer_das().subnets.join(', ')"></code>
-                      <i class="fa fa-copy text-muted p-1" role="button" data-placement="right" data-toggle="tooltip" data-bind="attr: {'data-clipboard-text': peer_das().subnets.join(', ')}" title="Copy custody subnets to clipboard"></i>
                     </td>
                   </tr>
               </tbody>
             </table>
             {{ html "<!-- /ko -->" }}
           </div>
-          <div class="client-row-divider">
+          <div class="client-row-divider" style="position: relative;">
             Peers
-            <button type="button" class="btn btn-outline-secondary btn-sm float-end peer-collapse-btn" data-bs-toggle="collapse" data-bind="attr: {'data-bs-target': '#peer-details-list-' + peer_id(), 'aria-controls': 'peer-details-list-' + peer_id()}" aria-expanded="false">
+            <button type="button" class="btn btn-outline-secondary btn-sm peer-collapse-btn" data-bs-toggle="collapse" data-bind="attr: {'data-bs-target': '#peer-details-list-' + peer_id(), 'aria-controls': 'peer-details-list-' + peer_id()}" aria-expanded="false" style="position: absolute; right: 0; top: 0;">
               <i class="fa fa-chevron-down"></i> Show Connected Peers
             </button>
           </div>
@@ -462,17 +455,10 @@
                       <table class="table table-borderless table-sm client-table-info" style="padding-left:0; margin-top:10px;margin-bottom: 10px; margin-left: 10px;">
                         <tbody>
                             <tr>
-                              <td>Custody columns</td>
+                              <td data-bind="text: 'Custody columns/subnets (' + $node.peer_das.columns.length + ')'"></td>
                               <td>
                                 <code class="enr-text-container" data-bind="text: $node.peer_das.columns.join(', ')"></code>
                                 <i class="fa fa-copy text-muted p-1" role="button" data-placement="right" data-toggle="tooltip" title="Copy to clipboard" data-bind="attr: {'data-clipboard-text': $node.peer_das.columns.join(', ')}" ></i>
-                              </td>
-                            </tr>
-                            <tr>
-                              <td>Custody subnets</td>
-                              <td>
-                                <code class="enr-text-container" data-bind="text: $node.peer_das.subnets.join(', ')"></code>
-                                <i class="fa fa-copy text-muted p-1" role="button" data-placement="right" data-toggle="tooltip" title="Copy to clipboard" data-bind="attr: {'data-clipboard-text': $node.peer_das.subnets.join(', ')}" ></i>
                               </td>
                             </tr>
                         </tbody>
@@ -537,12 +523,8 @@
                         <td><code data-bind="text: peer_das().cgc"></code></td>
                       </tr>
                       <tr>
-                        <td>Columns</td>
+                        <td data-bind="text: 'Columns/subnets (' + peer_das().columns.length + ')'"></td>
                         <td><code class="enr-text-container" data-bind="text: peer_das().columns.join(', ')"></code></td>
-                      </tr>
-                      <tr>
-                        <td>Subnets</td>
-                        <td><code class="enr-text-container" data-bind="text: peer_das().subnets.join(', ')"></code></td>
                       </tr>
                     {{ html "<!-- /ko -->" }}
                     <tr>


### PR DESCRIPTION
Column/subnets are now displayed in 1 row instead of duplicates of them. 

<img width="1556" alt="Screenshot 2025-06-24 at 14 14 42" src="https://github.com/user-attachments/assets/73bc3512-546b-4759-b519-3169a5c1c599" />
