### PR TITLE
Update EIP-7594 helper functions link to latest consensus-specs location

### DIFF
--- a/utils/peerdas.go
+++ b/utils/peerdas.go
@@ -63,7 +63,7 @@ func CustodyColumnSubnets(nodeId enode.ID, custodySubnetCount uint64, dataColumn
 }
 
 // CustodyColumns computes the columns the node should custody.
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip7594/das-core.md#helper-functions
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#helper-functions
 func CustodyColumns(nodeId enode.ID, custodySubnetCount uint64, numberOfColumns uint64, dataColumnSidecarSubnetCount uint64) (map[uint64]bool, error) {
 
 	// Compute the custodied subnets.


### PR DESCRIPTION
Replaced the outdated reference to the EIP-7594 DAS core helper functions in the CustodyColumns comment with the current link: https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#helper-functions This ensures the documentation points to the correct and up-to-date section of the Ethereum consensus-specs repository.