### PR TITLE
improve paging controls (allow jumping to specific pages)

### DIFF
--- a/handlers/blocks.go
+++ b/handlers/blocks.go
@@ -190,6 +190,14 @@ func buildBlocksPageData(firstSlot uint64, pageSize uint64, displayColumns strin
 	}
 	pageData.LastPageSlot = pageSize - 1
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+	if len(displayList) > 0 {
+		pageData.UrlParams["d"] = strings.Join(displayList, "+")
+	}
+	pageData.MaxSlot = uint64(maxSlot)
+
 	// Add pagination links with column selection preserved
 	pageData.FirstPageLink = fmt.Sprintf("/blocks?c=%v%v", pageData.PageSize, displayColumnsParam)
 	pageData.PrevPageLink = fmt.Sprintf("/blocks?s=%v&c=%v%v", pageData.PrevPageSlot, pageData.PageSize, displayColumnsParam)

--- a/handlers/el_consolidations.go
+++ b/handlers/el_consolidations.go
@@ -285,6 +285,15 @@ func buildFilteredElConsolidationsPageData(pageIdx uint64, pageSize uint64, minS
 		pageData.NextPageIndex = pageIdx + 1
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/validators/el_consolidations?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/validators/el_consolidations?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/validators/el_consolidations?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/handlers/el_withdrawals.go
+++ b/handlers/el_withdrawals.go
@@ -270,6 +270,15 @@ func buildFilteredElWithdrawalsPageData(pageIdx uint64, pageSize uint64, minSlot
 		pageData.NextPageIndex = pageIdx + 1
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/validators/el_withdrawals?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/validators/el_withdrawals?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/validators/el_withdrawals?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -101,6 +101,11 @@ func buildEpochsPageData(firstEpoch uint64, pageSize uint64) (*models.EpochsPage
 	}
 	pageData.LastPageEpoch = pageSize - 1
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	pageData.UrlParams["count"] = fmt.Sprintf("%v", pageData.PageSize)
+	pageData.MaxEpoch = uint64(currentEpoch)
+
 	finalizedEpoch, _ := chainState.GetFinalizedCheckpoint()
 	justifiedEpoch, _ := chainState.GetJustifiedCheckpoint()
 	epochLimit := pageSize

--- a/handlers/included_deposits.go
+++ b/handlers/included_deposits.go
@@ -291,6 +291,15 @@ func buildFilteredIncludedDepositsPageData(pageIdx uint64, pageSize uint64, minI
 		pageData.NextPageIndex = pageIdx + 1
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/validators/included_deposits?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/validators/included_deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/validators/included_deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/handlers/initiated_deposits.go
+++ b/handlers/initiated_deposits.go
@@ -236,6 +236,15 @@ func buildFilteredInitiatedDepositsPageData(pageIdx uint64, pageSize uint64, add
 		pageData.NextPageIndex = pageIdx + 1
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/validators/initiated_deposits?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/validators/initiated_deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/validators/initiated_deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/handlers/mev_blocks.go
+++ b/handlers/mev_blocks.go
@@ -258,6 +258,15 @@ func buildFilteredMevBlocksPageData(pageIdx uint64, pageSize uint64, minSlot uin
 		pageData.NextPageIndex = pageIdx + 1
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/mev/blocks?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/mev/blocks?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/mev/blocks?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/handlers/queued_deposits.go
+++ b/handlers/queued_deposits.go
@@ -164,6 +164,15 @@ func buildQueuedDepositsPageData(pageIdx uint64, pageSize uint64, minIndex uint6
 		filterArgs.Add("f.maxa", fmt.Sprintf("%v", maxAmount))
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/validators/queued_deposits?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/validators/queued_deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/validators/queued_deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/handlers/slashings.go
+++ b/handlers/slashings.go
@@ -238,6 +238,15 @@ func buildFilteredSlashingsPageData(pageIdx uint64, pageSize uint64, minSlot uin
 		pageData.NextPageIndex = pageIdx + 1
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/validators/slashings?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/validators/slashings?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/validators/slashings?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/handlers/slots.go
+++ b/handlers/slots.go
@@ -195,6 +195,14 @@ func buildSlotsPageData(firstSlot uint64, pageSize uint64, displayColumns string
 	}
 	pageData.LastPageSlot = pageSize - 1
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+	if len(displayList) > 0 {
+		pageData.UrlParams["d"] = strings.Join(displayList, "+")
+	}
+	pageData.MaxSlot = uint64(maxSlot)
+
 	// Add pagination links with column selection preserved
 	pageData.FirstPageLink = fmt.Sprintf("/slots?c=%v%v", pageData.PageSize, displayColumnsParam)
 	pageData.PrevPageLink = fmt.Sprintf("/slots?s=%v&c=%v%v", pageData.PrevPageSlot, pageData.PageSize, displayColumnsParam)

--- a/handlers/slots_filtered.go
+++ b/handlers/slots_filtered.go
@@ -402,6 +402,15 @@ func buildFilteredSlotsPageData(pageIdx uint64, pageSize uint64, graffiti string
 		pageData.TotalPages++
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/slots/filtered?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/slots/filtered?f&%v&c=%v&s=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageSlot)
 	pageData.NextPageLink = fmt.Sprintf("/slots/filtered?f&%v&c=%v&s=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageSlot)

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -294,6 +294,16 @@ func buildValidatorsPageData(pageNumber uint64, pageSize uint64, sortOrder strin
 	pageData.ValidatorCount = validatorSetLen
 	pageData.FirstValidator = pageNumber * pageSize
 	pageData.LastValidator = pageData.FirstValidator + uint64(len(pageData.Validators))
+
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FilteredPageLink = fmt.Sprintf("/validators?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 
 	return pageData, cacheTime

--- a/handlers/voluntary_exits.go
+++ b/handlers/voluntary_exits.go
@@ -218,6 +218,15 @@ func buildFilteredVoluntaryExitsPageData(pageIdx uint64, pageSize uint64, minSlo
 		pageData.NextPageIndex = pageIdx + 1
 	}
 
+	// Populate UrlParams for page jump functionality
+	pageData.UrlParams = make(map[string]string)
+	for key, values := range filterArgs {
+		if len(values) > 0 {
+			pageData.UrlParams[key] = values[0]
+		}
+	}
+	pageData.UrlParams["c"] = fmt.Sprintf("%v", pageData.PageSize)
+
 	pageData.FirstPageLink = fmt.Sprintf("/validators/voluntary_exits?f&%v&c=%v", filterArgs.Encode(), pageData.PageSize)
 	pageData.PrevPageLink = fmt.Sprintf("/validators/voluntary_exits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/validators/voluntary_exits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)

--- a/templates/blocks/blocks.html
+++ b/templates/blocks/blocks.html
@@ -222,6 +222,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                  {{ end }}
+                  <input type="hidden" id="maxSlot" value="{{ .MaxSlot }}">
+                  <input type="hidden" id="pageSize" value="{{ .PageSize }}">
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="page" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if le .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -284,6 +301,45 @@ $(function() {
         }
       }
     });
+  });
+
+  // Page jump functionality for index-based pagination
+  $('#pageJumpForm').on('submit', function(e) {
+    e.preventDefault();
+    
+    var pageInput = $('#pageJumpInput');
+    var pageNum = parseInt(pageInput.val());
+    var maxPages = parseInt(pageInput.attr('max'));
+    var maxSlot = parseInt($('#maxSlot').val());
+    var pageSize = parseInt($('#pageSize').val());
+    
+    if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+      pageInput.addClass('is-invalid');
+      setTimeout(function() {
+        pageInput.removeClass('is-invalid');
+      }, 2000);
+      return false;
+    }
+    
+    // Calculate start index from page number
+    // Page 1 = most recent blocks (no s parameter needed)
+    // Page 2+ = maxSlot - ((pageNum - 1) * pageSize)
+    var url = new URL(window.location);
+    if (pageNum === 1) {
+      url.searchParams.delete('s');
+    } else {
+      var startIndex = maxSlot - ((pageNum - 1) * pageSize);
+      url.searchParams.set('s', startIndex);
+    }
+    
+    window.location.href = url.toString();
+  });
+
+  // Enter key support for page jump
+  $('#pageJumpInput').on('keypress', function(e) {
+    if (e.which === 13) {
+      $('#pageJumpForm').submit();
+    }
   });
 
   // Initialize popovers for execution times

--- a/templates/el_consolidations/el_consolidations.html
+++ b/templates/el_consolidations/el_consolidations.html
@@ -347,6 +347,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -427,6 +444,29 @@
       if(lastPopover) {
         lastPopover.hide();
         lastPopover = null;
+      }
+    });
+
+    // Page jump functionality
+    $('#pageJumpForm').on('submit', function(e) {
+      var pageInput = $('#pageJumpInput');
+      var pageNum = parseInt(pageInput.val());
+      var maxPages = parseInt(pageInput.attr('max'));
+      
+      if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+        e.preventDefault();
+        pageInput.addClass('is-invalid');
+        setTimeout(function() {
+          pageInput.removeClass('is-invalid');
+        }, 2000);
+        return false;
+      }
+    });
+
+    // Enter key support for page jump
+    $('#pageJumpInput').on('keypress', function(e) {
+      if (e.which === 13) {
+        $('#pageJumpForm').submit();
       }
     });
 

--- a/templates/el_withdrawals/el_withdrawals.html
+++ b/templates/el_withdrawals/el_withdrawals.html
@@ -329,6 +329,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -409,6 +426,29 @@
       if(lastPopover) {
         lastPopover.hide();
         lastPopover = null;
+      }
+    });
+
+    // Page jump functionality
+    $('#pageJumpForm').on('submit', function(e) {
+      var pageInput = $('#pageJumpInput');
+      var pageNum = parseInt(pageInput.val());
+      var maxPages = parseInt(pageInput.attr('max'));
+      
+      if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+        e.preventDefault();
+        pageInput.addClass('is-invalid');
+        setTimeout(function() {
+          pageInput.removeClass('is-invalid');
+        }, 2000);
+        return false;
+      }
+    });
+
+    // Enter key support for page jump
+    $('#pageJumpInput').on('keypress', function(e) {
+      if (e.which === 13) {
+        $('#pageJumpForm').submit();
       }
     });
 

--- a/templates/epochs/epochs.html
+++ b/templates/epochs/epochs.html
@@ -141,6 +141,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                  {{ end }}
+                  <input type="hidden" id="maxEpoch" value="{{ .MaxEpoch }}">
+                  <input type="hidden" id="pageSize" value="{{ .PageSize }}">
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="page" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if le .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="/epochs?count={{ .PageSize }}">First</a>
@@ -168,6 +185,48 @@
   </div>
 {{ end }}
 {{ define "js" }}
+<script type="text/javascript">
+$(function() {
+  // Page jump functionality for index-based pagination
+  $('#pageJumpForm').on('submit', function(e) {
+    e.preventDefault();
+    
+    var pageInput = $('#pageJumpInput');
+    var pageNum = parseInt(pageInput.val());
+    var maxPages = parseInt(pageInput.attr('max'));
+    var maxEpoch = parseInt($('#maxEpoch').val());
+    var pageSize = parseInt($('#pageSize').val());
+    
+    if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+      pageInput.addClass('is-invalid');
+      setTimeout(function() {
+        pageInput.removeClass('is-invalid');
+      }, 2000);
+      return false;
+    }
+    
+    // Calculate starting epoch from page number
+    // Page 1 = most recent epochs (no epoch parameter needed)
+    // Page 2+ = maxEpoch - ((pageNum - 1) * pageSize)
+    var url = new URL(window.location);
+    if (pageNum === 1) {
+      url.searchParams.delete('epoch');
+    } else {
+      var startEpoch = maxEpoch - ((pageNum - 1) * pageSize);
+      url.searchParams.set('epoch', startEpoch);
+    }
+    
+    window.location.href = url.toString();
+  });
+
+  // Enter key support for page jump
+  $('#pageJumpInput').on('keypress', function(e) {
+    if (e.which === 13) {
+      $('#pageJumpForm').submit();
+    }
+  });
+});
+</script>
 {{ end }}
 {{ define "css" }}
 {{ end }}

--- a/templates/included_deposits/included_deposits.html
+++ b/templates/included_deposits/included_deposits.html
@@ -362,6 +362,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -443,6 +460,29 @@
       if(lastPopover) {
         lastPopover.hide();
         lastPopover = null;
+      }
+    });
+
+    // Page jump functionality
+    $('#pageJumpForm').on('submit', function(e) {
+      var pageInput = $('#pageJumpInput');
+      var pageNum = parseInt(pageInput.val());
+      var maxPages = parseInt(pageInput.attr('max'));
+      
+      if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+        e.preventDefault();
+        pageInput.addClass('is-invalid');
+        setTimeout(function() {
+          pageInput.removeClass('is-invalid');
+        }, 2000);
+        return false;
+      }
+    });
+
+    // Enter key support for page jump
+    $('#pageJumpInput').on('keypress', function(e) {
+      if (e.which === 13) {
+        $('#pageJumpForm').submit();
       }
     });
 

--- a/templates/initiated_deposits/initiated_deposits.html
+++ b/templates/initiated_deposits/initiated_deposits.html
@@ -231,6 +231,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -258,6 +275,32 @@
   </div>
 {{ end }}
 {{ define "js" }}
+<script>
+  $(document).ready(function() {
+    // Page jump functionality
+    $('#pageJumpForm').on('submit', function(e) {
+      var pageInput = $('#pageJumpInput');
+      var pageNum = parseInt(pageInput.val());
+      var maxPages = parseInt(pageInput.attr('max'));
+      
+      if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+        e.preventDefault();
+        pageInput.addClass('is-invalid');
+        setTimeout(function() {
+          pageInput.removeClass('is-invalid');
+        }, 2000);
+        return false;
+      }
+    });
+
+    // Enter key support for page jump
+    $('#pageJumpInput').on('keypress', function(e) {
+      if (e.which === 13) {
+        $('#pageJumpForm').submit();
+      }
+    });
+  });
+</script>
 {{ end }}
 {{ define "css" }}
 <style>

--- a/templates/mev_blocks/mev_blocks.html
+++ b/templates/mev_blocks/mev_blocks.html
@@ -222,6 +222,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -275,6 +292,29 @@
         this.$container.addClass("filter-multiselect-container");
       }
     });
+  });
+
+  // Page jump functionality
+  $('#pageJumpForm').on('submit', function(e) {
+    var pageInput = $('#pageJumpInput');
+    var pageNum = parseInt(pageInput.val());
+    var maxPages = parseInt(pageInput.attr('max'));
+    
+    if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+      e.preventDefault();
+      pageInput.addClass('is-invalid');
+      setTimeout(function() {
+        pageInput.removeClass('is-invalid');
+      }, 2000);
+      return false;
+    }
+  });
+
+  // Enter key support for page jump
+  $('#pageJumpInput').on('keypress', function(e) {
+    if (e.which === 13) {
+      $('#pageJumpForm').submit();
+    }
   });
 </script>
 {{ end }}

--- a/templates/queued_deposits/queued_deposits.html
+++ b/templates/queued_deposits/queued_deposits.html
@@ -278,6 +278,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -358,6 +375,29 @@
       if(lastPopover) {
         lastPopover.hide();
         lastPopover = null;
+      }
+    });
+
+    // Page jump functionality
+    $('#pageJumpForm').on('submit', function(e) {
+      var pageInput = $('#pageJumpInput');
+      var pageNum = parseInt(pageInput.val());
+      var maxPages = parseInt(pageInput.attr('max'));
+      
+      if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+        e.preventDefault();
+        pageInput.addClass('is-invalid');
+        setTimeout(function() {
+          pageInput.removeClass('is-invalid');
+        }, 2000);
+        return false;
+      }
+    });
+
+    // Enter key support for page jump
+    $('#pageJumpInput').on('keypress', function(e) {
+      if (e.which === 13) {
+        $('#pageJumpForm').submit();
       }
     });
 

--- a/templates/slashings/slashings.html
+++ b/templates/slashings/slashings.html
@@ -209,6 +209,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -236,6 +253,32 @@
   </div>
 {{ end }}
 {{ define "js" }}
+<script>
+  $(document).ready(function() {
+    // Page jump functionality
+    $('#pageJumpForm').on('submit', function(e) {
+      var pageInput = $('#pageJumpInput');
+      var pageNum = parseInt(pageInput.val());
+      var maxPages = parseInt(pageInput.attr('max'));
+      
+      if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+        e.preventDefault();
+        pageInput.addClass('is-invalid');
+        setTimeout(function() {
+          pageInput.removeClass('is-invalid');
+        }, 2000);
+        return false;
+      }
+    });
+
+    // Enter key support for page jump
+    $('#pageJumpInput').on('keypress', function(e) {
+      if (e.which === 13) {
+        $('#pageJumpForm').submit();
+      }
+    });
+  });
+</script>
 {{ end }}
 {{ define "css" }}
 <style>

--- a/templates/slots/slots.html
+++ b/templates/slots/slots.html
@@ -222,6 +222,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                  {{ end }}
+                  <input type="hidden" id="maxSlot" value="{{ .MaxSlot }}">
+                  <input type="hidden" id="pageSize" value="{{ .PageSize }}">
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="page" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if le .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -284,6 +301,45 @@ $(function() {
         }
       }
     });
+  });
+
+  // Page jump functionality for index-based pagination
+  $('#pageJumpForm').on('submit', function(e) {
+    e.preventDefault();
+    
+    var pageInput = $('#pageJumpInput');
+    var pageNum = parseInt(pageInput.val());
+    var maxPages = parseInt(pageInput.attr('max'));
+    var maxSlot = parseInt($('#maxSlot').val());
+    var pageSize = parseInt($('#pageSize').val());
+    
+    if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+      pageInput.addClass('is-invalid');
+      setTimeout(function() {
+        pageInput.removeClass('is-invalid');
+      }, 2000);
+      return false;
+    }
+    
+    // Calculate start index from page number
+    // Page 1 = most recent slots (no s parameter needed)
+    // Page 2+ = maxSlot - ((pageNum - 1) * pageSize)
+    var url = new URL(window.location);
+    if (pageNum === 1) {
+      url.searchParams.delete('s');
+    } else {
+      var startIndex = maxSlot - ((pageNum - 1) * pageSize);
+      url.searchParams.set('s', startIndex);
+    }
+    
+    window.location.href = url.toString();
+  });
+
+  // Enter key support for page jump
+  $('#pageJumpInput').on('keypress', function(e) {
+    if (e.which === 13) {
+      $('#pageJumpForm').submit();
+    }
   });
 
   // Initialize popovers for execution times

--- a/templates/slots_filtered/slots_filtered.html
+++ b/templates/slots_filtered/slots_filtered.html
@@ -318,6 +318,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "s" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="s" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if le .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -366,6 +383,29 @@ $(function() {
         this.$container.addClass("filter-multiselect-container");
       }
     });
+  });
+
+  // Page jump functionality
+  $('#pageJumpForm').on('submit', function(e) {
+    var pageInput = $('#pageJumpInput');
+    var pageNum = parseInt(pageInput.val());
+    var maxPages = parseInt(pageInput.attr('max'));
+    
+    if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+      e.preventDefault();
+      pageInput.addClass('is-invalid');
+      setTimeout(function() {
+        pageInput.removeClass('is-invalid');
+      }, 2000);
+      return false;
+    }
+  });
+
+  // Enter key support for page jump
+  $('#pageJumpInput').on('keypress', function(e) {
+    if (e.which === 13) {
+      $('#pageJumpForm').submit();
+    }
   });
 
   // Initialize popovers for execution times

--- a/templates/validators/validators.html
+++ b/templates/validators/validators.html
@@ -207,6 +207,26 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  {{ if not .IsDefaultSorting }}
+                    <input type="hidden" name="o" value="{{ .Sorting }}">
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if eq .CurrentPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FilteredPageLink }}&{{ if not .IsDefaultSorting }}o={{ .Sorting }}&{{ end }}c={{ .PageSize }}">First</a>
@@ -247,6 +267,29 @@ $(function() {
         this.$container.addClass("filter-multiselect-container");
       }
     });
+  });
+
+  // Page jump functionality
+  $('#pageJumpForm').on('submit', function(e) {
+    var pageInput = $('#pageJumpInput');
+    var pageNum = parseInt(pageInput.val());
+    var maxPages = parseInt(pageInput.attr('max'));
+    
+    if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+      e.preventDefault();
+      pageInput.addClass('is-invalid');
+      setTimeout(function() {
+        pageInput.removeClass('is-invalid');
+      }, 2000);
+      return false;
+    }
+  });
+
+  // Enter key support for page jump
+  $('#pageJumpInput').on('keypress', function(e) {
+    if (e.which === 13) {
+      $('#pageJumpForm').submit();
+    }
   });
 });
 </script>

--- a/templates/voluntary_exits/voluntary_exits.html
+++ b/templates/voluntary_exits/voluntary_exits.html
@@ -201,6 +201,23 @@
             </div>
             <div class="col-sm-12 col-md-7 table-paging">
               <div class="d-inline-block px-2">
+                <form method="GET" style="display: inline-flex; align-items: center;" id="pageJumpForm">
+                  {{ range $key, $value := .UrlParams }}
+                    {{ if ne $key "p" }}
+                      <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    {{ end }}
+                  {{ end }}
+                  <div class="input-group" style="width: 120px;">
+                    <input type="number" class="form-control" name="p" id="pageJumpInput" 
+                           min="1" max="{{ .TotalPages }}" placeholder="Page" 
+                           style="height: 38px; font-size: 14px; text-align: center; border-radius: 0.375rem 0 0 0.375rem;">
+                    <button type="submit" class="btn btn-outline-secondary" style="height: 38px; border-radius: 0 0.375rem 0.375rem 0;">
+                      Go
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <div class="d-inline-block px-2">
                 <ul class="pagination">
                   <li class="first paginate_button page-item {{ if lt .PrevPageIndex 1 }}disabled{{ end }}" id="tpg_first">
                     <a tab-index="1" aria-controls="tpg_first" class="page-link" href="{{ .FirstPageLink }}">First</a>
@@ -228,6 +245,32 @@
   </div>
 {{ end }}
 {{ define "js" }}
+<script>
+  $(document).ready(function() {
+    // Page jump functionality
+    $('#pageJumpForm').on('submit', function(e) {
+      var pageInput = $('#pageJumpInput');
+      var pageNum = parseInt(pageInput.val());
+      var maxPages = parseInt(pageInput.attr('max'));
+      
+      if (isNaN(pageNum) || pageNum < 1 || pageNum > maxPages) {
+        e.preventDefault();
+        pageInput.addClass('is-invalid');
+        setTimeout(function() {
+          pageInput.removeClass('is-invalid');
+        }, 2000);
+        return false;
+      }
+    });
+
+    // Enter key support for page jump
+    $('#pageJumpInput').on('keypress', function(e) {
+      if (e.which === 13) {
+        $('#pageJumpForm').submit();
+      }
+    });
+  });
+</script>
 {{ end }}
 {{ define "css" }}
 <style>

--- a/types/models/blocks.go
+++ b/types/models/blocks.go
@@ -48,6 +48,9 @@ type BlocksPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
+	MaxSlot   uint64            `json:"max_slot"`
 }
 
 type BlocksPageDataSlot struct {

--- a/types/models/el_consolidations.go
+++ b/types/models/el_consolidations.go
@@ -35,6 +35,8 @@ type ElConsolidationsPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type ElConsolidationsPageDataConsolidation struct {

--- a/types/models/el_withdrawals.go
+++ b/types/models/el_withdrawals.go
@@ -33,6 +33,8 @@ type ElWithdrawalsPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type ElWithdrawalsPageDataWithdrawal struct {

--- a/types/models/epochs.go
+++ b/types/models/epochs.go
@@ -21,6 +21,9 @@ type EpochsPageData struct {
 	NextPageIndex    uint64 `json:"next_page_index"`
 	NextPageEpoch    uint64 `json:"next_page_epoch"`
 	LastPageEpoch    uint64 `json:"last_page_epoch"`
+
+	UrlParams map[string]string `json:"url_params"`
+	MaxEpoch  uint64            `json:"max_epoch"`
 }
 
 type EpochsPageDataEpoch struct {

--- a/types/models/included_deposits.go
+++ b/types/models/included_deposits.go
@@ -33,6 +33,8 @@ type IncludedDepositsPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type IncludedDepositsPageDataDeposit struct {

--- a/types/models/initiated_deposits.go
+++ b/types/models/initiated_deposits.go
@@ -31,6 +31,8 @@ type InitiatedDepositsPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type InitiatedDepositsPageDataDeposit struct {

--- a/types/models/mev_blocks.go
+++ b/types/models/mev_blocks.go
@@ -32,6 +32,8 @@ type MevBlocksPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type MevBlocksPageDataBlock struct {

--- a/types/models/queued_deposits.go
+++ b/types/models/queued_deposits.go
@@ -31,6 +31,8 @@ type QueuedDepositsPageData struct {
 	PrevPageLink     string `json:"prev_page_link"`
 	NextPageLink     string `json:"next_page_link"`
 	LastPageLink     string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type QueuedDepositsPageDataDeposit struct {

--- a/types/models/slashings.go
+++ b/types/models/slashings.go
@@ -32,6 +32,8 @@ type SlashingsPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type SlashingsPageDataSlashing struct {

--- a/types/models/slots.go
+++ b/types/models/slots.go
@@ -48,6 +48,9 @@ type SlotsPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
+	MaxSlot   uint64            `json:"max_slot"`
 }
 
 type SlotsPageDataSlot struct {

--- a/types/models/slots_filtered.go
+++ b/types/models/slots_filtered.go
@@ -56,6 +56,8 @@ type SlotsFilteredPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type SlotsFilteredPageDataSlot struct {

--- a/types/models/validators.go
+++ b/types/models/validators.go
@@ -27,6 +27,8 @@ type ValidatorsPageData struct {
 	NextPageIndex    uint64                         `json:"next_page_index"`
 	LastPageIndex    uint64                         `json:"last_page_index"`
 	FilteredPageLink string                         `json:"filtered_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type ValidatorsPageDataStatusOption struct {

--- a/types/models/voluntary_exits.go
+++ b/types/models/voluntary_exits.go
@@ -30,6 +30,8 @@ type VoluntaryExitsPageData struct {
 	PrevPageLink  string `json:"prev_page_link"`
 	NextPageLink  string `json:"next_page_link"`
 	LastPageLink  string `json:"last_page_link"`
+
+	UrlParams map[string]string `json:"url_params"`
 }
 
 type VoluntaryExitsPageDataExit struct {


### PR DESCRIPTION
fixes #267:
![image](https://github.com/user-attachments/assets/65658db8-e9dc-4636-bc10-7cea43894226)

Applied to all list views with paging controls:
* epochs
* blocks
* mev_blocks
* slots
* slots_filtered
* validators
* el_consolidations
* el_withdrawals
* included_deposits
* initialized_deposits
* queued_deposits
* slashings
* voluntary_exits