### PR TITLE
fix: disable client graph on exec page load

### DIFF
--- a/templates/clients/clients_el.html
+++ b/templates/clients/clients_el.html
@@ -288,17 +288,11 @@
     peerGraph = $_network.create(container, peerGraphData);
   }
 
-  if(peerGraphData.nodes.filter(function(node) { return node.group == "internal" }).length <= 100) {
-    $('#peerGraph').addClass('show');
-    $('#peerGraphToggler').removeClass('collapsed');
+  $('#peerGraph').on('shown.bs.collapse', function () {
+    if(peerGraphRendered) return;
     renderPeerGraph();
-  } else {
-    $('#peerGraph').on('shown.bs.collapse', function () {
-      if(peerGraphRendered) return;
-      renderPeerGraph();
-      peerGraphRendered = true;
-    });
-  }
+    peerGraphRendered = true;
+  });
 
   $('.client-row').on('click', function() {
     var peerId = $(this).data('peerid');


### PR DESCRIPTION
Before:
<img width="1628" alt="Screenshot 2025-07-01 at 14 19 01" src="https://github.com/user-attachments/assets/544b4b7b-31ef-404b-838f-baf7ddf1ca8c" />

After:
<img width="1739" alt="Screenshot 2025-07-01 at 14 18 40" src="https://github.com/user-attachments/assets/3b103e97-e499-4257-b480-543e429c7734" />
