### PR TITLE
fix: inbound counter for nethermind

### DIFF
--- a/clients/execution/clientlogic.go
+++ b/clients/execution/clientlogic.go
@@ -113,7 +113,7 @@ func (client *Client) updateNodeMetadata(ctx context.Context) error {
 		return fmt.Errorf("could not get node info: %v", err)
 	}
 
-	peers, err := client.rpcClient.GetAdminPeers(ctx)
+	peers, err := client.rpcClient.GetAdminPeersWithClientType(ctx, rpc.ConvertClientType(client.clientType.Uint8()))
 	if err != nil {
 		client.didFetchPeers = false
 		return fmt.Errorf("could not get peers: %v", err)

--- a/clients/execution/rpc/executionapi.go
+++ b/clients/execution/rpc/executionapi.go
@@ -22,18 +22,18 @@ import (
 
 // NethermindPeerInfo represents the Nethermind-specific peer format
 type NethermindPeerInfo struct {
-	Name        string                 `json:"name,omitempty"`
-	ID          string                 `json:"id"`
-	Host        string                 `json:"host,omitempty"`
-	Port        uint16                 `json:"port,omitempty"`
-	Address     string                 `json:"address,omitempty"`
-	IsBootnode  bool                   `json:"isBootnode,omitempty"`
-	IsTrusted   bool                   `json:"isTrusted,omitempty"`
-	IsStatic    bool                   `json:"isStatic,omitempty"`
-	Enode       string                 `json:"enode"`
-	Inbound     bool                   `json:"inbound"`
-	Caps        []string               `json:"caps,omitempty"`
-	Protocols   map[string]interface{} `json:"protocols,omitempty"`
+	Name       string                 `json:"name,omitempty"`
+	ID         string                 `json:"id"`
+	Host       string                 `json:"host,omitempty"`
+	Port       uint16                 `json:"port,omitempty"`
+	Address    string                 `json:"address,omitempty"`
+	IsBootnode bool                   `json:"isBootnode,omitempty"`
+	IsTrusted  bool                   `json:"isTrusted,omitempty"`
+	IsStatic   bool                   `json:"isStatic,omitempty"`
+	Enode      string                 `json:"enode"`
+	Inbound    bool                   `json:"inbound"`
+	Caps       []string               `json:"caps,omitempty"`
+	Protocols  map[string]interface{} `json:"protocols,omitempty"`
 }
 
 // convertNethermindPeer converts a NethermindPeerInfo to p2p.PeerInfo format
@@ -45,14 +45,14 @@ func convertNethermindPeer(np *NethermindPeerInfo) *p2p.PeerInfo {
 		Enode:     np.Enode,
 		Protocols: np.Protocols,
 	}
-	
+
 	// Set the Network fields directly on the anonymous struct
-	peer.Network.LocalAddress = ""    // Not provided by Nethermind
+	peer.Network.LocalAddress = "" // Not provided by Nethermind
 	peer.Network.RemoteAddress = np.Address
 	peer.Network.Inbound = np.Inbound
 	peer.Network.Trusted = np.IsTrusted
 	peer.Network.Static = np.IsStatic
-	
+
 	return peer
 }
 
@@ -168,7 +168,7 @@ func (ec *ExecutionClient) GetChainSpec(ctx context.Context) (*ChainSpec, error)
 func (ec *ExecutionClient) GetAdminPeers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 	// Check if this is likely a Nethermind client by name
 	isNethermind := strings.Contains(strings.ToLower(ec.name), "nethermind")
-	
+
 	if isNethermind {
 		logrus.Debugf("Detected Nethermind client %s, using Nethermind-specific parsing", ec.name)
 		// For Nethermind, go directly to raw JSON parsing
@@ -181,36 +181,36 @@ func (ec *ExecutionClient) GetAdminPeers(ctx context.Context) ([]*p2p.PeerInfo, 
 				return nil, fmt.Errorf("failed to get admin_peers from Nethermind: %v", err)
 			}
 		}
-		
+
 		logrus.Debugf("Raw JSON response from Nethermind client %s: %s", ec.name, string(rawResult))
-		
+
 		// Try to unmarshal as Nethermind format
 		var nethermindPeers []*NethermindPeerInfo
 		if err := json.Unmarshal(rawResult, &nethermindPeers); err != nil {
 			return nil, fmt.Errorf("failed to parse Nethermind admin_peers response: %v", err)
 		}
-		
+
 		logrus.Debugf("Successfully parsed Nethermind format for client %s, converting %d peers", ec.name, len(nethermindPeers))
-		
+
 		// Convert Nethermind format to standard format
 		result := make([]*p2p.PeerInfo, len(nethermindPeers))
 		for i, np := range nethermindPeers {
 			result[i] = convertNethermindPeer(np)
 			logrus.Debugf("Converted peer %d: ID=%s, Inbound=%t -> %t", i, np.ID, np.Inbound, result[i].Network.Inbound)
 		}
-		
+
 		return result, nil
 	}
-	
+
 	// For non-Nethermind clients, use standard format
 	var standardResult []*p2p.PeerInfo
 	err := ec.rpcClient.CallContext(ctx, &standardResult, "admin_peers")
-	
+
 	if err == nil {
 		logrus.Debugf("Successfully parsed admin_peers in standard format for client %s", ec.name)
 		return standardResult, nil
 	}
-	
+
 	// If that fails with "Invalid params", try with boolean parameter (some clients need this)
 	if err.Error() == "Invalid params" {
 		logrus.Debugf("Trying admin_peers with boolean parameter for client %s", ec.name)
@@ -221,7 +221,7 @@ func (ec *ExecutionClient) GetAdminPeers(ctx context.Context) ([]*p2p.PeerInfo, 
 			return standardResult, nil
 		}
 	}
-	
+
 	return nil, fmt.Errorf("failed to get admin_peers: %v", err)
 }
 

--- a/static/css/clients.css
+++ b/static/css/clients.css
@@ -212,6 +212,10 @@ code.enr-text-container {
   word-break: break-all;
 }
 
+.client-table-info td:first-child {
+  white-space: nowrap;
+}
+
 /* Modal specific ENR styling */
 .modal-body .client-table-info td {
   max-width: calc(100vw - 300px);


### PR DESCRIPTION
Nethermind uses a different return structure than all other clients for admin_peers. 
They use: 
```json
    {
      "id": "a6be3b7ad539e4968ee0588b1d2cb534565e0c912e0ec9133f14ff8808019f9e",
      "host": "172.16.0.11",
      "port": 30303,
      "address": "[::ffff:172.16.0.11]:30303",
      "isBootnode": false,
      "isTrusted": false,
      "isStatic": false,
      "enode": "enode://8e29fa5cc9351c5d6fe939f5a559ddd380e6fbe6c32d5987dd8f4dfb9c8ca1edff0555a74c927fc117d22000d7eab44237880eae0ad3476ce084ff491709d922@172.16.0.11:30303",
      "inbound": true
    },
```

instead of:
```json
    {
      "enr": "enr:-Ke4QBGzMXZeGTe9XW_9PhE5z3oRzB83mow2nu9WCoYLvU_TSnfPiXYVVE_HHkXxckhvfycPDRbV9-OMvpmTrEtL26qGAZerqnftg2V0aMvKhIe8XVCEaGMaIIJpZIJ2NIJpcIRAF5cbiXNlY3AyNTZrMaEDHFFJqZEE-iOQPEh-lOoaHKq3Ww88C9vGLQdUUdfjSzSEc25hcMCDdGNwgnxJg3VkcIJ8SQ",
      "enode": "enode://1c5149a99104fa23903c487e94ea1a1caab75b0f3c0bdbc62d075451d7e34b3405672ef5dc1234a906386cc07b9da1d904ac962cedbb088fc27f4cda2c0fc777@64.23.151.27:31817",
      "id": "ee691f32878517b2aa27b594a5c9508f8ba6124daf562c095847eac21253f3f6",
      "name": "Geth/v1.15.12-unstable-df12e79e-20250623/linux-amd64/go1.24.4",
      "caps": [
        "eth/68",
        "eth/69",
        "snap/1"
      ],
      "network": {
        "localAddress": "172.18.0.7:57830",
        "remoteAddress": "64.23.151.27:31817",
        "inbound": false,
        "trusted": false,
        "static": false
      },
      "protocols": {
        "eth": {
          "version": 69,
          "earliestBlock": 0,
          "latestBlock": 30449,
          "latestBlockHash": "0xfa1bb18f424d950c16f0a5d241c6759ab3f19a921ff1063a256ea97f1158dd61"
        },
        "snap": {
          "version": 1
        }
      }
    },
```

This PR fixes the `inbound` field parsing, and shows the proper number of inbound peers that nethermind has.

Before:
<img width="513" alt="Screenshot 2025-07-02 at 12 05 15" src="https://github.com/user-attachments/assets/c5e4e2c4-5614-4e94-a6d8-6b3ee395905d" />

After:
<img width="497" alt="Screenshot 2025-07-02 at 12 05 22" src="https://github.com/user-attachments/assets/b2874d8d-661e-4399-ba7f-2ce475fe140c" />

