### PR TITLE
feat: add sorting for consensus/execution pages

### DIFF
--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -235,18 +235,18 @@
           <table class="table table-nobr" id="clients">
             <thead>
               <tr>
-                <th>#</th>
-                <th>Name</th>
-                <th>Peers</th>
-                <th>Head Slot</th>
-                <th>Head Root</th>
-                <th>Status</th>
-                <th>Version</th>
+                <th class="sortable" data-sort="index">#</th>
+                <th class="sortable" data-sort="name">Name <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="peers">Peers <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="headslot">Head Slot <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="headroot">Head Root <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="status">Status <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="version">Version <i class="fa fa-sort"></i></th>
               </tr>
             </thead>
-              <tbody>
+              <tbody id="clientsTableBody">
                 {{ range $i, $client := .Clients }}
-                  <tr>
+                  <tr class="client-row-data" data-index="{{ $client.Index }}" data-name="{{ $client.Name }}" data-peers="{{ $client.PeerCount }}" data-headslot="{{ $client.HeadSlot }}" data-headroot="{{ printf "%x" $client.HeadRoot }}" data-status="{{ $client.Status }}" data-version="{{ $client.Version }}">
                     <td>{{ $client.Index }}</td>
                     <td>
                       <svg class="client-node-icon" data-jdenticon-value="{{ $client.PeerID }}"></svg>
@@ -1002,6 +1002,82 @@
     }
   }
 
+  // Table sorting functionality
+  var currentSortColumn = 'name';
+  var currentSortDirection = 'desc';
+
+  function sortTable(column) {
+    var tbody = document.getElementById('clientsTableBody');
+    var rows = Array.from(tbody.querySelectorAll('tr.client-row-data'));
+    
+    // Toggle sort direction if clicking the same column
+    if (currentSortColumn === column) {
+      currentSortDirection = currentSortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      currentSortDirection = 'asc';
+      currentSortColumn = column;
+    }
+    
+    // Sort rows
+    rows.sort(function(a, b) {
+      var aValue = a.getAttribute('data-' + column);
+      var bValue = b.getAttribute('data-' + column);
+      
+      // Handle numeric columns
+      if (column === 'index' || column === 'peers' || column === 'headslot') {
+        aValue = parseInt(aValue) || 0;
+        bValue = parseInt(bValue) || 0;
+      }
+      
+      // Handle status column with priority order
+      if (column === 'status') {
+        var statusOrder = { 'online': 0, 'synchronizing': 1, 'optimistic': 2, 'offline': 3 };
+        aValue = statusOrder[aValue] !== undefined ? statusOrder[aValue] : 4;
+        bValue = statusOrder[bValue] !== undefined ? statusOrder[bValue] : 4;
+      }
+      
+      if (aValue < bValue) {
+        return currentSortDirection === 'asc' ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return currentSortDirection === 'asc' ? 1 : -1;
+      }
+      return 0;
+    });
+    
+    // Update sort indicators
+    document.querySelectorAll('th.sortable i').forEach(function(icon) {
+      icon.className = 'fa fa-sort';
+    });
+    
+    var currentHeader = document.querySelector('th[data-sort="' + column + '"] i');
+    if (currentHeader) {
+      currentHeader.className = 'fa fa-sort-' + (currentSortDirection === 'asc' ? 'up' : 'down');
+    }
+    
+    // Re-append sorted rows (including their peer info rows)
+    rows.forEach(function(row) {
+      tbody.appendChild(row);
+      var peerInfoRow = row.nextElementSibling;
+      if (peerInfoRow && peerInfoRow.classList.contains('peerInfo')) {
+        tbody.appendChild(peerInfoRow);
+      }
+    });
+  }
+
+  // Add click handlers to sortable headers
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('th.sortable').forEach(function(header) {
+      header.style.cursor = 'pointer';
+      header.addEventListener('click', function() {
+        sortTable(this.getAttribute('data-sort'));
+      });
+    });
+    
+    // Set initial sort by name
+    sortTable('name');
+  });
+
 </script>
 {{ end }}
 {{ define "css" }}
@@ -1014,6 +1090,24 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+th.sortable:hover {
+  background-color: rgba(0, 123, 255, 0.1);
+}
+
+th.sortable i {
+  margin-left: 5px;
+  opacity: 0.6;
+}
+
+th.sortable:hover i {
+  opacity: 1;
 }
 </style>
 {{ end }}

--- a/templates/clients/clients_el.html
+++ b/templates/clients/clients_el.html
@@ -52,19 +52,19 @@
           <table class="table" id="clients">
             <thead>
               <tr>
-                <th>#</th>
-                <th>Name</th>
-                <th>Peers</th>
-                <th>Block</th>
-                <th>Block hash</th>
-                <th>Status</th>
-                <th>Version</th>
+                <th class="sortable" data-sort="index">#</th>
+                <th class="sortable" data-sort="name">Name <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="peers">Peers <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="block">Block <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="blockhash">Block hash <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="status">Status <i class="fa fa-sort"></i></th>
+                <th class="sortable" data-sort="version">Version <i class="fa fa-sort"></i></th>
               </tr>
             </thead>
-              <tbody>
+              <tbody id="clientsTableBody">
                 {{ $root := . }}
                 {{ range $i, $client := .Clients }}
-                  <tr>
+                  <tr class="client-row-data" data-index="{{ $client.Index }}" data-name="{{ $client.Name }}" data-peers="{{ $client.PeerCount }}" data-block="{{ $client.HeadSlot }}" data-blockhash="{{ printf "%x" $client.HeadRoot }}" data-status="{{ $client.Status }}" data-version="{{ $client.Version }}">
                     <td>{{ $client.Index }}</td>
                     <td>
                       <svg class="client-node-icon" data-jdenticon-value="{{ $client.PeerID }}"></svg>
@@ -444,6 +444,82 @@
     }
   }
 
+  // Table sorting functionality
+  var currentSortColumn = 'name';
+  var currentSortDirection = 'desc';
+
+  function sortTable(column) {
+    var tbody = document.getElementById('clientsTableBody');
+    var rows = Array.from(tbody.querySelectorAll('tr.client-row-data'));
+    
+    // Toggle sort direction if clicking the same column
+    if (currentSortColumn === column) {
+      currentSortDirection = currentSortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      currentSortDirection = 'asc';
+      currentSortColumn = column;
+    }
+    
+    // Sort rows
+    rows.sort(function(a, b) {
+      var aValue = a.getAttribute('data-' + column);
+      var bValue = b.getAttribute('data-' + column);
+      
+      // Handle numeric columns
+      if (column === 'index' || column === 'peers' || column === 'block') {
+        aValue = parseInt(aValue) || 0;
+        bValue = parseInt(bValue) || 0;
+      }
+      
+      // Handle status column with priority order
+      if (column === 'status') {
+        var statusOrder = { 'online': 0, 'synchronizing': 1, 'optimistic': 2, 'offline': 3 };
+        aValue = statusOrder[aValue] !== undefined ? statusOrder[aValue] : 4;
+        bValue = statusOrder[bValue] !== undefined ? statusOrder[bValue] : 4;
+      }
+      
+      if (aValue < bValue) {
+        return currentSortDirection === 'asc' ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return currentSortDirection === 'asc' ? 1 : -1;
+      }
+      return 0;
+    });
+    
+    // Update sort indicators
+    document.querySelectorAll('th.sortable i').forEach(function(icon) {
+      icon.className = 'fa fa-sort';
+    });
+    
+    var currentHeader = document.querySelector('th[data-sort="' + column + '"] i');
+    if (currentHeader) {
+      currentHeader.className = 'fa fa-sort-' + (currentSortDirection === 'asc' ? 'up' : 'down');
+    }
+    
+    // Re-append sorted rows (including their peer info rows)
+    rows.forEach(function(row) {
+      tbody.appendChild(row);
+      var peerInfoRow = row.nextElementSibling;
+      if (peerInfoRow && peerInfoRow.classList.contains('peerInfo')) {
+        tbody.appendChild(peerInfoRow);
+      }
+    });
+  }
+
+  // Add click handlers to sortable headers
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('th.sortable').forEach(function(header) {
+      header.style.cursor = 'pointer';
+      header.addEventListener('click', function() {
+        sortTable(this.getAttribute('data-sort'));
+      });
+    });
+    
+    // Set initial sort by name
+    sortTable('name');
+  });
+
 </script>
 {{ end }}
 {{ define "css" }}
@@ -456,6 +532,24 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+th.sortable:hover {
+  background-color: rgba(0, 123, 255, 0.1);
+}
+
+th.sortable i {
+  margin-left: 5px;
+  opacity: 0.6;
+}
+
+th.sortable:hover i {
+  opacity: 1;
 }
 </style>
 {{ end }}


### PR DESCRIPTION
This PR enables you to start sorting the consensus/execution page by any of the column properties. 
e.g: 
<img width="1671" alt="Screenshot 2025-07-07 at 10 19 25" src="https://github.com/user-attachments/assets/beb896d0-cf87-4534-afde-a41baeea6d57" />

Default behaviour did not change. 