### PR TITLE
fix: ipv6 display format

### DIFF
--- a/utils/enr.go
+++ b/utils/enr.go
@@ -91,7 +91,7 @@ func formatAttrString(v rlp.RawValue) (string, bool) {
 
 func formatAttrIP(v rlp.RawValue) (string, bool) {
 	content, _, err := rlp.SplitString(v)
-	if err != nil || len(content) != 4 && len(content) != 6 {
+	if err != nil || (len(content) != 4 && len(content) != 16) {
 		return "", false
 	}
 	return net.IP(content).String(), true


### PR DESCRIPTION
show ipv6 address like `2604:a880:400:d1:0:2:8407:b001` instead of `0x902604a880040000d1000000028407b001`