### PR TITLE
fulu-support merge cleanup

### DIFF
--- a/handlers/epoch.go
+++ b/handlers/epoch.go
@@ -115,7 +115,7 @@ func buildEpochPageData(epoch uint64) (*models.EpochPageData, time.Duration) {
 		NextEpoch:     nextEpoch,
 		Ts:            chainState.SlotToTime(chainState.EpochToSlot(phase0.Epoch(epoch))),
 		Synchronized:  syncedEpoch,
-		Finalized:     finalizedEpoch >= phase0.Epoch(epoch),
+		Finalized:     finalizedEpoch > 0 && finalizedEpoch >= phase0.Epoch(epoch),
 	}
 
 	dbEpochs := services.GlobalBeaconService.GetDbEpochs(epoch, 1)

--- a/handlers/epochs.go
+++ b/handlers/epochs.go
@@ -120,7 +120,7 @@ func buildEpochsPageData(firstEpoch uint64, pageSize uint64) (*models.EpochsPage
 	allSynchronized := true
 	for epochIdx := int64(firstEpoch); epochIdx >= 0 && epochCount < epochLimit; epochIdx-- {
 		epoch := uint64(epochIdx)
-		finalized := int64(finalizedEpoch) >= epochIdx
+		finalized := int64(finalizedEpoch) > 0 && int64(finalizedEpoch) >= epochIdx
 		if !finalized {
 			allFinalized = false
 		}
@@ -128,7 +128,7 @@ func buildEpochsPageData(firstEpoch uint64, pageSize uint64) (*models.EpochsPage
 			Epoch:     epoch,
 			Ts:        chainState.EpochToTime(phase0.Epoch(epoch)),
 			Finalized: finalized,
-			Justified: int64(justifiedEpoch) >= epochIdx,
+			Justified: justifiedEpoch > 0 && int64(justifiedEpoch) >= epochIdx,
 		}
 		if dbIdx < dbCnt && dbEpochs[dbIdx] != nil && dbEpochs[dbIdx].Epoch == epoch {
 			dbEpoch := dbEpochs[dbIdx]

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -347,8 +347,8 @@ func buildIndexPageRecentEpochsData(pageData *models.IndexPageData, currentEpoch
 		pageData.RecentEpochs = append(pageData.RecentEpochs, &models.IndexPageDataEpochs{
 			Epoch:             epochData.Epoch,
 			Ts:                chainState.EpochToTime(phase0.Epoch(epochData.Epoch)),
-			Finalized:         uint64(finalizedEpoch) >= epochData.Epoch,
-			Justified:         uint64(justifiedEpoch) >= epochData.Epoch,
+			Finalized:         uint64(finalizedEpoch) > 0 && uint64(finalizedEpoch) >= epochData.Epoch,
+			Justified:         uint64(justifiedEpoch) > 0 && uint64(justifiedEpoch) >= epochData.Epoch,
 			EligibleEther:     epochData.Eligible,
 			TargetVoted:       epochData.VotedTarget,
 			VoteParticipation: voteParticipation,

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -298,9 +298,13 @@ func (block *Block) EnsureBlock(loadBlock func() (*spec.VersionedSignedBeaconBlo
 func (block *Block) setBlockIndex(body *spec.VersionedSignedBeaconBlock) {
 	blockIndex := &BlockBodyIndex{}
 	blockIndex.Graffiti, _ = body.Graffiti()
-	blockIndex.ExecutionExtraData, _ = getBlockExecutionExtraData(body)
-	blockIndex.ExecutionHash, _ = body.ExecutionBlockHash()
-	blockIndex.ExecutionNumber, _ = body.ExecutionBlockNumber()
+
+	executionPayload, _ := body.ExecutionPayload()
+	if executionPayload != nil {
+		blockIndex.ExecutionExtraData, _ = executionPayload.ExtraData()
+		blockIndex.ExecutionHash, _ = executionPayload.BlockHash()
+		blockIndex.ExecutionNumber, _ = executionPayload.BlockNumber()
+	}
 
 	// Calculate sync participation
 	syncAggregate, err := body.SyncAggregate()

--- a/indexer/beacon/block_helper.go
+++ b/indexer/beacon/block_helper.go
@@ -207,44 +207,6 @@ func unmarshalVersionedSignedBeaconBlockJson(version uint64, ssz []byte) (*spec.
 	return block, nil
 }
 
-// getBlockExecutionExtraData returns the extra data from the execution payload of a versioned signed beacon block.
-func getBlockExecutionExtraData(v *spec.VersionedSignedBeaconBlock) ([]byte, error) {
-	switch v.Version {
-	case spec.DataVersionBellatrix:
-		if v.Bellatrix == nil || v.Bellatrix.Message == nil || v.Bellatrix.Message.Body == nil || v.Bellatrix.Message.Body.ExecutionPayload == nil {
-			return nil, errors.New("no bellatrix block")
-		}
-
-		return v.Bellatrix.Message.Body.ExecutionPayload.ExtraData, nil
-	case spec.DataVersionCapella:
-		if v.Capella == nil || v.Capella.Message == nil || v.Capella.Message.Body == nil || v.Capella.Message.Body.ExecutionPayload == nil {
-			return nil, errors.New("no capella block")
-		}
-
-		return v.Capella.Message.Body.ExecutionPayload.ExtraData, nil
-	case spec.DataVersionDeneb:
-		if v.Deneb == nil || v.Deneb.Message == nil || v.Deneb.Message.Body == nil || v.Deneb.Message.Body.ExecutionPayload == nil {
-			return nil, errors.New("no deneb block")
-		}
-
-		return v.Deneb.Message.Body.ExecutionPayload.ExtraData, nil
-	case spec.DataVersionElectra:
-		if v.Electra == nil || v.Electra.Message == nil || v.Electra.Message.Body == nil || v.Electra.Message.Body.ExecutionPayload == nil {
-			return nil, errors.New("no electra block")
-		}
-
-		return v.Electra.Message.Body.ExecutionPayload.ExtraData, nil
-	case spec.DataVersionFulu:
-		if v.Fulu == nil || v.Fulu.Message == nil || v.Fulu.Message.Body == nil || v.Fulu.Message.Body.ExecutionPayload == nil {
-			return nil, errors.New("no fulu block")
-		}
-
-		return v.Fulu.Message.Body.ExecutionPayload.ExtraData, nil
-	default:
-		return nil, errors.New("unknown version")
-	}
-}
-
 // getStateRandaoMixes returns the RANDAO mixes from a versioned beacon state.
 func getStateRandaoMixes(v *spec.VersionedBeaconState) ([]phase0.Root, error) {
 	switch v.Version {
@@ -477,6 +439,32 @@ func getStatePendingConsolidations(v *spec.VersionedBeaconState) ([]*electra.Pen
 		}
 
 		return v.Fulu.PendingConsolidations, nil
+	default:
+		return nil, errors.New("unknown version")
+	}
+}
+
+// getStateProposerLookahead returns the proposer lookahead from a versioned beacon state.
+func getStateProposerLookahead(v *spec.VersionedBeaconState) ([]phase0.ValidatorIndex, error) {
+	switch v.Version {
+	case spec.DataVersionPhase0:
+		return nil, errors.New("no proposer lookahead in phase0")
+	case spec.DataVersionAltair:
+		return nil, errors.New("no proposer lookahead in altair")
+	case spec.DataVersionBellatrix:
+		return nil, errors.New("no proposer lookahead in bellatrix")
+	case spec.DataVersionCapella:
+		return nil, errors.New("no proposer lookahead in capella")
+	case spec.DataVersionDeneb:
+		return nil, errors.New("no proposer lookahead in deneb")
+	case spec.DataVersionElectra:
+		return nil, errors.New("no proposer lookahead in electra")
+	case spec.DataVersionFulu:
+		if v.Fulu == nil || v.Fulu.ProposerLookahead == nil {
+			return nil, errors.New("no fulu block")
+		}
+
+		return v.Fulu.ProposerLookahead, nil
 	default:
 		return nil, errors.New("unknown version")
 	}

--- a/indexer/beacon/epochstate.go
+++ b/indexer/beacon/epochstate.go
@@ -32,6 +32,7 @@ type epochState struct {
 	pendingDeposits           []*electra.PendingDeposit
 	pendingPartialWithdrawals []*electra.PendingPartialWithdrawal
 	pendingConsolidations     []*electra.PendingConsolidation
+	proposerLookahead         []phase0.ValidatorIndex
 }
 
 // newEpochState creates a new epochState instance with the root of the state to be loaded.
@@ -225,6 +226,9 @@ func (s *epochState) processState(state *spec.VersionedBeaconState, cache *epoch
 		// apply epoch transition to get remaining pending consolidations
 		s.pendingConsolidations = pendingConsolidations
 	}
+
+	proposerLookahead, _ := getStateProposerLookahead(state)
+	s.proposerLookahead = proposerLookahead
 
 	return nil
 }

--- a/indexer/beacon/epochstats.go
+++ b/indexer/beacon/epochstats.go
@@ -441,17 +441,17 @@ func (es *EpochStats) processState(indexer *Indexer, validatorSet []*phase0.Vali
 		values.ProposerDuties = proposerDuties
 	}
 
-	if beaconState.RandaoMix != nil {
-		values.RandaoMix = *beaconState.RandaoMix
-		values.NextRandaoMix = *beaconState.NextRandaoMix
-	}
-
 	// compute committees
 	attesterDuties, err := duties.GetAttesterDuties(chainState.GetSpecs(), beaconState, es.epoch)
 	if err != nil {
 		indexer.logger.Warnf("failed computing attester duties for epoch %v: %v", es.epoch, err)
 	}
 	values.AttesterDuties = attesterDuties
+
+	if beaconState.RandaoMix != nil {
+		values.RandaoMix = *beaconState.RandaoMix
+		values.NextRandaoMix = *beaconState.NextRandaoMix
+	}
 
 	es.values = values
 	es.precalcValues = nil

--- a/indexer/beacon/epochstats.go
+++ b/indexer/beacon/epochstats.go
@@ -415,7 +415,7 @@ func (es *EpochStats) processState(indexer *Indexer, validatorSet []*phase0.Vali
 	indexer.logger.Debugf("processing epoch %v stats (root: %v / state: %v), validators: %v/%v", es.epoch, es.dependentRoot.String(), dependentState.stateRoot.String(), values.ActiveValidators, len(validatorSet))
 
 	// compute proposers
-	if len(dependentState.proposerLookahead) > 0 && (es.epoch == chainState.EpochOfSlot(dependentState.stateSlot) || es.epoch == chainState.EpochOfSlot(dependentState.stateSlot)+2) {
+	if len(dependentState.proposerLookahead) > 0 && (es.epoch == chainState.EpochOfSlot(dependentState.stateSlot) || es.epoch == chainState.EpochOfSlot(dependentState.stateSlot)+1) {
 		slotsPerEpoch := chainState.GetSpecs().SlotsPerEpoch
 		offset := uint64(0)
 		if es.epoch == chainState.EpochOfSlot(dependentState.stateSlot)+1 {

--- a/indexer/beacon/epochstats.go
+++ b/indexer/beacon/epochstats.go
@@ -415,21 +415,32 @@ func (es *EpochStats) processState(indexer *Indexer, validatorSet []*phase0.Vali
 	indexer.logger.Debugf("processing epoch %v stats (root: %v / state: %v), validators: %v/%v", es.epoch, es.dependentRoot.String(), dependentState.stateRoot.String(), values.ActiveValidators, len(validatorSet))
 
 	// compute proposers
-	proposerDuties := []phase0.ValidatorIndex{}
-	for slot := chainState.EpochToSlot(es.epoch); slot < chainState.EpochToSlot(es.epoch+1); slot++ {
-		proposer, err := duties.GetProposerIndex(chainState.GetSpecs(), beaconState, slot)
-		proposerIndex := phase0.ValidatorIndex(math.MaxInt64)
-		if err != nil {
-			indexer.logger.Warnf("failed computing proposer for slot %v: %v", slot, err)
-			proposerIndex = math.MaxInt64
-		} else {
-			proposerIndex = values.ActiveIndices[proposer]
+	if len(dependentState.proposerLookahead) > 0 && (es.epoch == chainState.EpochOfSlot(dependentState.stateSlot) || es.epoch == chainState.EpochOfSlot(dependentState.stateSlot)+2) {
+		slotsPerEpoch := chainState.GetSpecs().SlotsPerEpoch
+		offset := uint64(0)
+		if es.epoch == chainState.EpochOfSlot(dependentState.stateSlot)+1 {
+			offset = slotsPerEpoch
 		}
 
-		proposerDuties = append(proposerDuties, proposerIndex)
+		values.ProposerDuties = dependentState.proposerLookahead[offset : offset+slotsPerEpoch]
+	} else {
+		proposerDuties := []phase0.ValidatorIndex{}
+		for slot := chainState.EpochToSlot(es.epoch); slot < chainState.EpochToSlot(es.epoch+1); slot++ {
+			proposer, err := duties.GetProposerIndex(chainState.GetSpecs(), beaconState, slot)
+			proposerIndex := phase0.ValidatorIndex(math.MaxInt64)
+			if err != nil {
+				indexer.logger.Warnf("failed computing proposer for slot %v: %v", slot, err)
+				proposerIndex = math.MaxInt64
+			} else {
+				proposerIndex = values.ActiveIndices[proposer]
+			}
+
+			proposerDuties = append(proposerDuties, proposerIndex)
+		}
+
+		values.ProposerDuties = proposerDuties
 	}
 
-	values.ProposerDuties = proposerDuties
 	if beaconState.RandaoMix != nil {
 		values.RandaoMix = *beaconState.RandaoMix
 		values.NextRandaoMix = *beaconState.NextRandaoMix

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -5,6 +5,8 @@ import (
 	"math"
 
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/dora/clients/consensus"
@@ -243,12 +245,22 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 	proposerSlashings, _ := blockBody.ProposerSlashings()
 	blsToExecChanges, _ := blockBody.BLSToExecutionChanges()
 	syncAggregate, _ := blockBody.SyncAggregate()
-	executionBlockNumber, _ := blockBody.ExecutionBlockNumber()
-	executionBlockHash, _ := blockBody.ExecutionBlockHash()
-	executionExtraData, _ := getBlockExecutionExtraData(blockBody)
-	executionTransactions, _ := blockBody.ExecutionTransactions()
-	executionWithdrawals, _ := blockBody.Withdrawals()
 	blobKzgCommitments, _ := blockBody.BlobKZGCommitments()
+
+	var executionExtraData []byte
+	var executionBlockNumber uint64
+	var executionBlockHash phase0.Hash32
+	var executionTransactions []bellatrix.Transaction
+	var executionWithdrawals []*capella.Withdrawal
+
+	executionPayload, _ := blockBody.ExecutionPayload()
+	if executionPayload != nil {
+		executionExtraData, _ = executionPayload.ExtraData()
+		executionBlockHash, _ = executionPayload.BlockHash()
+		executionBlockNumber, _ = executionPayload.BlockNumber()
+		executionTransactions, _ = executionPayload.Transactions()
+		executionWithdrawals, _ = executionPayload.Withdrawals()
+	}
 
 	var depositRequests []*electra.DepositRequest
 

--- a/templates/slot/attestations.html
+++ b/templates/slot/attestations.html
@@ -321,27 +321,35 @@
     document.addEventListener('mouseover', function(e) {
       if (e.target.classList.contains('committee-badge')) {
         const committeeIdx = e.target.getAttribute('data-committee-idx');
-        // Highlight corresponding aggregation bits
-        document.querySelectorAll(`.committee-idx-${committeeIdx}`).forEach(bit => {
-          bit.classList.add('aggregation-bit-highlighted');
-        });
+        // Find the parent attestation card
+        const attestationCard = e.target.closest('.card');
+        if (attestationCard) {
+          // Highlight corresponding aggregation bits within this attestation only
+          attestationCard.querySelectorAll(`.committee-idx-${committeeIdx}`).forEach(bit => {
+            bit.classList.add('aggregation-bit-highlighted');
+          });
+        }
       }
       
       // Handle hover on aggregation bits
       if (e.target.classList.contains('aggregation-bit')) {
-        // Find the committee index from the class
-        const classes = Array.from(e.target.classList);
-        const committeeClass = classes.find(c => c.startsWith('committee-idx-'));
-        if (committeeClass) {
-          const committeeIdx = committeeClass.replace('committee-idx-', '');
-          // Highlight all bits with same committee index
-          document.querySelectorAll(`.${committeeClass}`).forEach(bit => {
-            bit.classList.add('aggregation-bit-highlighted');
-          });
-          // Highlight corresponding badge
-          document.querySelectorAll(`[data-committee-idx="${committeeIdx}"]`).forEach(badge => {
-            badge.classList.add('committee-badge-highlighted');
-          });
+        // Find the parent attestation card
+        const attestationCard = e.target.closest('.card');
+        if (attestationCard) {
+          // Find the committee index from the class
+          const classes = Array.from(e.target.classList);
+          const committeeClass = classes.find(c => c.startsWith('committee-idx-'));
+          if (committeeClass) {
+            const committeeIdx = committeeClass.replace('committee-idx-', '');
+            // Highlight all bits with same committee index within this attestation only
+            attestationCard.querySelectorAll(`.${committeeClass}`).forEach(bit => {
+              bit.classList.add('aggregation-bit-highlighted');
+            });
+            // Highlight corresponding badge within this attestation only
+            attestationCard.querySelectorAll(`[data-committee-idx="${committeeIdx}"]`).forEach(badge => {
+              badge.classList.add('committee-badge-highlighted');
+            });
+          }
         }
       }
     });
@@ -350,21 +358,29 @@
     document.addEventListener('mouseout', function(e) {
       if (e.target.classList.contains('committee-badge')) {
         const committeeIdx = e.target.getAttribute('data-committee-idx');
-        // Remove highlight from aggregation bits
-        document.querySelectorAll(`.committee-idx-${committeeIdx}`).forEach(bit => {
-          bit.classList.remove('aggregation-bit-highlighted');
-        });
+        // Find the parent attestation card
+        const attestationCard = e.target.closest('.card');
+        if (attestationCard) {
+          // Remove highlight from aggregation bits within this attestation only
+          attestationCard.querySelectorAll(`.committee-idx-${committeeIdx}`).forEach(bit => {
+            bit.classList.remove('aggregation-bit-highlighted');
+          });
+        }
       }
       
       // Handle hover out on aggregation bits
       if (e.target.classList.contains('aggregation-bit')) {
-        // Remove all highlights
-        document.querySelectorAll('.aggregation-bit-highlighted').forEach(bit => {
-          bit.classList.remove('aggregation-bit-highlighted');
-        });
-        document.querySelectorAll('.committee-badge-highlighted').forEach(badge => {
-          badge.classList.remove('committee-badge-highlighted');
-        });
+        // Find the parent attestation card
+        const attestationCard = e.target.closest('.card');
+        if (attestationCard) {
+          // Remove all highlights within this attestation only
+          attestationCard.querySelectorAll('.aggregation-bit-highlighted').forEach(bit => {
+            bit.classList.remove('aggregation-bit-highlighted');
+          });
+          attestationCard.querySelectorAll('.committee-badge-highlighted').forEach(badge => {
+            badge.classList.remove('committee-badge-highlighted');
+          });
+        }
       }
     });
   });


### PR DESCRIPTION
code cleanup & small fixes related to fulu-support merge:
* fixed aggregation bit highlighting with multiple attestations (rel #441)
* fixed epoch 0 always being shown as finalized, even before genesis (rel #411)
* use new proposer lookahead from fulu states to skip local proposer calculation
* use new versioned execution payload wrapper from go-eth2-client to avoid fork specific switch case patterns