### PR TITLE
fix panic when parsing legacy tx without chainid

### DIFF
--- a/indexer/execution/contract_indexer.go
+++ b/indexer/execution/contract_indexer.go
@@ -267,7 +267,11 @@ func (ci *contractIndexer[TxType]) processFinalizedBlocks(finalizedBlockNumber u
 			}
 
 			// get transaction sender
-			txFrom, err := types.Sender(types.LatestSignerForChainID(txDetails.ChainId()), txDetails)
+			chainId := txDetails.ChainId()
+			if chainId != nil && chainId.Cmp(big.NewInt(0)) == 0 {
+				chainId = nil
+			}
+			txFrom, err := types.Sender(types.LatestSignerForChainID(chainId), txDetails)
 			if err != nil {
 				return fmt.Errorf("could not decode tx sender (%v): %v", log.TxHash, err)
 			}


### PR DESCRIPTION
fix for a panic as observed on https://dora.hoodi.ethpandaops.io/:
```
panic: invalid chainID 0 [recovered]
	panic: interface conversion: string is not error: missing method Error

goroutine 481 [running]:
github.com/ethpandaops/dora/utils.HandleSubroutinePanic({0x25aa1cd, 0x24}, 0xc01843af80)
	/home/runner/work/dora/dora/utils/process.go:21 +0x94
panic({0x212f500?, 0xc02dcf8aa0?})
	/opt/hostedtoolcache/go/1.24.5/x64/src/runtime/panic.go:792 +0x132
github.com/ethereum/go-ethereum/core/types.newModernSigner(0xfe2177?, 0xc02dcf8a40?)
	/home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.15.11/core/types/transaction_signing.go:193 +0x24c
github.com/ethereum/go-ethereum/core/types.NewPragueSigner(...)
	/home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.15.11/core/types/transaction_signing.go:287
github.com/ethereum/go-ethereum/core/types.LatestSignerForChainID(0x2f89d6320d2744f2?)
	/home/runner/go/pkg/mod/github.com/ethereum/go-ethereum@v1.15.11/core/types/transaction_signing.go:103 +0x2e
github.com/ethpandaops/dora/indexer/execution.(*contractIndexer[...]).processFinalizedBlocks(0x45f8480, 0xf4b5a)
	/home/runner/work/dora/dora/indexer/execution/contract_indexer.go:270 +0xc4c
github.com/ethpandaops/dora/indexer/execution.(*contractIndexer[...]).runContractIndexer(0x45f8480)
	/home/runner/work/dora/dora/indexer/execution/contract_indexer.go:125 +0x90
github.com/ethpandaops/dora/indexer/execution.(*DepositIndexer).runDepositIndexerLoop(0xc000339980)
	/home/runner/work/dora/dora/indexer/execution/deposit_indexer.go:97 +0xc7
created by github.com/ethpandaops/dora/indexer/execution.NewDepositIndexer in goroutine 1
	/home/runner/work/dora/dora/indexer/execution/deposit_indexer.go:84 +0x65c
```

panic was triggered by a legacy (non replay protected) tx, which does not have a chainId.
The `tx.ChainId()` method returns chainId 0 in this case, which is an invalid value for `LatestSignerForChainID()`.
