### PR TITLE
improve AI generated release notes

### DIFF
--- a/.github/scripts/ai-release-notes.sh
+++ b/.github/scripts/ai-release-notes.sh
@@ -1,14 +1,117 @@
 #!/bin/bash
 
-# Sanitize the changelog by escaping backticks to prevent command execution
-changelog_safe="${1//\`/\\\`}"
+previous_tag="${1}"
 
-previous_release_notes=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -c '.[0:8][] | {"body": .body, "name": .name}')
+# Get merge commits only
+if [ "$previous_tag" ]; then
+    merge_commits=$(git log --oneline --merges --first-parent --no-decorate $previous_tag..HEAD)
+else 
+    merge_commits=$(git log --oneline --merges --first-parent --no-decorate)
+fi
+
+# Extract PR numbers from merge commits
+pr_numbers=$(echo "$merge_commits" | grep -oP '(?<=Merge pull request #)\d+' | sort -u)
+
+# Convert PR numbers to array
+pr_array=($pr_numbers)
+
+# Fetch PR details from GitHub API using GraphQL for batching
+pr_details=""
+if [ ${#pr_array[@]} -gt 0 ]; then
+    # Split repository into owner and name
+    IFS='/' read -r repo_owner repo_name <<< "$GITHUB_REPOSITORY"
+    
+    # Process PRs in batches of 50 (GraphQL limit)
+    batch_size=50
+    for ((i=0; i<${#pr_array[@]}; i+=batch_size)); do
+        # Build GraphQL query for batch
+        graphql_query="query {"
+        batch_end=$((i + batch_size))
+        if [ $batch_end -gt ${#pr_array[@]} ]; then
+            batch_end=${#pr_array[@]}
+        fi
+        
+        for ((j=i; j<batch_end; j++)); do
+            pr_num=${pr_array[j]}
+            graphql_query="${graphql_query} pr${pr_num}: repository(owner: \"${repo_owner}\", name: \"${repo_name}\") { pullRequest(number: ${pr_num}) { number title body author { login } } }"
+        done
+        graphql_query="${graphql_query} }"
+        
+        # Execute GraphQL query
+        graphql_response=$(curl -s -X POST \
+            -H "Authorization: bearer $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\": \"$(echo $graphql_query | sed 's/"/\\"/g')\"}" \
+            "https://api.github.com/graphql")
+        
+        # Parse response
+        if [ -f ./pr-details.txt ]; then
+            rm ./pr-details.txt
+        fi
+        for ((j=i; j<batch_end; j++)); do
+            pr_num=${pr_array[j]}
+            pr_data=$(echo "$graphql_response" | jq -r ".data.pr${pr_num}.pullRequest")
+            
+            if [ "$pr_data" != "null" ]; then
+                pr_title=$(echo "$pr_data" | jq -r '.title // empty')
+                pr_body=$(echo "$pr_data" | jq -r '.body // empty' | head -n 20)
+                pr_user=$(echo "$pr_data" | jq -r '.author.login // "unknown"')
+                
+                if [ -n "$pr_title" ]; then
+                    echo "PR #${pr_num}: ${pr_title} (by @${pr_user})" >> ./pr-details.txt
+                    if [ -n "$pr_body" ] && [ "$pr_body" != "null" ]; then
+                        # Remove HTML tags and limit to 512 characters
+                        pr_body_clean=$(echo "$pr_body" | sed -e 's/<[^>]*>//g' -e 's/&nbsp;/ /g' -e 's/&quot;/"/g' -e 's/&amp;/\&/g' -e 's/&lt;/</g' -e 's/&gt;/>/g' | tr '\n' ' ' | sed 's/  */ /g' | cut -c1-512)
+                        if [ -n "$pr_body_clean" ]; then
+                            echo "  ${pr_body_clean}..." >> ./pr-details.txt
+                        fi
+                    fi
+                    echo "" >> ./pr-details.txt
+                fi
+            fi
+        done
+    done
+fi
+
+# Create a minified changelog combining merge commits and PR details
+minified_changelog=$(cat <<EOF
+Merged Pull Requests:
+${merge_commits}
+
+Pull Request Details:
+$(cat ./pr-details.txt)
+EOF
+)
+rm ./pr-details.txt
+
+# Sanitize the changelog by escaping backticks to prevent command execution
+changelog_safe="${minified_changelog//\`/\\\`}"
+
+# Fetch previous release notes in a more readable format, removing everything after <details>
+# Only include non-prerelease and non-draft versions, limit to 5 releases
+previous_releases=""
+release_count=0
+while IFS= read -r release; do
+    if [ $release_count -ge 5 ]; then
+        break
+    fi
+    name=$(echo "$release" | jq -r '.name')
+    body=$(echo "$release" | jq -r '.body' | sed '/<details>/,$d' | sed 's/[[:space:]]*$//')
+    if [ -n "$body" ]; then
+        previous_releases="${previous_releases}$(echo -e "\nRelease: ${name}\n${body}\n---\n")"
+        ((release_count++))
+    fi
+done < <(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/releases | jq -c '.[] | select(.prerelease == false and .draft == false)')
+previous_release_notes=$(echo -e "Recent releases for reference:\n${previous_releases}")
 
 conv=$(cat <<EOF
 You are a helpful assistant that generates release notes for a software project.
-You will be given a changelog and you will need to generate release notes for the following changelog:
+You will be given a changelog with merged pull requests and their details.
+
 $changelog_safe
+
+Based on the PR titles and descriptions above, generate concise release notes highlighting the most important changes.
+Focus on user-facing features, bug fixes, and breaking changes.
 
 The release notes will be embedded in the following format:
 ### Major Changes
@@ -18,14 +121,23 @@ The release notes will be embedded in the following format:
 ...
 </details>
 
-Avoid long release notes. Keep it short and concise, a few bullet points (max 5-6). Use markdown formatting if needed.
+Guidelines:
+- Keep it short and concise, maximum 5-6 bullet points
+- Prioritize user-facing changes and important bug fixes
+- Group similar changes together when possible
+- Use clear, non-technical language when possible
+- Use markdown formatting
+
 Do NOT respond with suggestions! The response will be processed programmatically and embedded in the release notes.
 Do NOT include the details tag or content in the response. Do NOT include the Major Changes header in the response.
 
-Previous release notes:
+Previous release notes for context:
 $previous_release_notes
 EOF
 )
+
+#echo "$conv"
+#exit 0
 
 conv_json=$(echo "$conv" | jq -R -s '{"model": "'"$OPENROUTER_MODEL"'", "messages": [{"role": "user", "content": .}]}')
 conv_response=$(curl -X POST -H "Authorization: Bearer $OPENROUTER_TOKEN" -H "Content-Type: application/json" -d "$conv_json" https://openrouter.ai/api/v1/chat/completions)

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -60,13 +60,13 @@ jobs:
         fi
         echo "changelog<<EOF" >> $GITHUB_OUTPUT
         echo " - ${changelog//$'\n'/$'\n' - }" >> $GITHUB_OUTPUT
-        echo " - ${changelog//$'\n'/$'\n' - }" >> ./generated_changelog.txt
         echo "EOF" >> $GITHUB_OUTPUT
+        echo "prev_tag=$prev_tag" >> $GITHUB_OUTPUT
 
     - name: "Generate AI release notes"
       id: ai_release_notes
       run: |
-        ./.github/scripts/ai-release-notes.sh "$(cat ./generated_changelog.txt)"
+        ./.github/scripts/ai-release-notes.sh "${{ steps.changelog.outputs.prev_tag }}"
       env:
         OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL }}
         OPENROUTER_TOKEN: ${{ secrets.OPENROUTER_TOKEN }}


### PR DESCRIPTION
rel #477 

AI didn't get enough context to generate proper release notes from the branch names only.
I've extended the AI query by additional PR titles & descriptions and structured the query properly.
This version now generates proper notes (example for 1.19.0 release): [[changeset](https://github.com/ethpandaops/dora/compare/v1.18.3...v1.19.0)]

```
release_notes<<EOF
* Added comprehensive v1 API endpoints with JWT authentication and rate limiting (#473)
* Introduced new UI pages for consolidation, withdrawal, and exit queue details (#474)
* Fixed endpoint URL issues and improved casing consistency (#471, #472)
* Added EL chain config handling and blob base fee calculation visualization (#467)
* Implemented optional validator summary page (#466)
EOF

release_notes<<EOF
* Implement comprehensive v1 API endpoints with JWT authentication and rate limiting (#473)
* Add new UI pages for consolidation/withdrawal/exit queue details (#474)
* Fix endpoint URL issues and casing (#471, #472)
* Add EL chain config handling and blob base fee visualization (#467)
* Dependency updates across UI and backend packages (#468, #469, #475, #476)
EOF

release_notes<<EOF
* Added new UI overview pages for consolidation, withdrawal, and exit queues with detailed stats and previews (#474)  
* Implemented comprehensive v1 API endpoints with advanced authentication and rate limiting (#473)  
* Enhanced Execution Layer (EL) chain config handling and visualization, including blob base fee calculations (#467)  
* Fixed endpoint URL casing and related issues (#471, #472)  
* Updated dependencies for improved stability and security (#468, #469, #475, #476)
EOF
```