### PR TITLE
ignore dummy el

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ui-package /app
 RUN npm run build
 
 # go build env
-FROM golang:1.25.0 AS go-env
+FROM golang:1.25.1 AS go-env
 COPY go.mod go.sum /src/
 WORKDIR /src
 RUN go mod download

--- a/services/chainservice.go
+++ b/services/chainservice.go
@@ -199,6 +199,12 @@ func (cs *ChainService) StartService() error {
 
 	// add execution clients
 	for _, endpoint := range utils.Config.ExecutionApi.Endpoints {
+		// Skip dummy execution clients (they don't respond to RPC calls)
+		if strings.Contains(strings.ToLower(endpoint.Name), "dummy") {
+			cs.logger.Debugf("skipping dummy execution client '%v'", endpoint.Name)
+			continue
+		}
+
 		// Apply authGroup settings if configured
 		processedEndpoint, err := applyAuthGroupToEndpoint(&endpoint)
 		if err != nil {


### PR DESCRIPTION
running with dummy ELs we get some annoying warn messages:
```sh
time="2026-01-09T15:55:01Z" level=warning msg="error updating node metadata: error while fetching node version: 422 Unprocessable Entity: Failed to deserialize the JSON body into the target type: missing field `params` at line 1 column 55" client=3-dummy-lighthouse service=el-pool
time="2026-01-09T15:55:01Z" level=warning msg="execution client error: error while fetching specs: 422 Unprocessable Entity: Failed to deserialize the JSON body into the target type: missing field `params` at line 1 column 48, retrying in 60 sec..." client=3-dummy-lighthouse service=el-pool
```