### PR TITLE
fix: attach exec times to blocks after gloas payload arrives

### DIFF
--- a/indexer/beacon/client.go
+++ b/indexer/beacon/client.go
@@ -460,31 +460,7 @@ func (c *Client) processBlock(slot phase0.Slot, root phase0.Root, header *phase0
 		c.indexer.blockCache.addBlockToParentMap(block)
 		c.indexer.blockCache.addBlockToExecBlockMap(block)
 
-		// Check for cached execution times and add them to the block
-		blockIndex := block.GetBlockIndex(c.indexer.ctx)
-		if blockIndex != nil && !bytes.Equal(blockIndex.ExecutionHash[:], zeroHash[:]) {
-			executionHash := common.Hash(blockIndex.ExecutionHash)
-			cachedTimes := c.indexer.executionTimeProvider.GetAndDeleteExecutionTimes(executionHash)
-			for _, cachedTime := range cachedTimes {
-				// Convert the cached time to beacon ExecutionTime format
-				client := cachedTime.GetClient()
-				execTime := ExecutionTime{
-					ClientType: client.GetClientType().Uint8(),
-					MinTime:    cachedTime.GetTime(),
-					MaxTime:    cachedTime.GetTime(),
-					AvgTime:    cachedTime.GetTime(),
-					Count:      1,
-				}
-				block.AddExecutionTime(c.indexer.ctx, execTime)
-			}
-			if len(cachedTimes) > 0 {
-				c.logger.WithFields(map[string]interface{}{
-					"slot":           block.Slot,
-					"execution_hash": executionHash.Hex(),
-					"times_count":    len(cachedTimes),
-				}).Debug("Added cached execution times to block")
-			}
-		}
+		c.drainCachedExecutionTimes(block)
 
 		t1 := time.Now()
 
@@ -654,9 +630,54 @@ func (c *Client) processExecutionPayloadAvailableEvent(executionPayloadEvent *v1
 		if err != nil {
 			return err
 		}
+
+		// In EIP-7732 the body and the payload arrive on separate gossip topics.
+		// When the body arrives first, processBlock ran addBlockToExecBlockMap
+		// while ExecutionHash was still zero (the payload populates it via
+		// setBlockIndex), so the block was skipped and stayed invisible to
+		// execution-hash lookups (most notably the snooper exec-time matcher).
+		// Now that EnsureExecutionPayload populated ExecutionHash, register the
+		// block and drain any exec times the snooper cached in the meantime.
+		if executionPayloadEvent.Slot >= finalizedSlot {
+			c.indexer.blockCache.addBlockToExecBlockMap(block)
+			c.drainCachedExecutionTimes(block)
+		}
 	}
 
 	return nil
+}
+
+// drainCachedExecutionTimes attaches any execution times the snooper cached
+// for this block's execution payload hash. Safe to call multiple times:
+// GetAndDeleteExecutionTimes removes entries on read.
+func (c *Client) drainCachedExecutionTimes(block *Block) {
+	blockIndex := block.GetBlockIndex(c.indexer.ctx)
+	if blockIndex == nil || bytes.Equal(blockIndex.ExecutionHash[:], zeroHash[:]) {
+		return
+	}
+
+	executionHash := common.Hash(blockIndex.ExecutionHash)
+	cachedTimes := c.indexer.executionTimeProvider.GetAndDeleteExecutionTimes(executionHash)
+	if len(cachedTimes) == 0 {
+		return
+	}
+
+	for _, cachedTime := range cachedTimes {
+		client := cachedTime.GetClient()
+		block.AddExecutionTime(c.indexer.ctx, ExecutionTime{
+			ClientType: client.GetClientType().Uint8(),
+			MinTime:    cachedTime.GetTime(),
+			MaxTime:    cachedTime.GetTime(),
+			AvgTime:    cachedTime.GetTime(),
+			Count:      1,
+		})
+	}
+
+	c.logger.WithFields(logrus.Fields{
+		"slot":           block.Slot,
+		"execution_hash": executionHash.Hex(),
+		"times_count":    len(cachedTimes),
+	}).Debug("attached cached execution times to block")
 }
 
 func (c *Client) persistExecutionPayload(block *Block) error {


### PR DESCRIPTION
## Summary

- Exec Time column was empty for every post-gloas slot because the snooper could never match its `engine_newPayloadV5` timings to the corresponding beacon block.
- Root cause: in EIP-7732 the beacon block body no longer carries the execution payload. The body arrives first on its own gossip topic, so `processBlock` runs `addBlockToExecBlockMap` while `blockIndex.ExecutionHash` is still zero, and the zero-hash guard skips it. When the payload later lands via `execution_payload_available`, `setBlockIndex` populates the hash but `addBlockToExecBlockMap` is never called again — the block stays absent from `execBlockMap`, and the snooper's `GetBlocksByExecutionBlockHash` lookup always misses. The exec time gets parked in the 5-minute fallback cache and expires unused.
- Fix: in `processExecutionPayloadAvailableEvent`, once `EnsureExecutionPayload` has populated `ExecutionHash`, call `addBlockToExecBlockMap(block)` so the block becomes findable, and drain any exec times the snooper cached for that hash while the block was missing.
- The drain-from-cache logic is factored out of `processBlock` into `drainCachedExecutionTimes` so both code paths share it.

## Test plan

- [x] Build & vet clean (`go build ./... && go vet ./...`)
- [x] Run a kurtosis devnet with `gloas_fork_epoch: 1` and `snooper_enabled: true`, confirm the Exec Time column populates for slots in epoch 1+ (previously only epoch 0 had values)
- [x] Confirm pre-gloas behaviour unchanged (epoch 0 still shows exec times)
- [x] Verify no regressions in the per-block detail view's exec-time breakdown