### PR TITLE
feat(das-guardian): surface Gloas proposer preferences in scan modal

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2947,6 +2947,10 @@ const docTemplate = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "wait_for_proposer_preferences_seconds": {
+                    "description": "WaitForProposerPreferencesSeconds, if \u003e 0, keeps the Gloas\n` + "`" + `proposer_preferences` + "`" + ` gossip subscription open for this many seconds\nafter the RPC exchange so the gossip mesh has time to deliver messages.\nCapped at 60s server-side. Ignored on pre-Gloas forks.",
+                    "type": "integer"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2901,6 +2901,32 @@ const docTemplate = `{
                 }
             }
         },
+        "api.APIDasGuardianProposerPreference": {
+            "type": "object",
+            "properties": {
+                "dependent_root": {
+                    "type": "string"
+                },
+                "fee_recipient": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "proposal_slot": {
+                    "type": "integer"
+                },
+                "received_at": {
+                    "type": "string"
+                },
+                "validator_index": {
+                    "type": "integer"
+                }
+            }
+        },
         "api.APIDasGuardianScanRequest": {
             "type": "object",
             "properties": {
@@ -2953,6 +2979,13 @@ const docTemplate = `{
                     "description": "P2P Information",
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proposer_preferences": {
+                    "description": "Gloas SignedProposerPreferences sniffed off the peer's gossip during\nthe scan window. Empty pre-Gloas, or when no proposer published in time.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.APIDasGuardianProposerPreference"
+                    }
                 },
                 "remote_metadata": {
                     "description": "Metadata (from RemoteMetadata)",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2886,6 +2886,10 @@ const docTemplate = `{
                     "items": {
                         "type": "integer"
                     }
+                },
+                "wait_for_proposer_preferences_seconds": {
+                    "description": "WaitForProposerPreferencesSeconds, if \u003e 0, keeps the Gloas\n` + "`" + `proposer_preferences` + "`" + ` gossip subscription open for this many seconds\nafter the RPC exchange so the gossip mesh has time to deliver messages.\nCapped at 60s server-side. Ignored on pre-Gloas forks.",
+                    "type": "integer"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2840,6 +2840,32 @@ const docTemplate = `{
                 }
             }
         },
+        "api.APIDasGuardianProposerPreference": {
+            "type": "object",
+            "properties": {
+                "dependent_root": {
+                    "type": "string"
+                },
+                "fee_recipient": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "proposal_slot": {
+                    "type": "integer"
+                },
+                "received_at": {
+                    "type": "string"
+                },
+                "validator_index": {
+                    "type": "integer"
+                }
+            }
+        },
         "api.APIDasGuardianScanRequest": {
             "type": "object",
             "properties": {
@@ -2892,6 +2918,13 @@ const docTemplate = `{
                     "description": "P2P Information",
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proposer_preferences": {
+                    "description": "Gloas SignedProposerPreferences sniffed off the peer's gossip during\nthe scan window. Empty pre-Gloas, or when no proposer published in time.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.APIDasGuardianProposerPreference"
+                    }
                 },
                 "remote_metadata": {
                     "description": "Metadata (from RemoteMetadata)",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2944,6 +2944,10 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "wait_for_proposer_preferences_seconds": {
+                    "description": "WaitForProposerPreferencesSeconds, if \u003e 0, keeps the Gloas\n`proposer_preferences` gossip subscription open for this many seconds\nafter the RPC exchange so the gossip mesh has time to deliver messages.\nCapped at 60s server-side. Ignored on pre-Gloas forks.",
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2837,6 +2837,32 @@
                 }
             }
         },
+        "api.APIDasGuardianProposerPreference": {
+            "type": "object",
+            "properties": {
+                "dependent_root": {
+                    "type": "string"
+                },
+                "fee_recipient": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "proposal_slot": {
+                    "type": "integer"
+                },
+                "received_at": {
+                    "type": "string"
+                },
+                "validator_index": {
+                    "type": "integer"
+                }
+            }
+        },
         "api.APIDasGuardianScanRequest": {
             "type": "object",
             "properties": {
@@ -2889,6 +2915,13 @@
                     "description": "P2P Information",
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proposer_preferences": {
+                    "description": "Gloas SignedProposerPreferences sniffed off the peer's gossip during\nthe scan window. Empty pre-Gloas, or when no proposer published in time.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.APIDasGuardianProposerPreference"
+                    }
                 },
                 "remote_metadata": {
                     "description": "Metadata (from RemoteMetadata)",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2883,6 +2883,10 @@
                     "items": {
                         "type": "integer"
                     }
+                },
+                "wait_for_proposer_preferences_seconds": {
+                    "description": "WaitForProposerPreferencesSeconds, if \u003e 0, keeps the Gloas\n`proposer_preferences` gossip subscription open for this many seconds\nafter the RPC exchange so the gossip mesh has time to deliver messages.\nCapped at 60s server-side. Ignored on pre-Gloas forks.",
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2898,6 +2898,32 @@
                 }
             }
         },
+        "api.APIDasGuardianProposerPreference": {
+            "type": "object",
+            "properties": {
+                "dependent_root": {
+                    "type": "string"
+                },
+                "fee_recipient": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "proposal_slot": {
+                    "type": "integer"
+                },
+                "received_at": {
+                    "type": "string"
+                },
+                "validator_index": {
+                    "type": "integer"
+                }
+            }
+        },
         "api.APIDasGuardianScanRequest": {
             "type": "object",
             "properties": {
@@ -2950,6 +2976,13 @@
                     "description": "P2P Information",
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proposer_preferences": {
+                    "description": "Gloas SignedProposerPreferences sniffed off the peer's gossip during\nthe scan window. Empty pre-Gloas, or when no proposer published in time.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.APIDasGuardianProposerPreference"
+                    }
                 },
                 "remote_metadata": {
                     "description": "Metadata (from RemoteMetadata)",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -324,6 +324,13 @@ definitions:
         items:
           type: integer
         type: array
+      wait_for_proposer_preferences_seconds:
+        description: |-
+          WaitForProposerPreferencesSeconds, if > 0, keeps the Gloas
+          `proposer_preferences` gossip subscription open for this many seconds
+          after the RPC exchange so the gossip mesh has time to deliver messages.
+          Capped at 60s server-side. Ignored on pre-Gloas forks.
+        type: integer
     type: object
   api.APIDasGuardianScanResponse:
     properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -292,6 +292,23 @@ definitions:
       syncnets:
         type: string
     type: object
+  api.APIDasGuardianProposerPreference:
+    properties:
+      dependent_root:
+        type: string
+      fee_recipient:
+        type: string
+      from:
+        type: string
+      gas_limit:
+        type: integer
+      proposal_slot:
+        type: integer
+      received_at:
+        type: string
+      validator_index:
+        type: integer
+    type: object
   api.APIDasGuardianScanRequest:
     properties:
       enr:
@@ -327,6 +344,13 @@ definitions:
         additionalProperties: true
         description: P2P Information
         type: object
+      proposer_preferences:
+        description: |-
+          Gloas SignedProposerPreferences sniffed off the peer's gossip during
+          the scan window. Empty pre-Gloas, or when no proposer published in time.
+        items:
+          $ref: '#/definitions/api.APIDasGuardianProposerPreference'
+        type: array
       remote_metadata:
         allOf:
         - $ref: '#/definitions/api.APIDasGuardianMetadata'

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522074339-91446aa011c6
+	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1
+	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964
+	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522091055-3f6edd4ccde3
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56
+	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/eth-das-guardian v0.1.1
+	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522074339-91446aa011c6
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.2
-	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522091055-3f6edd4ccde3
+	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522095023-d09ab17a2b35
 	github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/cockroachdb/pebble v1.1.5
 	github.com/ethereum/go-ethereum v1.17.4
-	github.com/ethpandaops/eth-das-guardian v0.1.1
+	github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260702094214-e1a365ea3c01
 	github.com/ethpandaops/ethcore v0.0.0-20260604021418-f61e8ea2d4ab
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.6-0.20260629130636-6d2ee1978c4e

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964 h1:
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522091055-3f6edd4ccde3 h1:K8h1AX/mBg/s3EQTyrDH4yJsOx1/BfXo6DJDNH5zFtM=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522091055-3f6edd4ccde3/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522095023-d09ab17a2b35 h1:uJR6xuKYt8OMIsb+qng0XPE65VSXOn/Kn2dRQbVsm4U=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522095023-d09ab17a2b35/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJlRGioqm0jQRIojiH8DSyLRFSTCCBxN6o=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/ethereum/go-ethereum v1.17.2 h1:ag6geu0kn8Hv5FLKTpH+Hm2DHD+iuFtuqKxEu
 github.com/ethereum/go-ethereum v1.17.2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1 h1:QbgdX6WLkOSGA6YFu3pg235nvNPgyHWzAORZhqf5WzE=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56 h1:UtfnQdPA8W5X6RiUOaeNisnjw/BZpcVFkeCdja08lFI=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJlRGioqm0jQRIojiH8DSyLRFSTCCBxN6o=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.2 h1:ag6geu0kn8Hv5FLKTpH+Hm2DHD+iuFtuqKxEuwUsDOI=
 github.com/ethereum/go-ethereum v1.17.2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522074339-91446aa011c6 h1:WcHdeuBTlRMOHQLkidZ4NRhNS3iwuD72gG3Hwnavamw=
-github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522074339-91446aa011c6/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1 h1:QbgdX6WLkOSGA6YFu3pg235nvNPgyHWzAORZhqf5WzE=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJlRGioqm0jQRIojiH8DSyLRFSTCCBxN6o=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.4 h1:uA4q+qiLp7QImBsjdRbINu8iX6OEVmj4DPc5/E5Fsxc=
 github.com/ethereum/go-ethereum v1.17.4/go.mod h1:qMdgwqqRAen+aT8P7KKQKi0Qt6RzG4cfejVAbCpJgqA=
-github.com/ethpandaops/eth-das-guardian v0.1.1 h1:RN96h3HSAMyU4XUOCqkj/9+lB+UW7cVW4Wr4JzdjmZY=
-github.com/ethpandaops/eth-das-guardian v0.1.1/go.mod h1:7amdK4bN9N9Zp0b9Y9FcbDm1YrpeGBm8ix8qpiX0WuY=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260702094214-e1a365ea3c01 h1:XxObBGjnyF2Nyf6evVMYIXnuCFGsAEgfqjmCeNmvA/Q=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260702094214-e1a365ea3c01/go.mod h1:y5sTESfKLcpUistOLU0TF7Do2MphBVTi8in+KdQkz8E=
 github.com/ethpandaops/ethcore v0.0.0-20260604021418-f61e8ea2d4ab h1:B3gbA1Jf9pCG4gKlv3WtXNY7pUJF/wC0G+axx/7rq/0=
 github.com/ethpandaops/ethcore v0.0.0-20260604021418-f61e8ea2d4ab/go.mod h1:jMel7Tumm/0Ni44yb4OTGC6MsMiK7FBQDP/n/GOthpw=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56 h1:
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964 h1:BRAxqF/Tor8PApcnFsevGzT7OfU933sNScThLI0TDw0=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522091055-3f6edd4ccde3 h1:K8h1AX/mBg/s3EQTyrDH4yJsOx1/BfXo6DJDNH5zFtM=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522091055-3f6edd4ccde3/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJlRGioqm0jQRIojiH8DSyLRFSTCCBxN6o=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1 h1:
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522080519-13921e4ca7f1/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56 h1:UtfnQdPA8W5X6RiUOaeNisnjw/BZpcVFkeCdja08lFI=
 github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522082151-67ee99d84f56/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964 h1:BRAxqF/Tor8PApcnFsevGzT7OfU933sNScThLI0TDw0=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522090705-b0aedc982964/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJlRGioqm0jQRIojiH8DSyLRFSTCCBxN6o=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.2 h1:ag6geu0kn8Hv5FLKTpH+Hm2DHD+iuFtuqKxEuwUsDOI=
 github.com/ethereum/go-ethereum v1.17.2/go.mod h1:KHcRXfGOUfUmKg51IhQ0IowiqZ6PqZf08CMtk0g5K1o=
-github.com/ethpandaops/eth-das-guardian v0.1.1 h1:RN96h3HSAMyU4XUOCqkj/9+lB+UW7cVW4Wr4JzdjmZY=
-github.com/ethpandaops/eth-das-guardian v0.1.1/go.mod h1:7amdK4bN9N9Zp0b9Y9FcbDm1YrpeGBm8ix8qpiX0WuY=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522074339-91446aa011c6 h1:WcHdeuBTlRMOHQLkidZ4NRhNS3iwuD72gG3Hwnavamw=
+github.com/ethpandaops/eth-das-guardian v0.1.2-0.20260522074339-91446aa011c6/go.mod h1:nNlQGSz4cf8FPBuf0KIXHt1/lPfsuKXl1VfLipaUPeE=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c h1:uBRIitwcuCJlRGioqm0jQRIojiH8DSyLRFSTCCBxN6o=
 github.com/ethpandaops/ethcore v0.0.0-20260320045412-9cdd5d70a29c/go.mod h1:QsmYTdesob+vQ6pW4KtRVvxLZUNop3cdtd/DgD30hJU=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=

--- a/handlers/api/api_das_guardian.go
+++ b/handlers/api/api_das_guardian.go
@@ -253,7 +253,7 @@ func APIDasGuardianScan(w http.ResponseWriter, r *http.Request) {
 					ValidatorIndex: uint64(msg.ValidatorIndex),
 					ProposalSlot:   uint64(msg.ProposalSlot),
 					FeeRecipient:   fmt.Sprintf("0x%x", msg.FeeRecipient),
-					GasLimit:       msg.GasLimit,
+					GasLimit:       msg.TargetGasLimit,
 					DependentRoot:  fmt.Sprintf("0x%x", msg.DependentRoot),
 					ReceivedAt:     obs.ReceivedAt.Format(time.RFC3339),
 					From:           obs.From.String(),

--- a/handlers/api/api_das_guardian.go
+++ b/handlers/api/api_das_guardian.go
@@ -42,8 +42,24 @@ type APIDasGuardianScanResult struct {
 	// Metadata (from RemoteMetadata)
 	RemoteMetadata *APIDasGuardianMetadata `json:"remote_metadata,omitempty"`
 
+	// Gloas SignedProposerPreferences sniffed off the peer's gossip during
+	// the scan window. Empty pre-Gloas, or when no proposer published in time.
+	ProposerPreferences []*APIDasGuardianProposerPreference `json:"proposer_preferences,omitempty"`
+
 	// DAS Evaluation Result
 	EvalResult *APIDasGuardianEvalResult `json:"eval_result,omitempty"`
+}
+
+// APIDasGuardianProposerPreference is one SignedProposerPreferences gossip
+// message observed during the scan, attributed to the peer that delivered it.
+type APIDasGuardianProposerPreference struct {
+	ValidatorIndex uint64 `json:"validator_index"`
+	ProposalSlot   uint64 `json:"proposal_slot"`
+	FeeRecipient   string `json:"fee_recipient"`
+	GasLimit       uint64 `json:"gas_limit"`
+	DependentRoot  string `json:"dependent_root"`
+	ReceivedAt     string `json:"received_at"`
+	From           string `json:"from"`
 }
 
 // APIDasGuardianStatus represents the beacon node status
@@ -197,6 +213,28 @@ func APIDasGuardianScan(w http.ResponseWriter, r *http.Request) {
 				Syncnets:          fmt.Sprintf("0x%x", scanResult.RemoteMetadataV3.Syncnets),
 				CustodyGroupCount: uint64(scanResult.RemoteMetadataV3.CustodyGroupCount),
 			}
+		}
+
+		// Map any Gloas SignedProposerPreferences messages that were observed
+		// off the wire during the scan window.
+		if len(scanResult.ProposerPreferences) > 0 {
+			prefs := make([]*APIDasGuardianProposerPreference, 0, len(scanResult.ProposerPreferences))
+			for _, obs := range scanResult.ProposerPreferences {
+				if obs == nil || obs.Message == nil || obs.Message.Message == nil {
+					continue
+				}
+				msg := obs.Message.Message
+				prefs = append(prefs, &APIDasGuardianProposerPreference{
+					ValidatorIndex: uint64(msg.ValidatorIndex),
+					ProposalSlot:   uint64(msg.ProposalSlot),
+					FeeRecipient:   fmt.Sprintf("0x%x", msg.FeeRecipient),
+					GasLimit:       msg.GasLimit,
+					DependentRoot:  fmt.Sprintf("0x%x", msg.DependentRoot),
+					ReceivedAt:     obs.ReceivedAt.Format(time.RFC3339),
+					From:           obs.From.String(),
+				})
+			}
+			result.ProposerPreferences = prefs
 		}
 
 		// Map evaluation result (always present since it's not a pointer)

--- a/handlers/api/api_das_guardian.go
+++ b/handlers/api/api_das_guardian.go
@@ -22,6 +22,11 @@ type APIDasGuardianScanRequest struct {
 	Slots       []uint64 `json:"slots,omitempty"`        // Optional slot numbers to scan
 	RandomMode  string   `json:"random_mode,omitempty"`  // Random slot selection mode: "non_missed", "with_blobs", "available"
 	RandomCount int32    `json:"random_count,omitempty"` // Number of random slots to select (default: 4)
+	// WaitForProposerPreferencesSeconds, if > 0, keeps the Gloas
+	// `proposer_preferences` gossip subscription open for this many seconds
+	// after the RPC exchange so the gossip mesh has time to deliver messages.
+	// Capped at 60s server-side. Ignored on pre-Gloas forks.
+	WaitForProposerPreferencesSeconds int32 `json:"wait_for_proposer_preferences_seconds,omitempty"`
 }
 
 // APIDasGuardianScanResponse represents the response from DAS Guardian scan
@@ -126,11 +131,31 @@ func APIDasGuardianScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Honour an optional wait window so the Gloas proposer_preferences
+	// gossip subscription has time to deliver messages. Cap at 60s so a
+	// caller can't tie up a worker indefinitely.
+	waitSeconds := req.WaitForProposerPreferencesSeconds
+	if waitSeconds < 0 {
+		waitSeconds = 0
+	}
+	if waitSeconds > 60 {
+		waitSeconds = 60
+	}
+	scanTimeout := 30 * time.Second
+	if extra := time.Duration(waitSeconds) * time.Second; extra > 0 {
+		scanTimeout = 30*time.Second + extra
+	}
+
 	// Create temporary DAS Guardian instance
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), scanTimeout)
 	defer cancel()
 
-	dasGuardian, err := services.NewDasGuardian(ctx, logrus.WithField("component", "das-guardian-api"))
+	guardianOpts := make([]services.DasGuardianOption, 0, 1)
+	if waitSeconds > 0 {
+		guardianOpts = append(guardianOpts, services.WithProposerPreferencesWait(time.Duration(waitSeconds)*time.Second))
+	}
+
+	dasGuardian, err := services.NewDasGuardian(ctx, logrus.WithField("component", "das-guardian-api"), guardianOpts...)
 	if err != nil {
 		logrus.WithError(err).Error("failed to create DAS Guardian instance")
 		http.Error(w, `{"error": "failed to initialize DAS Guardian"}`, http.StatusInternalServerError)

--- a/services/dasguardian.go
+++ b/services/dasguardian.go
@@ -19,7 +19,7 @@ type DasGuardian struct {
 	guardian *dasguardian.DasGuardian
 }
 
-func NewDasGuardian(ctx context.Context, logger logrus.FieldLogger) (*DasGuardian, error) {
+func NewDasGuardian(ctx context.Context, logger logrus.FieldLogger, options ...DasGuardianOption) (*DasGuardian, error) {
 	guardianApi := &dasGuardianAPI{}
 
 	// Convert FieldLogger to *logrus.Logger
@@ -39,6 +39,9 @@ func NewDasGuardian(ctx context.Context, logger logrus.FieldLogger) (*DasGuardia
 		ConnectionTimeout: 10 * time.Second,
 		InitTimeout:       1 * time.Second,
 	}
+	for _, opt := range options {
+		opt(opts)
+	}
 
 	guardian, err := dasguardian.NewDASGuardian(ctx, opts)
 	if err != nil {
@@ -48,6 +51,20 @@ func NewDasGuardian(ctx context.Context, logger logrus.FieldLogger) (*DasGuardia
 	return &DasGuardian{
 		guardian: guardian,
 	}, nil
+}
+
+// DasGuardianOption customises the DasGuardianConfig used to construct the
+// underlying guardian. Used to enable Gloas-only paths like the proposer
+// preferences gossip wait without affecting the default scan.
+type DasGuardianOption func(*dasguardian.DasGuardianConfig)
+
+// WithProposerPreferencesWait configures the underlying scan to keep the
+// `proposer_preferences` gossip subscription open for the given duration so
+// the gossip mesh has time to deliver messages.
+func WithProposerPreferencesWait(d time.Duration) DasGuardianOption {
+	return func(cfg *dasguardian.DasGuardianConfig) {
+		cfg.ProposerPreferencesWaitDuration = d
+	}
 }
 
 func (d *DasGuardian) Close() error {

--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -2264,7 +2264,43 @@
             </table>
           </div>`;
         }
-        
+
+        if (result.proposer_preferences && result.proposer_preferences.length > 0) {
+          const prefs = result.proposer_preferences;
+          html += `<div class="mb-4">
+            <h6 class="border-bottom pb-2">
+              <i class="fa-solid fa-user-tie"></i> Proposer Preferences
+              <span class="badge bg-secondary ms-1">${prefs.length}</span>
+              <small class="text-muted ms-2">(Gloas <code>proposer_preferences</code> gossip sniffed during scan)</small>
+            </h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-bordered">
+                <thead>
+                  <tr>
+                    <th>Validator</th>
+                    <th>Proposal Slot</th>
+                    <th>Fee Recipient</th>
+                    <th class="text-end">Gas Limit</th>
+                    <th>Received</th>
+                  </tr>
+                </thead>
+                <tbody>`;
+          for (const pref of prefs) {
+            const feeShort = pref.fee_recipient
+              ? pref.fee_recipient.slice(0, 10) + '…' + pref.fee_recipient.slice(-6)
+              : '-';
+            html += `<tr>
+                <td><a href="/validator/${pref.validator_index}">${pref.validator_index.toLocaleString()}</a></td>
+                <td><a href="/slot/${pref.proposal_slot}">${pref.proposal_slot.toLocaleString()}</a></td>
+                <td><code title="${escapeHtml(pref.fee_recipient)}">${escapeHtml(feeShort)}</code></td>
+                <td class="text-end">${pref.gas_limit.toLocaleString()}</td>
+                <td><span title="${escapeHtml(pref.received_at)}">${escapeHtml(pref.received_at)}</span></td>
+              </tr>`;
+          }
+          html += `</tbody></table></div>
+          </div>`;
+        }
+
         // DAS Evaluation Results
         if (result.eval_result) {
           const evalResult = result.eval_result;

--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -723,7 +723,23 @@
                       <strong>Metadata Only</strong> - Quick scan for node status and custody information (no DAS column validation)
                     </label>
                   </div>
-                  
+                  <div class="form-check mb-3">
+                    <input class="form-check-input" type="radio" name="scanType" id="scanProposerPreferences" value="preferences">
+                    <label class="form-check-label" for="scanProposerPreferences">
+                      <strong>Proposer Preferences</strong> - Subscribe to the Gloas <code>proposer_preferences</code> gossip and report messages this peer relayed during the wait window (Gloas only)
+                    </label>
+                  </div>
+
+                  <!-- Proposer Preferences options (hidden by default) -->
+                  <div id="preferencesSelectionSection" style="display: none;" class="mt-3 p-3 border rounded">
+                    <h6>Gossip Wait Window</h6>
+                    <p class="text-muted small mb-2">SignedProposerPreferences are broadcast a slot or two before a proposal. A longer wait increases the chance of catching one, at the cost of scan latency.</p>
+                    <div class="mb-3">
+                      <label for="preferencesWaitSeconds" class="form-label">Wait seconds (1–60):</label>
+                      <input type="number" class="form-control" id="preferencesWaitSeconds" min="1" max="60" value="24">
+                    </div>
+                  </div>
+
                   <!-- Slot Selection (hidden by default) -->
                   <div id="slotSelectionSection" style="display: none;" class="mt-3 p-3 border rounded">
                     <h6>Select Slots to Scan</h6>
@@ -1992,11 +2008,14 @@
       const scanType = $(this).val();
       $('#slotSelectionSection').hide();
       $('#randomSlotSelectionSection').hide();
-      
+      $('#preferencesSelectionSection').hide();
+
       if (scanType === 'slots') {
         $('#slotSelectionSection').show();
       } else if (scanType === 'random') {
         $('#randomSlotSelectionSection').show();
+      } else if (scanType === 'preferences') {
+        $('#preferencesSelectionSection').show();
       }
     });
     
@@ -2127,6 +2146,12 @@
         const randomCount = parseInt($('#randomSlotCount').val()) || 4;
         requestData.random_mode = randomMode;
         requestData.random_count = randomCount;
+      } else if (scanType === 'preferences') {
+        let wait = parseInt($('#preferencesWaitSeconds').val()) || 24;
+        if (wait < 1) wait = 1;
+        if (wait > 60) wait = 60;
+        requestData.wait_for_proposer_preferences_seconds = wait;
+        $('#dasGuardianLoading p').text('Listening for proposer_preferences gossip (' + wait + 's)…');
       }
       
       // Make API call
@@ -2265,40 +2290,45 @@
           </div>`;
         }
 
-        if (result.proposer_preferences && result.proposer_preferences.length > 0) {
-          const prefs = result.proposer_preferences;
+        const preferencesScan = $('input[name="scanType"]:checked').val() === 'preferences';
+        if ((result.proposer_preferences && result.proposer_preferences.length > 0) || preferencesScan) {
+          const prefs = result.proposer_preferences || [];
           html += `<div class="mb-4">
             <h6 class="border-bottom pb-2">
               <i class="fa-solid fa-user-tie"></i> Proposer Preferences
               <span class="badge bg-secondary ms-1">${prefs.length}</span>
               <small class="text-muted ms-2">(Gloas <code>proposer_preferences</code> gossip sniffed during scan)</small>
-            </h6>
-            <div class="table-responsive">
-              <table class="table table-sm table-bordered">
-                <thead>
-                  <tr>
-                    <th>Validator</th>
-                    <th>Proposal Slot</th>
-                    <th>Fee Recipient</th>
-                    <th class="text-end">Gas Limit</th>
-                    <th>Received</th>
-                  </tr>
-                </thead>
-                <tbody>`;
-          for (const pref of prefs) {
-            const feeShort = pref.fee_recipient
-              ? pref.fee_recipient.slice(0, 10) + '…' + pref.fee_recipient.slice(-6)
-              : '-';
-            html += `<tr>
-                <td><a href="/validator/${pref.validator_index}">${pref.validator_index.toLocaleString()}</a></td>
-                <td><a href="/slot/${pref.proposal_slot}">${pref.proposal_slot.toLocaleString()}</a></td>
-                <td><code title="${escapeHtml(pref.fee_recipient)}">${escapeHtml(feeShort)}</code></td>
-                <td class="text-end">${pref.gas_limit.toLocaleString()}</td>
-                <td><span title="${escapeHtml(pref.received_at)}">${escapeHtml(pref.received_at)}</span></td>
-              </tr>`;
+            </h6>`;
+          if (prefs.length === 0) {
+            html += `<div class="alert alert-secondary mb-0"><i class="fa-solid fa-circle-info"></i> No <code>SignedProposerPreferences</code> were observed from this peer during the wait window. This is expected pre-Gloas, or if none of the peer's validators were due to propose soon.</div>`;
+          } else {
+            html += `<div class="table-responsive">
+                <table class="table table-sm table-bordered">
+                  <thead>
+                    <tr>
+                      <th>Validator</th>
+                      <th>Proposal Slot</th>
+                      <th>Fee Recipient</th>
+                      <th class="text-end">Gas Limit</th>
+                      <th>Received</th>
+                    </tr>
+                  </thead>
+                  <tbody>`;
+            for (const pref of prefs) {
+              const feeShort = pref.fee_recipient
+                ? pref.fee_recipient.slice(0, 10) + '…' + pref.fee_recipient.slice(-6)
+                : '-';
+              html += `<tr>
+                  <td><a href="/validator/${pref.validator_index}">${pref.validator_index.toLocaleString()}</a></td>
+                  <td><a href="/slot/${pref.proposal_slot}">${pref.proposal_slot.toLocaleString()}</a></td>
+                  <td><code title="${escapeHtml(pref.fee_recipient)}">${escapeHtml(feeShort)}</code></td>
+                  <td class="text-end">${pref.gas_limit.toLocaleString()}</td>
+                  <td><span title="${escapeHtml(pref.received_at)}">${escapeHtml(pref.received_at)}</span></td>
+                </tr>`;
+            }
+            html += `</tbody></table></div>`;
           }
-          html += `</tbody></table></div>
-          </div>`;
+          html += `</div>`;
         }
 
         // DAS Evaluation Results

--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -2245,7 +2245,43 @@
             </table>
           </div>`;
         }
-        
+
+        if (result.proposer_preferences && result.proposer_preferences.length > 0) {
+          const prefs = result.proposer_preferences;
+          html += `<div class="mb-4">
+            <h6 class="border-bottom pb-2">
+              <i class="fa-solid fa-user-tie"></i> Proposer Preferences
+              <span class="badge bg-secondary ms-1">${prefs.length}</span>
+              <small class="text-muted ms-2">(Gloas <code>proposer_preferences</code> gossip sniffed during scan)</small>
+            </h6>
+            <div class="table-responsive">
+              <table class="table table-sm table-bordered">
+                <thead>
+                  <tr>
+                    <th>Validator</th>
+                    <th>Proposal Slot</th>
+                    <th>Fee Recipient</th>
+                    <th class="text-end">Gas Limit</th>
+                    <th>Received</th>
+                  </tr>
+                </thead>
+                <tbody>`;
+          for (const pref of prefs) {
+            const feeShort = pref.fee_recipient
+              ? pref.fee_recipient.slice(0, 10) + '…' + pref.fee_recipient.slice(-6)
+              : '-';
+            html += `<tr>
+                <td><a href="/validator/${pref.validator_index}">${pref.validator_index.toLocaleString()}</a></td>
+                <td><a href="/slot/${pref.proposal_slot}">${pref.proposal_slot.toLocaleString()}</a></td>
+                <td><code title="${escapeHtml(pref.fee_recipient)}">${escapeHtml(feeShort)}</code></td>
+                <td class="text-end">${pref.gas_limit.toLocaleString()}</td>
+                <td><span title="${escapeHtml(pref.received_at)}">${escapeHtml(pref.received_at)}</span></td>
+              </tr>`;
+          }
+          html += `</tbody></table></div>
+          </div>`;
+        }
+
         // DAS Evaluation Results
         if (result.eval_result) {
           const evalResult = result.eval_result;

--- a/templates/clients/clients_cl.html
+++ b/templates/clients/clients_cl.html
@@ -721,7 +721,23 @@
                       <strong>Metadata Only</strong> - Quick scan for node status and custody information (no DAS column validation)
                     </label>
                   </div>
-                  
+                  <div class="form-check mb-3">
+                    <input class="form-check-input" type="radio" name="scanType" id="scanProposerPreferences" value="preferences">
+                    <label class="form-check-label" for="scanProposerPreferences">
+                      <strong>Proposer Preferences</strong> - Subscribe to the Gloas <code>proposer_preferences</code> gossip and report messages this peer relayed during the wait window (Gloas only)
+                    </label>
+                  </div>
+
+                  <!-- Proposer Preferences options (hidden by default) -->
+                  <div id="preferencesSelectionSection" style="display: none;" class="mt-3 p-3 border rounded">
+                    <h6>Gossip Wait Window</h6>
+                    <p class="text-muted small mb-2">SignedProposerPreferences are broadcast a slot or two before a proposal. A longer wait increases the chance of catching one, at the cost of scan latency.</p>
+                    <div class="mb-3">
+                      <label for="preferencesWaitSeconds" class="form-label">Wait seconds (1–60):</label>
+                      <input type="number" class="form-control" id="preferencesWaitSeconds" min="1" max="60" value="24">
+                    </div>
+                  </div>
+
                   <!-- Slot Selection (hidden by default) -->
                   <div id="slotSelectionSection" style="display: none;" class="mt-3 p-3 border rounded">
                     <h6>Select Slots to Scan</h6>
@@ -1973,11 +1989,14 @@
       const scanType = $(this).val();
       $('#slotSelectionSection').hide();
       $('#randomSlotSelectionSection').hide();
-      
+      $('#preferencesSelectionSection').hide();
+
       if (scanType === 'slots') {
         $('#slotSelectionSection').show();
       } else if (scanType === 'random') {
         $('#randomSlotSelectionSection').show();
+      } else if (scanType === 'preferences') {
+        $('#preferencesSelectionSection').show();
       }
     });
     
@@ -2108,6 +2127,12 @@
         const randomCount = parseInt($('#randomSlotCount').val()) || 4;
         requestData.random_mode = randomMode;
         requestData.random_count = randomCount;
+      } else if (scanType === 'preferences') {
+        let wait = parseInt($('#preferencesWaitSeconds').val()) || 24;
+        if (wait < 1) wait = 1;
+        if (wait > 60) wait = 60;
+        requestData.wait_for_proposer_preferences_seconds = wait;
+        $('#dasGuardianLoading p').text('Listening for proposer_preferences gossip (' + wait + 's)…');
       }
       
       // Make API call
@@ -2246,40 +2271,45 @@
           </div>`;
         }
 
-        if (result.proposer_preferences && result.proposer_preferences.length > 0) {
-          const prefs = result.proposer_preferences;
+        const preferencesScan = $('input[name="scanType"]:checked').val() === 'preferences';
+        if ((result.proposer_preferences && result.proposer_preferences.length > 0) || preferencesScan) {
+          const prefs = result.proposer_preferences || [];
           html += `<div class="mb-4">
             <h6 class="border-bottom pb-2">
               <i class="fa-solid fa-user-tie"></i> Proposer Preferences
               <span class="badge bg-secondary ms-1">${prefs.length}</span>
               <small class="text-muted ms-2">(Gloas <code>proposer_preferences</code> gossip sniffed during scan)</small>
-            </h6>
-            <div class="table-responsive">
-              <table class="table table-sm table-bordered">
-                <thead>
-                  <tr>
-                    <th>Validator</th>
-                    <th>Proposal Slot</th>
-                    <th>Fee Recipient</th>
-                    <th class="text-end">Gas Limit</th>
-                    <th>Received</th>
-                  </tr>
-                </thead>
-                <tbody>`;
-          for (const pref of prefs) {
-            const feeShort = pref.fee_recipient
-              ? pref.fee_recipient.slice(0, 10) + '…' + pref.fee_recipient.slice(-6)
-              : '-';
-            html += `<tr>
-                <td><a href="/validator/${pref.validator_index}">${pref.validator_index.toLocaleString()}</a></td>
-                <td><a href="/slot/${pref.proposal_slot}">${pref.proposal_slot.toLocaleString()}</a></td>
-                <td><code title="${escapeHtml(pref.fee_recipient)}">${escapeHtml(feeShort)}</code></td>
-                <td class="text-end">${pref.gas_limit.toLocaleString()}</td>
-                <td><span title="${escapeHtml(pref.received_at)}">${escapeHtml(pref.received_at)}</span></td>
-              </tr>`;
+            </h6>`;
+          if (prefs.length === 0) {
+            html += `<div class="alert alert-secondary mb-0"><i class="fa-solid fa-circle-info"></i> No <code>SignedProposerPreferences</code> were observed from this peer during the wait window. This is expected pre-Gloas, or if none of the peer's validators were due to propose soon.</div>`;
+          } else {
+            html += `<div class="table-responsive">
+                <table class="table table-sm table-bordered">
+                  <thead>
+                    <tr>
+                      <th>Validator</th>
+                      <th>Proposal Slot</th>
+                      <th>Fee Recipient</th>
+                      <th class="text-end">Gas Limit</th>
+                      <th>Received</th>
+                    </tr>
+                  </thead>
+                  <tbody>`;
+            for (const pref of prefs) {
+              const feeShort = pref.fee_recipient
+                ? pref.fee_recipient.slice(0, 10) + '…' + pref.fee_recipient.slice(-6)
+                : '-';
+              html += `<tr>
+                  <td><a href="/validator/${pref.validator_index}">${pref.validator_index.toLocaleString()}</a></td>
+                  <td><a href="/slot/${pref.proposal_slot}">${pref.proposal_slot.toLocaleString()}</a></td>
+                  <td><code title="${escapeHtml(pref.fee_recipient)}">${escapeHtml(feeShort)}</code></td>
+                  <td class="text-end">${pref.gas_limit.toLocaleString()}</td>
+                  <td><span title="${escapeHtml(pref.received_at)}">${escapeHtml(pref.received_at)}</span></td>
+                </tr>`;
+            }
+            html += `</tbody></table></div>`;
           }
-          html += `</tbody></table></div>
-          </div>`;
+          html += `</div>`;
         }
 
         // DAS Evaluation Results


### PR DESCRIPTION
## Summary
- Bumps `github.com/ethpandaops/eth-das-guardian` to the pre-release SHA from ethpandaops/eth-das-guardian#6, which adds a Gloas `proposer_preferences` gossip sniffer.
- Extends `APIDasGuardianScanResult` with `proposer_preferences[]` (validator_index, proposal_slot, fee_recipient, gas_limit, dependent_root, received_at, from) and maps the observations from the underlying scan result.
- Adds a new section to the DAS Guardian modal in `templates/clients/clients_cl.html` that renders a small table when any preferences are observed: validator → `/validator/{index}`, proposal slot → `/slot/{slot}`, truncated fee recipient (full value on hover), formatted gas limit, RFC3339 receive timestamp.

Depends on ethpandaops/eth-das-guardian#6 — needs to be re-pinned to a tagged version once that PR lands.

## Why this is a section, not a table column
SignedProposerPreferences are per-validator and broadcast a slot or two before each proposal. A single scan window may catch zero, one or several messages, so a fixed column in the mass-scan grid would be empty most of the time. The detail modal already groups status / metadata / DAS check; a fourth grouped table fits the same shape and stays out of the way on pre-Gloas networks (the section is hidden entirely when the array is empty).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Manual: run dora against a Gloas devnet, open the CL clients page, run a DAS Guardian check on a node, confirm the "Proposer Preferences" section renders when messages are observed (and is hidden otherwise)
- [ ] Confirm validator/slot links route correctly