### PR TITLE
fix: swallow lighthouse head 404 noise on transient REST API race

### DIFF
--- a/clients/consensus/rpc/beaconapi.go
+++ b/clients/consensus/rpc/beaconapi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	nethttp "net/http"
@@ -27,6 +28,11 @@ import (
 	"github.com/ethpandaops/dora/clients/sshtunnel"
 	"github.com/ethpandaops/dora/utils"
 )
+
+// ErrBlockNotFound is returned by block lookups when the beacon node responds 404.
+// This typically signals a transient race between the SSE event stream and the REST API
+// (most often observed with Lighthouse for head events at high block production rates).
+var ErrBlockNotFound = errors.New("beacon block not found")
 
 type BeaconClient struct {
 	name       string
@@ -355,6 +361,9 @@ func (bc *BeaconClient) GetBlockHeaderByBlockroot(ctx context.Context, blockroot
 		},
 	})
 	if err != nil {
+		if strings.HasPrefix(err.Error(), "GET failed with status 404") {
+			return nil, fmt.Errorf("%w: %v", ErrBlockNotFound, err)
+		}
 		return nil, err
 	}
 

--- a/indexer/beacon/client.go
+++ b/indexer/beacon/client.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -181,15 +182,25 @@ func (c *Client) runClientLoop() error {
 				blockEvent := event.Data.(*v1.BlockEvent)
 				err := c.processBlockEvent(blockEvent)
 				if err != nil {
-					c.logger.Errorf("failed processing block %v (%v): %v",
-						blockEvent.Slot, blockEvent.Block.String(), err)
+					if errors.Is(err, rpc.ErrBlockNotFound) {
+						c.logger.Debugf("block %v (%v) not yet queryable via REST API, will retry on next event: %v",
+							blockEvent.Slot, blockEvent.Block.String(), err)
+					} else {
+						c.logger.Errorf("failed processing block %v (%v): %v",
+							blockEvent.Slot, blockEvent.Block.String(), err)
+					}
 				}
 			case rpc.StreamHeadEvent:
 				headEvent := event.Data.(*v1.HeadEvent)
 				err := c.processHeadEvent(headEvent)
 				if err != nil {
-					c.logger.Errorf("failed processing head %v (%v): %v",
-						headEvent.Slot, headEvent.Block.String(), err)
+					if errors.Is(err, rpc.ErrBlockNotFound) {
+						c.logger.Debugf("head %v (%v) not yet queryable via REST API, will retry on next event: %v",
+							headEvent.Slot, headEvent.Block.String(), err)
+					} else {
+						c.logger.Errorf("failed processing head %v (%v): %v",
+							headEvent.Slot, headEvent.Block.String(), err)
+					}
 				}
 			}
 		case executionPayloadEvent := <-c.executionPayloadSubscription.Channel():


### PR DESCRIPTION
## Summary

Lighthouse occasionally emits SSE `head` (and sometimes `block`) events for a block root that is **not yet queryable via its own REST API**. The block always lands on the REST endpoint a moment later — I verified this on a running kurtosis devnet: every previously-404'd root I checked (slots 53, 54, 57, 63, 70, 71, 78) returns `HTTP 200` with `canonical: true, finalized: true` from the same Lighthouse instance that 404'd it.

But the indexer was surfacing every one of these as:

```
ERROR  failed processing head 70 (0xb9b4…): GET failed with status 404: NOT_FOUND: beacon block with root 0xb9b4…  client=cl-3-lighthouse-ethrex
```

which is misleading (looks operational, isn't) and frequent on multi-client devnets with multiple Lighthouse nodes.

## What this PR does

- Detects the 404 in `GetBlockHeaderByBlockroot` using the **same `strings.HasPrefix(err.Error(), "GET failed with status 404")` check that `GetBlockHeaderBySlot` and `GetBlockBodyByBlockroot` already use**, so the lookup path matches the rest of the 404 swallows in this file.
- Wraps the 404 in a typed `rpc.ErrBlockNotFound` sentinel so callers can distinguish "transient race, will retry" from a genuine RPC failure.
- In `processBlockEvent` / `processHeadEvent` (`indexer/beacon/client.go`), demotes the log line to `Debugf` when the error is `ErrBlockNotFound`. Anything else still logs at `Errorf`.

## Why a typed error and not bare `(nil, nil)`

The sibling methods return `(nil, nil)` directly, but their callers explicitly check for nil. `EnsureHeader`'s contract is "non-nil header iff nil error" — returning `(nil, nil)` would leave the block-cache entry in a corrupt state (header channel closed with a nil header). The sentinel keeps that invariant and just lets the next `block` or `head` event for the same root re-trigger the fetch (which always succeeds, your logs prove it).

## Test plan

- [x] `go build ./...` is clean
- [ ] Run dora against the current kurtosis devnet with multiple Lighthouse nodes and confirm the `failed processing head ...: 404` lines no longer surface at error level (they should appear at debug only)
- [ ] Confirm head/block tracking still keeps up after the change (`canonical head computation complete` events continue arriving in the seconds following a debug-level "not yet queryable" log)

## Out of scope

`GetBlockBodyByBlockroot` already swallows 404 to `(nil, nil)`, and `EnsureBlock` / `setBlockIndex` will happily store that nil — almost certainly a latent bug but pre-existing, and worth a separate PR.