### PR TITLE
Show revert reason tooltip on failed tx badge in slot view

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -23,10 +23,13 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/golang/snappy"
 	"github.com/gorilla/mux"
+	dynssz "github.com/pk910/dynamic-ssz"
 	"github.com/sirupsen/logrus"
 
 	"github.com/ethpandaops/dora/blockdb"
+	bdbtypes "github.com/ethpandaops/dora/blockdb/types"
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/indexer/beacon"
@@ -1163,6 +1166,7 @@ func getSlotPageTransactions(ctx context.Context, pageData *models.SlotPageBlock
 	if utils.Config.ExecutionIndexer.Enabled && len(pageData.Transactions) > 0 {
 		elTxs, err := db.GetElTransactionsByBlockUid(ctx, blockUid)
 		if err == nil && len(elTxs) > 0 {
+			failedTxs := []*models.SlotPageTransaction{}
 			for _, elTx := range elTxs {
 				txData := txHashMap[string(elTx.TxHash)]
 				if txData == nil {
@@ -1178,8 +1182,61 @@ func getSlotPageTransactions(ctx context.Context, pageData *models.SlotPageBlock
 				if elTx.GasUsed > 0 && elTx.EffGasPrice > 0 {
 					txData.TxFee = float64(elTx.GasUsed) * elTx.EffGasPrice / 1e9
 				}
+
+				if elTx.Reverted {
+					failedTxs = append(failedTxs, txData)
+				}
+			}
+
+			if len(failedTxs) > 0 {
+				getSlotPageTransactionRevertReasons(ctx, pageData.BlockRoot, failedTxs, blockUid)
 			}
 		}
+	}
+}
+
+// getSlotPageTransactionRevertReasons loads call traces from blockdb for failed
+// transactions and extracts the revert reason for the status badge tooltip.
+func getSlotPageTransactionRevertReasons(ctx context.Context, blockRoot []byte, failedTxs []*models.SlotPageTransaction, blockUid uint64) {
+	if blockdb.GlobalBlockDb == nil || !blockdb.GlobalBlockDb.SupportsExecData() || len(blockRoot) == 0 {
+		return
+	}
+
+	elBlock, err := db.GetElBlock(ctx, blockUid)
+	if err != nil || elBlock == nil || elBlock.DataStatus&dbtypes.ElBlockDataCallTraces == 0 {
+		return
+	}
+
+	// Bound the number of blockdb lookups for blocks with lots of failed transactions
+	if len(failedTxs) > 50 {
+		failedTxs = failedTxs[:50]
+	}
+
+	slot := blockUid >> 16
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	for _, txData := range failedTxs {
+		sections, err := blockdb.GlobalBlockDb.GetExecDataTxSections(
+			ctx, slot, blockRoot, txData.Hash,
+			bdbtypes.ExecDataSectionCallTrace,
+		)
+		if err != nil || sections == nil || sections.CallTraceData == nil {
+			continue
+		}
+
+		uncompData, err := snappy.Decode(nil, sections.CallTraceData)
+		if err != nil {
+			continue
+		}
+
+		var frames []bdbtypes.FlatCallFrame
+		if err := dynssz.GetGlobalDynSsz().UnmarshalSSZ(&frames, uncompData); err != nil || len(frames) == 0 {
+			continue
+		}
+
+		// The first frame is the top-level call; bubbled-up errors end up there
+		txData.RevertReason = utils.FormatRevertReason(frames[0].Error, frames[0].Output)
 	}
 }
 

--- a/templates/slot/transactions.html
+++ b/templates/slot/transactions.html
@@ -52,7 +52,7 @@
             {{ if $transaction.HasElData }}
             <td>
               {{ if $transaction.Reverted }}
-              <span class="badge text-bg-danger" style="font-size: 11px;"><i class="fas fa-times me-1"></i>Failed</span>
+              <span class="badge text-bg-danger" style="font-size: 11px;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="{{ if $transaction.RevertReason }}{{ $transaction.RevertReason }}{{ else }}Transaction failed{{ end }}"><i class="fas fa-times me-1"></i>Failed</span>
               {{ else }}
               <span class="badge text-bg-success" style="font-size: 11px;"><i class="fas fa-check me-1"></i>Success</span>
               {{ end }}

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -291,6 +291,9 @@ type SlotPageTransaction struct {
 	GasLimit    uint64  `json:"gas_limit"`
 	TxFee       float64 `json:"tx_fee"`        // Transaction fee in ETH
 	EffGasPrice float64 `json:"eff_gas_price"` // Effective gas price in Gwei
+
+	// Revert reason from call traces (only available when traces are stored)
+	RevertReason string `json:"revert_reason"`
 }
 
 type SlotPageDepositRequest struct {

--- a/utils/calldata.go
+++ b/utils/calldata.go
@@ -740,3 +740,50 @@ func decodeBLS12G2MSMInput(data []byte) []*DecodedCalldataParam {
 
 	return params
 }
+
+// solidityPanicReasons maps Panic(uint256) error codes to readable descriptions.
+var solidityPanicReasons = map[uint64]string{
+	0x00: "generic panic",
+	0x01: "assertion failed",
+	0x11: "arithmetic overflow or underflow",
+	0x12: "division or modulo by zero",
+	0x21: "invalid enum conversion",
+	0x22: "corrupted storage byte array",
+	0x31: "pop on empty array",
+	0x32: "array index out of bounds",
+	0x41: "memory allocation overflow",
+	0x51: "call to invalid internal function",
+}
+
+// FormatRevertReason builds a human readable revert reason from a call frame's
+// error text and return data. It decodes Error(string) and Panic(uint256)
+// payloads and falls back to the raw selector for custom errors.
+func FormatRevertReason(errorText string, output []byte) string {
+	if errorText == "" {
+		return ""
+	}
+	if len(output) < 4 {
+		return errorText
+	}
+
+	switch binary.BigEndian.Uint32(output[:4]) {
+	case 0x08c379a0: // Error(string)
+		if reason, err := abi.UnpackRevert(output); err == nil && reason != "" {
+			return fmt.Sprintf("%s: %s", errorText, strings.ToValidUTF8(reason, "?"))
+		}
+	case 0x4e487b71: // Panic(uint256)
+		if len(output) >= 36 {
+			code := new(big.Int).SetBytes(output[4:36])
+			if code.IsUint64() {
+				if reason, ok := solidityPanicReasons[code.Uint64()]; ok {
+					return fmt.Sprintf("%s: panic - %s", errorText, reason)
+				}
+				return fmt.Sprintf("%s: panic 0x%x", errorText, code)
+			}
+		}
+	default:
+		return fmt.Sprintf("%s (custom error 0x%x)", errorText, output[:4])
+	}
+
+	return errorText
+}


### PR DESCRIPTION
## Summary

The Transactions tab on the slot page only shows a plain `Failed` badge with no indication of *why* a transaction failed. This adds a tooltip to the badge with the revert reason.

The success/fail bit comes from receipts, which don't carry a reason — so this pulls the reason from the call traces already stored in blockdb (when `executionIndexer.tracesEnabled` is on), the same data the tx details page uses for its Internal Txs tab.

## Changes

- **`handlers/slot.go`**: after EL enrichment, failed txs get a second pass that loads each tx's call-trace section from blockdb, takes the top-level call frame, and extracts the error. Gated on the block's `data_status` call-traces flag and capped at 50 failed txs per block to bound blockdb lookups on spam blocks.
- **`utils/calldata.go`**: new `FormatRevertReason` helper — decodes `Error(string)` payloads to `execution reverted: <message>`, maps `Panic(uint256)` codes to readable text, shows the 4-byte selector for custom errors, and falls back to the raw trace error (e.g. `out of gas`).
- **`types/models/slot.go`**: added `RevertReason` field to `SlotPageTransaction`.
- **`templates/slot/transactions.html`**: Failed badge now carries the tooltip (falls back to "Transaction failed" when no trace data is stored).