### PR TITLE
feat(dora): show EIP-7778 block gas delta in slot overview

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -866,8 +866,10 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 			getSlotPageTransactions(ctx, pageData, executionPayload.Transactions, blockUid)
 		}
 
-		// EIP-7778: compute gas refund delta = block.gasUsed - sum(receipt.gasUsed).
-		// block.gasUsed is pre-refund (EIP-7778); each receipt.gasUsed is post-refund.
+		// EIP-7778: compute gas refund delta = |block.gasUsed - sum(receipt.gasUsed)|.
+		// In Amsterdam these two counters ALWAYS diverge (they were equal pre-Amsterdam):
+		//   block.gasUsed  = gp.Used()           = max(sum_regular, sum_state)
+		//   sum(receipts)  = gp.CumulativeUsed() = sum(max(pre_refund-refund, floor))
 		// Only computed when EL indexing has enriched ALL tx receipts in this block.
 		if len(pageData.Transactions) > 0 {
 			var sumTxGas uint64
@@ -880,10 +882,15 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 			}
 			if elDataCount == len(pageData.Transactions) {
 				blockGas := executionPayload.GasUsed
-				if blockGas > sumTxGas {
+				pageData.ExecutionData.SumTxGasUsed = &sumTxGas
+				if blockGas >= sumTxGas {
 					delta := blockGas - sumTxGas
-					pageData.ExecutionData.SumTxGasUsed = &sumTxGas
 					pageData.ExecutionData.GasRefundDelta = &delta
+					pageData.ExecutionData.GasRefundDeltaExcess = true
+				} else {
+					delta := sumTxGas - blockGas
+					pageData.ExecutionData.GasRefundDelta = &delta
+					pageData.ExecutionData.GasRefundDeltaExcess = false
 				}
 			}
 		}

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -885,12 +885,12 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 				pageData.ExecutionData.SumTxGasUsed = &sumTxGas
 				if blockGas >= sumTxGas {
 					delta := blockGas - sumTxGas
-					pageData.ExecutionData.GasRefundDelta = &delta
-					pageData.ExecutionData.GasRefundDeltaExcess = true
+					pageData.ExecutionData.BlockGasDelta = &delta
+					pageData.ExecutionData.BlockGasDeltaExcess = true
 				} else {
 					delta := sumTxGas - blockGas
-					pageData.ExecutionData.GasRefundDelta = &delta
-					pageData.ExecutionData.GasRefundDeltaExcess = false
+					pageData.ExecutionData.BlockGasDelta = &delta
+					pageData.ExecutionData.BlockGasDeltaExcess = false
 				}
 			}
 		}

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -866,6 +866,28 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 			getSlotPageTransactions(ctx, pageData, executionPayload.Transactions, blockUid)
 		}
 
+		// EIP-7778: compute gas refund delta = block.gasUsed - sum(receipt.gasUsed).
+		// block.gasUsed is pre-refund (EIP-7778); each receipt.gasUsed is post-refund.
+		// Only computed when EL indexing has enriched ALL tx receipts in this block.
+		if len(pageData.Transactions) > 0 {
+			var sumTxGas uint64
+			elDataCount := 0
+			for _, tx := range pageData.Transactions {
+				if tx.HasElData {
+					sumTxGas += tx.GasUsed
+					elDataCount++
+				}
+			}
+			if elDataCount == len(pageData.Transactions) {
+				blockGas := executionPayload.GasUsed
+				if blockGas >= sumTxGas {
+					delta := blockGas - sumTxGas
+					pageData.ExecutionData.SumTxGasUsed = &sumTxGas
+					pageData.ExecutionData.GasRefundDelta = &delta
+				}
+			}
+		}
+
 		// EIP-7928 Block Access List — the chainservice sources the bytes
 		// either from the envelope (fresh from the node) or from blockdb
 		// (preserved after the node pruned it).

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -866,10 +866,10 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 			getSlotPageTransactions(ctx, pageData, executionPayload.Transactions, blockUid)
 		}
 
-		// EIP-7778: compute gas refund delta = |block.gasUsed - sum(receipt.gasUsed)|.
-		// In Amsterdam these two counters ALWAYS diverge (they were equal pre-Amsterdam):
-		//   block.gasUsed  = gp.Used()           = max(sum_regular, sum_state)
-		//   sum(receipts)  = gp.CumulativeUsed() = sum(max(pre_refund-refund, floor))
+		// EIP-7778: compute block gas delta = block.gasUsed - sum(receipt.gasUsed).
+		// Pre-Amsterdam these were always equal; Amsterdam introduces a 2D gas model:
+		//   block.gasUsed = max(sum_regular, sum_state)          [EIP-7778]
+		//   receipt.gasUsed per tx = regular + state - refund    [EIP-8037, EIP-3529]
 		// Only computed when EL indexing has enriched ALL tx receipts in this block.
 		if len(pageData.Transactions) > 0 {
 			var sumTxGas uint64

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -880,7 +880,7 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 			}
 			if elDataCount == len(pageData.Transactions) {
 				blockGas := executionPayload.GasUsed
-				if blockGas >= sumTxGas {
+				if blockGas > sumTxGas {
 					delta := blockGas - sumTxGas
 					pageData.ExecutionData.SumTxGasUsed = &sumTxGas
 					pageData.ExecutionData.GasRefundDelta = &delta

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -371,6 +371,17 @@
                   </div>
                 </div>
 
+                {{ if .GasRefundDelta }}
+                <div class="row py-1">
+                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed is pre-refund gas. Gas refunds (SSTORE clears) are not subtracted from block space. Delta = block.gasUsed − sum(receipt.gasUsed). Refunds are credited to tx.origin (EIP-8037).">Gas Refund Delta:</span></div>
+                  <div class="col-md-10 text-monospace">
+                    +{{ formatAddCommas .GasRefundDelta }}
+                    <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: refunds excluded from block gas accounting">EIP-7778</span>
+                    <small class="text-muted ms-2">(receipts sum: {{ formatAddCommas .SumTxGasUsed }})</small>
+                  </div>
+                </div>
+                {{ end }}
+
                 {{ if not $block.PayloadHeader }}
                   <div class="row py-1">
                     <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Gas Limit">Gas Limit:</span></div>

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -373,10 +373,10 @@
 
                 {{ if .GasRefundDelta }}
                 <div class="row py-1">
-                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed is pre-refund gas. Gas refunds (SSTORE clears) are not subtracted from block space. Delta = block.gasUsed − sum(receipt.gasUsed). Refunds are credited to tx.origin (EIP-8037).">Gas Refund Delta:</span></div>
+                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed = max(sum_regular, sum_state) — a 2D formula. When block.gasUsed exceeds sum(receipt.gasUsed), refunds are not reducing block space. Delta = block.gasUsed − sum(receipt.gasUsed). Refunds go to tx.origin (EIP-8037).">Gas Refund Delta:</span></div>
                   <div class="col-md-10 text-monospace">
                     +{{ formatAddCommas .GasRefundDelta }}
-                    <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: refunds excluded from block gas accounting">EIP-7778</span>
+                    <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: block uses 2D gas formula; regular gas dimension dominates in this block">EIP-7778</span>
                     <small class="text-muted ms-2">(receipts sum: {{ formatAddCommas .SumTxGasUsed }})</small>
                   </div>
                 </div>

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -373,10 +373,15 @@
 
                 {{ if .GasRefundDelta }}
                 <div class="row py-1">
-                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed = max(sum_regular, sum_state) — a 2D formula. When block.gasUsed exceeds sum(receipt.gasUsed), refunds are not reducing block space. Delta = block.gasUsed − sum(receipt.gasUsed). Refunds go to tx.origin (EIP-8037).">Gas Refund Delta:</span></div>
+                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed = max(sum_regular, sum_state). These two counters ALWAYS diverge in Amsterdam (they were equal pre-Amsterdam). +delta: regular gas dominates (block > receipts). -delta: state gas dominates (block < receipts).">Gas Refund Delta:</span></div>
                   <div class="col-md-10 text-monospace">
-                    +{{ formatAddCommas .GasRefundDelta }}
-                    <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: block uses 2D gas formula; regular gas dimension dominates in this block">EIP-7778</span>
+                    {{ if .GasRefundDeltaExcess }}
+                      <span class="text-success">+{{ formatAddCommas .GasRefundDelta }}</span>
+                      <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: regular gas dominates — block.gasUsed exceeds sum(receipt.gasUsed). Refunds not subtracted from block space.">EIP-7778 ▲</span>
+                    {{ else }}
+                      <span class="text-warning">−{{ formatAddCommas .GasRefundDelta }}</span>
+                      <span class="badge bg-warning text-dark ms-2" data-bs-toggle="tooltip" title="EIP-7778: state gas dominates — block.gasUsed is BELOW sum(receipt.gasUsed). 2D accounting: block counts max(regular,state), not simple sum.">EIP-7778 ▼</span>
+                    {{ end }}
                     <small class="text-muted ms-2">(receipts sum: {{ formatAddCommas .SumTxGasUsed }})</small>
                   </div>
                 </div>

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -373,14 +373,14 @@
 
                 {{ if .BlockGasDelta }}
                 <div class="row py-1">
-                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed = max(sum_regular, sum_state), which differs from sum(receipt.gasUsed). +delta: block.gasUsed &gt; receipts sum (regular gas dominates; in refund-only blocks this equals sum of EIP-3529 refunds). -delta: block.gasUsed &lt; receipts sum (state gas dominates, EIP-8037).">Block Gas Delta:</span></div>
+                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778 (Amsterdam): block.gasUsed = max(Σ regular, Σ state) instead of Σ receipt.gasUsed. Receipts include regular + state gas (EIP-8037) minus EIP-3529 refunds. The delta reveals how the 2D gas model shifts gas accounting: positive means the block header under-counts relative to receipts (refunds not reflected); negative means state gas inflated receipts beyond what the block header counts.">Block Gas Delta:</span></div>
                   <div class="col-md-10 text-monospace">
                     {{ if .BlockGasDeltaExcess }}
                       <span class="text-success">+{{ formatAddCommas .BlockGasDelta }}</span>
-                      <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: regular gas dominates — block.gasUsed exceeds sum(receipt.gasUsed). In refund-only blocks this equals the sum of EIP-3529 gas refunds.">EIP-7778 ▲</span>
+                      <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="block.gasUsed &gt; Σ receipt.gasUsed — regular gas dominates the block dimension. The gap equals gas refunds (EIP-3529) when no state gas is present, or refunds minus state gas in mixed blocks. Means senders were charged more in receipts than the block header reports.">EIP-7778 ▲</span>
                     {{ else }}
                       <span class="text-warning">−{{ formatAddCommas .BlockGasDelta }}</span>
-                      <span class="badge bg-warning text-dark ms-2" data-bs-toggle="tooltip" title="EIP-7778: state gas dominates — block.gasUsed is BELOW sum(receipt.gasUsed). 2D accounting: block counts max(regular,state); receipts include both regular+state gas.">EIP-7778 ▼</span>
+                      <span class="badge bg-warning text-dark ms-2" data-bs-toggle="tooltip" title="block.gasUsed &lt; Σ receipt.gasUsed — state gas (EIP-8037) dominates the block dimension. Receipts sum higher than block.gasUsed because receipts include both regular + state gas per tx, but the block header only reports max(regular, state).">EIP-7778 ▼</span>
                     {{ end }}
                     <small class="text-muted ms-2">(receipts sum: {{ formatAddCommas .SumTxGasUsed }})</small>
                   </div>

--- a/templates/slot/overview.html
+++ b/templates/slot/overview.html
@@ -371,16 +371,16 @@
                   </div>
                 </div>
 
-                {{ if .GasRefundDelta }}
+                {{ if .BlockGasDelta }}
                 <div class="row py-1">
-                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed = max(sum_regular, sum_state). These two counters ALWAYS diverge in Amsterdam (they were equal pre-Amsterdam). +delta: regular gas dominates (block > receipts). -delta: state gas dominates (block < receipts).">Gas Refund Delta:</span></div>
+                  <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="EIP-7778: block.gasUsed = max(sum_regular, sum_state), which differs from sum(receipt.gasUsed). +delta: block.gasUsed &gt; receipts sum (regular gas dominates; in refund-only blocks this equals sum of EIP-3529 refunds). -delta: block.gasUsed &lt; receipts sum (state gas dominates, EIP-8037).">Block Gas Delta:</span></div>
                   <div class="col-md-10 text-monospace">
-                    {{ if .GasRefundDeltaExcess }}
-                      <span class="text-success">+{{ formatAddCommas .GasRefundDelta }}</span>
-                      <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: regular gas dominates — block.gasUsed exceeds sum(receipt.gasUsed). Refunds not subtracted from block space.">EIP-7778 ▲</span>
+                    {{ if .BlockGasDeltaExcess }}
+                      <span class="text-success">+{{ formatAddCommas .BlockGasDelta }}</span>
+                      <span class="badge bg-info ms-2" data-bs-toggle="tooltip" title="EIP-7778: regular gas dominates — block.gasUsed exceeds sum(receipt.gasUsed). In refund-only blocks this equals the sum of EIP-3529 gas refunds.">EIP-7778 ▲</span>
                     {{ else }}
-                      <span class="text-warning">−{{ formatAddCommas .GasRefundDelta }}</span>
-                      <span class="badge bg-warning text-dark ms-2" data-bs-toggle="tooltip" title="EIP-7778: state gas dominates — block.gasUsed is BELOW sum(receipt.gasUsed). 2D accounting: block counts max(regular,state), not simple sum.">EIP-7778 ▼</span>
+                      <span class="text-warning">−{{ formatAddCommas .BlockGasDelta }}</span>
+                      <span class="badge bg-warning text-dark ms-2" data-bs-toggle="tooltip" title="EIP-7778: state gas dominates — block.gasUsed is BELOW sum(receipt.gasUsed). 2D accounting: block counts max(regular,state); receipts include both regular+state gas.">EIP-7778 ▼</span>
                     {{ end }}
                     <small class="text-muted ms-2">(receipts sum: {{ formatAddCommas .SumTxGasUsed }})</small>
                   </div>

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -143,6 +143,11 @@ type SlotPageExecutionData struct {
 	BlockAccessListHash []byte                          `json:"block_access_list_hash,omitempty"`
 	BlockAccessList     []*SlotPageBlockAccessListEntry `json:"block_access_list,omitempty"`
 	BALSummary          *SlotPageBALSummary             `json:"bal_summary,omitempty"`
+
+	// EIP-7778: gas refund delta (block.gasUsed - sum(receipt.gasUsed)).
+	// Only set when EL indexing has enriched all tx receipts; nil otherwise.
+	SumTxGasUsed    *uint64 `json:"sum_tx_gas_used,omitempty"`
+	GasRefundDelta  *uint64 `json:"gas_refund_delta,omitempty"`
 }
 
 type SlotPageValidatorName struct {

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -147,8 +147,8 @@ type SlotPageExecutionData struct {
 	// EIP-7778: block gas delta. In Amsterdam block.gasUsed = max(sum_regular,sum_state)
 	// while sum(receipt.gasUsed) includes both regular+state gas per tx (minus refunds).
 	// Only set when EL indexing has enriched all tx receipts; nil otherwise.
-	SumTxGasUsed         *uint64 `json:"sum_tx_gas_used,omitempty"`
-	BlockGasDelta       *uint64 `json:"block_gas_delta,omitempty"`       // absolute value of block.gasUsed - sum(receipt.gasUsed)
+	SumTxGasUsed        *uint64 `json:"sum_tx_gas_used,omitempty"`
+	BlockGasDelta       *uint64 `json:"block_gas_delta,omitempty"`        // absolute value of block.gasUsed - sum(receipt.gasUsed)
 	BlockGasDeltaExcess bool    `json:"block_gas_delta_excess,omitempty"` // true = block > sum (regular dominates), false = block < sum (state dominates)
 }
 

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -144,12 +144,12 @@ type SlotPageExecutionData struct {
 	BlockAccessList     []*SlotPageBlockAccessListEntry `json:"block_access_list,omitempty"`
 	BALSummary          *SlotPageBALSummary             `json:"bal_summary,omitempty"`
 
-	// EIP-7778: gas refund delta. In Amsterdam block.gasUsed = max(sum_regular,sum_state)
-	// while sum(receipt.gasUsed) = gp.CumulativeUsed(). These ALWAYS diverge in Amsterdam.
+	// EIP-7778: block gas delta. In Amsterdam block.gasUsed = max(sum_regular,sum_state)
+	// while sum(receipt.gasUsed) includes both regular+state gas per tx (minus refunds).
 	// Only set when EL indexing has enriched all tx receipts; nil otherwise.
 	SumTxGasUsed         *uint64 `json:"sum_tx_gas_used,omitempty"`
-	GasRefundDelta       *uint64 `json:"gas_refund_delta,omitempty"`       // absolute value of delta
-	GasRefundDeltaExcess bool    `json:"gas_refund_delta_excess,omitempty"` // true = block > sum (regular dominates), false = block < sum (state dominates)
+	BlockGasDelta       *uint64 `json:"block_gas_delta,omitempty"`       // absolute value of block.gasUsed - sum(receipt.gasUsed)
+	BlockGasDeltaExcess bool    `json:"block_gas_delta_excess,omitempty"` // true = block > sum (regular dominates), false = block < sum (state dominates)
 }
 
 type SlotPageValidatorName struct {

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -144,10 +144,12 @@ type SlotPageExecutionData struct {
 	BlockAccessList     []*SlotPageBlockAccessListEntry `json:"block_access_list,omitempty"`
 	BALSummary          *SlotPageBALSummary             `json:"bal_summary,omitempty"`
 
-	// EIP-7778: gas refund delta (block.gasUsed - sum(receipt.gasUsed)).
+	// EIP-7778: gas refund delta. In Amsterdam block.gasUsed = max(sum_regular,sum_state)
+	// while sum(receipt.gasUsed) = gp.CumulativeUsed(). These ALWAYS diverge in Amsterdam.
 	// Only set when EL indexing has enriched all tx receipts; nil otherwise.
-	SumTxGasUsed    *uint64 `json:"sum_tx_gas_used,omitempty"`
-	GasRefundDelta  *uint64 `json:"gas_refund_delta,omitempty"`
+	SumTxGasUsed         *uint64 `json:"sum_tx_gas_used,omitempty"`
+	GasRefundDelta       *uint64 `json:"gas_refund_delta,omitempty"`       // absolute value of delta
+	GasRefundDeltaExcess bool    `json:"gas_refund_delta_excess,omitempty"` // true = block > sum (regular dominates), false = block < sum (state dominates)
 }
 
 type SlotPageValidatorName struct {


### PR DESCRIPTION
## Summary

Adds a **Block Gas Delta** row below *Gas Used* in the slot execution payload section, showing the difference between `block.gasUsed` and `Σ receipt.gasUsed`.

Amsterdam (EIP-7778) changed `block.gasUsed` from the naive sum of receipts to `max(Σ regular, Σ state)`, introducing a 2D gas model where the block header and the receipts can diverge:

- **Positive delta** (`block.gasUsed > Σ receipts`): regular gas dominates. The gap equals EIP-3529 gas refunds when no state gas is present, or refunds minus state gas in mixed blocks. Senders were charged more in receipts than the block header reports.
- **Zero delta**: no refunds and no state gas — block and receipts agree (e.g. pure ETH transfer blocks).
- **Negative delta** (`block.gasUsed < Σ receipts`): state gas (EIP-8037) dominates. Receipts include both regular + state gas per tx, but the block header only records `max(regular, state)`, so state-heavy blocks have receipts that exceed `block.gasUsed`.

The row is only shown when the EL indexer has enriched **all** tx receipts in the block (guard: `elDataCount == len(transactions)`). The model struct exposes `BlockGasDelta` (absolute value), `BlockGasDeltaExcess` (sign), and `SumTxGasUsed` for the receipts total.

## Screenshot

![Block Gas Delta on glamsterdam-devnet-6 Kurtosis network](https://assets.starflinger.eu/sha256/85/85a29ccdf02e333869e32224cd398046a0eb035504be47b5b30eea0b7aa239d4.png)

*Pure ETH-transfer block: delta = +0, confirming block header and receipts agree when there are no refunds and no state gas writes.*

## Test plan

- [x] Deploy against a glamsterdam-devnet-6 network — **Block Gas Delta** row appears below Gas Used for blocks with EL-indexed transactions
- [x] Zero-delta block (simple transfers): shows `+0 [EIP-7778 ▲]` with receipts sum matching `block.gasUsed`
- [ ] Block with SSTORE refunds: delta shows a positive non-zero value equal to the sum of EIP-3529 refunds
- [ ] Block with heavy state gas writes (EIP-8037): delta goes negative, `EIP-7778 ▼` badge appears
- [ ] Block where EL indexer has not yet enriched all receipts: row does not appear