### PR TITLE
fix: safe type assertion in beacon config and align rpc proxy IP extraction with middleware

### DIFF
--- a/clients/consensus/rpc/beaconapi.go
+++ b/clients/consensus/rpc/beaconapi.go
@@ -295,11 +295,12 @@ func (bc *BeaconClient) GetConfigSpecs(ctx context.Context) (map[string]interfac
 		return nil, fmt.Errorf("error retrieving specs: %v", err)
 	}
 
-	if specs["data"] == nil {
-		return nil, fmt.Errorf("specs data is nil")
+	dataMap, ok := specs["data"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("specs data is not an object (got %T)", specs["data"])
 	}
 
-	parsedSpecs := utils.ParseSpecMap(specs["data"].(map[string]interface{}))
+	parsedSpecs := utils.ParseSpecMap(dataMap)
 
 	return parsedSpecs, nil
 }

--- a/cmd/dora-explorer/main.go
+++ b/cmd/dora-explorer/main.go
@@ -90,7 +90,7 @@ func main() {
 	}
 
 	if cfg.RateLimit.Enabled {
-		err = services.StartCallRateLimiter(cfg.RateLimit.ProxyCount, cfg.RateLimit.Rate, cfg.RateLimit.Burst)
+		err = services.StartCallRateLimiter(cfg.GetProxyCount(), cfg.RateLimit.Rate, cfg.RateLimit.Burst)
 		if err != nil {
 			logger.Fatalf("error starting call rate limiter: %v", err)
 		}

--- a/handlers/middleware/utils.go
+++ b/handlers/middleware/utils.go
@@ -26,7 +26,7 @@ func APIErrorResponse(w http.ResponseWriter, status int, message string) {
 
 // GetClientIP extracts the real client IP from the request
 func GetClientIP(r *http.Request) string {
-	proxyCount := utils.Config.RateLimit.ProxyCount
+	proxyCount := utils.Config.GetProxyCount()
 
 	var ip string
 

--- a/services/rpcproxy.go
+++ b/services/rpcproxy.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/ethpandaops/dora/handlers/middleware"
 	"github.com/sirupsen/logrus"
 )
 
@@ -289,29 +289,6 @@ func parseBlockNumber(block interface{}) (int64, error) {
 	}
 }
 
-// getClientIP extracts the client IP from the request
-func (rp *RPCProxy) getClientIP(r *http.Request) string {
-	// Check X-Forwarded-For header first (for reverse proxies)
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take the first IP in the chain
-		if ips := strings.Split(xff, ","); len(ips) > 0 {
-			return strings.TrimSpace(ips[0])
-		}
-	}
-
-	// Check X-Real-IP header
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
-	}
-
-	// Fall back to remote address
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
-}
-
 // ServeHTTP implements the HTTP handler for the RPC proxy
 func (rp *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Only allow POST requests
@@ -321,7 +298,7 @@ func (rp *RPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get client IP and check rate limit
-	clientIP := rp.getClientIP(r)
+	clientIP := middleware.GetClientIP(r)
 	if !rp.rateLimiter.Allow(clientIP) {
 		rp.logger.WithField("client_ip", clientIP).Warn("Rate limit exceeded")
 		w.Header().Set("Content-Type", "application/json")

--- a/types/config.go
+++ b/types/config.go
@@ -17,8 +17,9 @@ type Config struct {
 	} `yaml:"logging"`
 
 	Server struct {
-		Port string `yaml:"port" envconfig:"FRONTEND_SERVER_PORT"`
-		Host string `yaml:"host" envconfig:"FRONTEND_SERVER_HOST"`
+		Port       string `yaml:"port" envconfig:"FRONTEND_SERVER_PORT"`
+		Host       string `yaml:"host" envconfig:"FRONTEND_SERVER_HOST"`
+		ProxyCount *uint  `yaml:"proxyCount" envconfig:"SERVER_PROXY_COUNT"`
 	} `yaml:"server"`
 
 	Chain struct {
@@ -92,7 +93,7 @@ type Config struct {
 
 	RateLimit struct {
 		Enabled    bool `yaml:"enabled" envconfig:"RATELIMIT_ENABLED"`
-		ProxyCount uint `yaml:"proxyCount" envconfig:"RATELIMIT_PROXY_COUNT"`
+		ProxyCount uint `yaml:"proxyCount" envconfig:"RATELIMIT_PROXY_COUNT"` // Deprecated: use server.proxyCount instead
 		Rate       uint `yaml:"rate" envconfig:"RATELIMIT_RATE"`
 		Burst      uint `yaml:"burst" envconfig:"RATELIMIT_BURST"`
 	} `yaml:"rateLimit"`
@@ -351,3 +352,13 @@ func (b *YamlBool) UnmarshalYAML(unmarshal func(any) error) error {
 
 	return nil
 }
+
+// GetProxyCount returns the resolved proxy count.
+// It prioritizes server.proxyCount (new setting) and falls back to rateLimit.proxyCount (deprecated setting).
+func (c *Config) GetProxyCount() uint {
+	if c.Server.ProxyCount != nil {
+		return *c.Server.ProxyCount
+	}
+	return c.RateLimit.ProxyCount
+}
+

--- a/types/config.go
+++ b/types/config.go
@@ -361,4 +361,3 @@ func (c *Config) GetProxyCount() uint {
 	}
 	return c.RateLimit.ProxyCount
 }
-

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -6,10 +6,10 @@ import (
 
 func TestConfigGetProxyCount(t *testing.T) {
 	tests := []struct {
-		name       string
-		serverVal  *uint
-		rateVal    uint
-		expected   uint
+		name      string
+		serverVal *uint
+		rateVal   uint
+		expected  uint
 	}{
 		{
 			name:      "only server.proxyCount is defined",

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestConfigGetProxyCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverVal  *uint
+		rateVal    uint
+		expected   uint
+	}{
+		{
+			name:      "only server.proxyCount is defined",
+			serverVal: uintPtr(3),
+			rateVal:   0,
+			expected:  3,
+		},
+		{
+			name:      "only rateLimit.proxyCount is defined",
+			serverVal: nil,
+			rateVal:   5,
+			expected:  5,
+		},
+		{
+			name:      "both are defined, server.proxyCount should prioritize",
+			serverVal: uintPtr(2),
+			rateVal:   4,
+			expected:  2,
+		},
+		{
+			name:      "neither is defined (server.proxyCount nil, rateLimit.proxyCount 0)",
+			serverVal: nil,
+			rateVal:   0,
+			expected:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.Server.ProxyCount = tt.serverVal
+			cfg.RateLimit.ProxyCount = tt.rateVal
+
+			got := cfg.GetProxyCount()
+			if got != tt.expected {
+				t.Errorf("GetProxyCount() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func uintPtr(u uint) *uint {
+	return &u
+}


### PR DESCRIPTION
Hey,

Two small but important fixes in this PR.

**1. Safe type assertion in GetConfigSpecs (beaconapi.go)**
In `GetConfigSpecs`, we were doing an unchecked type assertion on the beacon node config response - `specs["data"].(map[string]interface{})`. The nil check only checked if `data` is missing, but if the beacon node returns `data` as a string or array, it would panic and crash the explorer. Since this is called during client initialization, a panic here crashes the whole explorer.
Fixed it by using a proper comma-ok type assertion. If it is not a map, we now return a clean error instead of panicking. No change in behavior for normal responses.

**2. Centralized proxyCount configuration and consistent IP extraction (rpcproxy.go & types/config.go)**
The RPC proxy had its own `getClientIP` method which was not aligned with the middleware's `GetClientIP`. The RPC proxy was taking the leftmost IP from `X-Forwarded-For` which is easily spoofable by the client.
* Aligned the RPC proxy to use the shared `middleware.GetClientIP` instead.
* As suggested, we moved the `proxyCount` setting to the `server` config section (`server.proxyCount`) since it is a base connectivity option that affects multiple components.
* Added fallback logic: if `server.proxyCount` is not configured, it will fall back to using the deprecated `rateLimit.proxyCount` so we don't break old setups. Commented the old field as deprecated.
* Initialized the call rate limiter in `main.go` using the same resolved proxy count.
