### PR TITLE
fix(api): guard against divide-by-zero in epoch participation rate

### DIFF
--- a/handlers/api/epoch_v1.go
+++ b/handlers/api/epoch_v1.go
@@ -96,7 +96,9 @@ func ApiEpochV1(w http.ResponseWriter, r *http.Request) {
 		data.AttesterSlashingsCount = dbEpoch.AttesterSlashingCount
 		data.EligibleEther = dbEpoch.Eligible
 		data.VotedEther = dbEpoch.VotedTotal
-		data.GlobalParticipationRate = uint64(dbEpoch.VotedTarget * 100 / dbEpoch.Eligible)
+		if dbEpoch.Eligible > 0 {
+			data.GlobalParticipationRate = uint64(dbEpoch.VotedTarget * 100 / dbEpoch.Eligible)
+		}
 		data.ValidatorsCount = dbEpoch.ValidatorCount
 		data.TotalValidatorBalance = dbEpoch.ValidatorBalance
 		if dbEpoch.ValidatorCount > 0 {


### PR DESCRIPTION
## Summary

- `ApiEpochV1` panics with `integer divide by zero` at `epoch_v1.go:99` when `dbEpoch.Eligible == 0`
- This occurs for epoch 0 (genesis) and early epochs on new/devnet chains where no validators have been assigned duties yet
- Negroni's recovery middleware catches the panic and returns it as an HTTP 500 with the full stack trace

The fix wraps the division in a zero-guard, leaving `GlobalParticipationRate` at its zero-value when there is no eligible ether.

Introduced in #235 (`c02ed586`).

## Test plan

- [ ] Query `/api/v1/epoch/0` on a fresh devnet — should return 200 with `globalparticipationrate: 0` instead of panicking
- [ ] Query a normal epoch — participation rate should be unchanged