### PR TITLE
fix(clients): invalidate clients page cache on force refresh

### DIFF
--- a/cache/redis_cache.go
+++ b/cache/redis_cache.go
@@ -104,6 +104,23 @@ func (cache *RedisCache) Set(ctx context.Context, key string, value interface{},
 	return cache.redisRemoteCache.Set(ctx, fmt.Sprintf("%s%s", cache.keyPrefix, key), valueMarshal, expiration).Err()
 }
 
+func (cache *RedisCache) DeleteByPrefix(ctx context.Context, prefix string) error {
+	match := fmt.Sprintf("%s%s*", cache.keyPrefix, prefix)
+	iter := cache.redisRemoteCache.Scan(ctx, 0, match, 100).Iterator()
+
+	keys := []string{}
+	for iter.Next(ctx) {
+		keys = append(keys, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		return err
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return cache.redisRemoteCache.Del(ctx, keys...).Err()
+}
+
 func (cache *RedisCache) Get(ctx context.Context, key string, returnValue interface{}) (interface{}, error) {
 	value, err := cache.redisRemoteCache.Get(ctx, fmt.Sprintf("%s%s", cache.keyPrefix, key)).Result()
 	if err != nil {

--- a/cache/tiered_cache.go
+++ b/cache/tiered_cache.go
@@ -43,6 +43,8 @@ type RemoteCache interface {
 	GetString(ctx context.Context, key string) (string, error)
 	GetUint64(ctx context.Context, key string) (uint64, error)
 	GetBool(ctx context.Context, key string) (bool, error)
+
+	DeleteByPrefix(ctx context.Context, prefix string) error
 }
 
 func NewTieredCache(cacheSize int, redisAddress string, redisPrefix string, logger logrus.FieldLogger) (*TieredCache, error) {
@@ -221,6 +223,34 @@ func (cache *TieredCache) Get(key string, returnValue interface{}) (interface{},
 		cache.localGoCache.Set(key, valueMarshal)
 	}
 	return cacheValue.Value, nil
+}
+
+// DeleteByPrefix removes every entry whose key starts with prefix from both the local
+// and (if configured) the remote cache. It is used to actively invalidate a group of
+// related cached entries, e.g. all sort-order variants of a page after a forced refresh.
+func (cache *TieredCache) DeleteByPrefix(prefix string) error {
+	it := cache.localGoCache.Iterator()
+	localKeys := []string{}
+	for it.SetNext() {
+		entry, err := it.Value()
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(entry.Key(), prefix) {
+			localKeys = append(localKeys, entry.Key())
+		}
+	}
+	for _, key := range localKeys {
+		cache.localGoCache.Delete(key)
+	}
+
+	if cache.remoteCache == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	return cache.remoteCache.DeleteByPrefix(ctx, prefix)
 }
 
 // TieredCacheStats holds statistics about the tiered cache.

--- a/handlers/clients_cl.go
+++ b/handlers/clients_cl.go
@@ -52,9 +52,20 @@ func ClientsCL(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// clClientsPageCacheKeyPrefix is the shared prefix of every cached consensus clients page
+// variant. Each request caches under "<prefix><sortOrder>", so deleting the prefix evicts
+// all variants regardless of which sort orders were requested.
+const clClientsPageCacheKeyPrefix = "clients/consensus/"
+
+// InvalidateCLClientsPageCache evicts all cached variants of the consensus clients page
+// so the next request rebuilds them from freshly refreshed client data.
+func InvalidateCLClientsPageCache() {
+	services.GlobalFrontendCache.RemoveCacheByPrefix(clClientsPageCacheKeyPrefix)
+}
+
 func getCLClientsPageData(sortOrder string) (*models.ClientsCLPageData, error) {
 	pageData := &models.ClientsCLPageData{}
-	pageCacheKey := fmt.Sprintf("clients/consensus/%s", sortOrder)
+	pageCacheKey := fmt.Sprintf("%s%s", clClientsPageCacheKeyPrefix, sortOrder)
 	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(pageCall *services.FrontendCacheProcessingPage) interface{} {
 		pageData, cacheTimeout := buildCLClientsPageData(sortOrder)
 		pageCall.CacheTimeout = cacheTimeout

--- a/handlers/clients_cl_refresh.go
+++ b/handlers/clients_cl_refresh.go
@@ -187,7 +187,12 @@ func ClientsCLRefresh(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Note: Cache will be automatically invalidated on next page load due to fresh data
+	// Evict the cached consensus clients page(s). The page is served from the frontend
+	// page cache with a per-slot timeout, so without an explicit eviction the post-refresh
+	// reload would keep serving the stale render until that timeout expires.
+	if refreshedClients > 0 {
+		InvalidateCLClientsPageCache()
+	}
 
 	// Return success response
 	w.Header().Set("Content-Type", "application/json")

--- a/handlers/clients_el.go
+++ b/handlers/clients_el.go
@@ -48,9 +48,20 @@ func ClientsEl(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// elClientsPageCacheKeyPrefix is the shared prefix of every cached execution clients page
+// variant. Each request caches under "<prefix><sortOrder>", so deleting the prefix evicts
+// all variants regardless of which sort orders were requested.
+const elClientsPageCacheKeyPrefix = "clients/execution/"
+
+// InvalidateELClientsPageCache evicts all cached variants of the execution clients page
+// so the next request rebuilds them from freshly refreshed client data.
+func InvalidateELClientsPageCache() {
+	services.GlobalFrontendCache.RemoveCacheByPrefix(elClientsPageCacheKeyPrefix)
+}
+
 func getELClientsPageData(sortOrder string) (*models.ClientsELPageData, error) {
 	pageData := &models.ClientsELPageData{}
-	pageCacheKey := fmt.Sprintf("clients/execution/%s", sortOrder)
+	pageCacheKey := fmt.Sprintf("%s%s", elClientsPageCacheKeyPrefix, sortOrder)
 	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, pageData, func(pageCall *services.FrontendCacheProcessingPage) interface{} {
 		pageData, cacheTimeout := buildELClientsPageData(sortOrder)
 		pageCall.CacheTimeout = cacheTimeout

--- a/handlers/clients_el_refresh.go
+++ b/handlers/clients_el_refresh.go
@@ -187,7 +187,12 @@ func ClientsELRefresh(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Note: Cache will be automatically invalidated on next page load due to fresh data
+	// Evict the cached execution clients page(s). The page is served from the frontend
+	// page cache with a per-slot timeout, so without an explicit eviction the post-refresh
+	// reload would keep serving the stale render until that timeout expires.
+	if refreshedClients > 0 {
+		InvalidateELClientsPageCache()
+	}
 
 	// Return success response
 	w.Header().Set("Content-Type", "application/json")

--- a/services/frontendcache.go
+++ b/services/frontendcache.go
@@ -281,6 +281,17 @@ func (fc *FrontendCacheService) setFrontendCache(pageKey string, value interface
 	return fc.tieredCache.Set(pageKey, value, timeout)
 }
 
+// RemoveCacheByPrefix evicts every cached page whose key starts with pageKeyPrefix, so the
+// next request rebuilds them from fresh data. This is used to actively invalidate all
+// variants of a page (e.g. every sort order) after the underlying data has been
+// force-refreshed, instead of waiting for each page's cache timeout to expire.
+func (fc *FrontendCacheService) RemoveCacheByPrefix(pageKeyPrefix string) error {
+	if !fc.cachingEnabled {
+		return nil
+	}
+	return fc.tieredCache.DeleteByPrefix(pageKeyPrefix)
+}
+
 func (fc *FrontendCacheService) completePageLoad(pageKey string, processingPage *FrontendCacheProcessingPage) {
 	processingPage.modelMutex.Unlock()
 	fc.processingMutex.Lock()


### PR DESCRIPTION
## Problem

The **refresh button** on the consensus/execution clients pages (the ⟳ next to "Peer infos") doesn't take effect until the page cache happens to expire on its own — so users see stale peer counts, ENR fields (e.g. `cgc`), and the peer matrix even right after clicking it.

### Root cause

`ClientsCLRefresh` / `ClientsELRefresh` call `client.ForceUpdateNodeMetadata`, which **does** refresh the backend data — `updateNodeMetadata` updates both `client.nodeIdentity` and `client.peers` (`clients/consensus/clientlogic.go`). The button's JS then `window.location.reload()`s ~1s later.

But the clients page is served through the frontend page cache:

```go
pageCacheKey := fmt.Sprintf("clients/consensus/%s", sortOrder) // CacheTimeout = SlotDurationMs
GlobalFrontendCache.ProcessCachedPage(pageCacheKey, true, …)
```

`ProcessCachedPage` is a plain TTL cache — if the key is still valid it returns the cached render and never calls the build function. The refresh handlers **never evicted** these keys; they only carried the comment:

```go
// Note: Cache will be automatically invalidated on next page load due to fresh data
```

…which isn't true. The post-refresh reload lands inside the still-valid per-slot window and re-serves the **pre-refresh** render. There was also no cache-eviction primitive in the codebase at all (`FrontendCacheService` had no delete; `TieredCache` only had `Get`/`Set`).

## Fix

- Add a **prefix-based** eviction path: `TieredCache.DeleteByPrefix` (local bigcache iterate-and-delete + redis `SCAN`/`DEL`, via a new `DeleteByPrefix` on the `RemoteCache` interface / `RedisCache`) and a `FrontendCacheService.RemoveCacheByPrefix` wrapper.
- After a successful force refresh, evict the `clients/consensus/` and `clients/execution/` page-cache prefixes, so the reload rebuilds from fresh data immediately.
- Replace the misleading comments.

Deleting by prefix covers every cached sort-order variant **without enumerating them**. The sort order is taken verbatim from the `o` query arg (the sort `switch`'s `default` accepts any value), so the keyspace is open-ended and an explicit list couldn't cover it reliably anyway. The page handlers now declare the shared key prefix as the single source of truth for the key format.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- Reproduced against a 15-node Kurtosis devnet: the live beacon API reported a node's refreshed ENR/`cgc`/peers (`custody_group_count: 128`) while Dora's page kept showing the stale boot-time values (`cgc: 4`) until the slot-length cache TTL lapsed; the refresh `POST` returned `{"success": true}` yet the reload stayed stale. With the prefix eviction the reload reflects the refreshed data right away.