### PR TITLE
fix(ui): compact builder column to link button for long builder URLs

### DIFF
--- a/utils/format.go
+++ b/utils/format.go
@@ -921,10 +921,7 @@ func formatBuilder(index uint64, name string, externalURL string, icon string, w
 	// instance, showing the URL on hover instead of printing it inline.
 	if externalURL != "" {
 		linkButton := fmt.Sprintf(` <a href="%v" target="_blank" rel="noopener noreferrer" class="builder-external-link text-muted ms-1" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="%v"><i class="fas fa-external-link-alt"></i></a>`, html.EscapeString(externalURL), html.EscapeString(externalURL))
-		if withIndex {
-			return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, index, linkButton))
-		}
-		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><a href=\"/builder/%v\"><i class=\"fas %v\"></i></a>%v</span>", index, icon, linkButton))
+		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, index, linkButton))
 	}
 
 	if name != "" {

--- a/utils/format.go
+++ b/utils/format.go
@@ -916,12 +916,10 @@ func formatBuilder(index uint64, name string, externalURL string, icon string, w
 	}
 
 	// When the builder exposes an external URL, its "name" is often the full API URL, which is
-	// far too long for the table columns. Collapse it to a compact link button: the hard-hat icon
-	// links to the builder details page and a small external-link button opens the buildoor
-	// instance, showing the URL on hover instead of printing it inline.
+	// far too long for the table columns. Collapse it to the hyperlinked builder index and show
+	// the full API URL on hover instead of printing it inline.
 	if externalURL != "" {
-		linkButton := fmt.Sprintf(` <a href="%v" target="_blank" rel="noopener noreferrer" class="builder-external-link text-muted ms-1" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="%v"><i class="fas fa-external-link-alt"></i></a>`, html.EscapeString(externalURL), html.EscapeString(externalURL))
-		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, index, linkButton))
+		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\" data-bs-toggle=\"tooltip\" data-bs-placement=\"top\" data-bs-title=\"%v\">%v</a></span>", icon, index, html.EscapeString(externalURL), index))
 	}
 
 	if name != "" {

--- a/utils/format.go
+++ b/utils/format.go
@@ -915,9 +915,16 @@ func formatBuilder(index uint64, name string, externalURL string, icon string, w
 		return template.HTML("<span class=\"builder-label builder-index\"><i class=\"fas fa-house mr-2\"></i> Self-built</span>")
 	}
 
-	externalLink := ""
+	// When the builder exposes an external URL, its "name" is often the full API URL, which is
+	// far too long for the table columns. Collapse it to a compact link button: the hard-hat icon
+	// links to the builder details page and a small external-link button opens the buildoor
+	// instance, showing the URL on hover instead of printing it inline.
 	if externalURL != "" {
-		externalLink = fmt.Sprintf(` <a href="%v" target="_blank" rel="noopener noreferrer" class="builder-external-link text-muted ms-1" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Open buildoor instance"><i class="fas fa-external-link-alt"></i></a>`, html.EscapeString(externalURL))
+		linkButton := fmt.Sprintf(` <a href="%v" target="_blank" rel="noopener noreferrer" class="builder-external-link text-muted ms-1" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="%v"><i class="fas fa-external-link-alt"></i></a>`, html.EscapeString(externalURL), html.EscapeString(externalURL))
+		if withIndex {
+			return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, index, linkButton))
+		}
+		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><a href=\"/builder/%v\"><i class=\"fas %v\"></i></a>%v</span>", index, icon, linkButton))
 	}
 
 	if name != "" {
@@ -927,9 +934,9 @@ func formatBuilder(index uint64, name string, externalURL string, icon string, w
 		} else {
 			nameLabel = html.EscapeString(name)
 		}
-		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-name\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, nameLabel, externalLink))
+		return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-name\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a></span>", icon, index, nameLabel))
 	}
-	return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a>%v</span>", icon, index, index, externalLink))
+	return template.HTML(fmt.Sprintf("<span class=\"builder-label builder-index\"><i class=\"fas %v\"></i> <a href=\"/builder/%v\">%v</a></span>", icon, index, index))
 }
 
 func FormatRecentTimeShort(ts time.Time) template.HTML {


### PR DESCRIPTION
Before: 
<img width="1713" height="1196" alt="Screenshot 2026-06-25 at 17 11 05" src="https://github.com/user-attachments/assets/a5f0b774-fa58-4116-966c-4849ce03d42c" />

After: 
<img width="1585" height="748" alt="Screenshot 2026-06-25 at 17 12 26" src="https://github.com/user-attachments/assets/842484ab-0d29-4d30-bcda-d7d07a506bba" />



## Problem

On devnets where the builder API name is the full buildoor URL (e.g. `api-buildoor-lodestar-besu-1.srv.glamsterdam-devnet-6.ethpandaops.io`), the Blocks page Builder column gets very wide and awkward, since the long name is printed inline.

## Change

In `formatBuilder` (`utils/format.go`), when a builder has an external (buildoor) URL, render a compact link button instead of the long inline name:

- the hard-hat icon links to the builder details page (`/builder/{index}`)
- a small external-link button opens the buildoor instance, with the **full API URL shown on hover** (tooltip)
- the `withIndex` variants still show the numeric index so rows stay distinguishable

Builders without an external URL keep their existing name/index rendering. Applies everywhere the formatter is used (blocks list, slots list, slot bids).

## Note

This collapses the name for *any* builder with an external URL, including setups where the name is a short friendly label. On ethpandaops devnets the name is the URL, so this is a clear win.