### PR TITLE
fix(ui): show missed payload status on blocks view

### DIFF
--- a/handlers/blocks.go
+++ b/handlers/blocks.go
@@ -254,12 +254,19 @@ func buildBlocksPageData(ctx context.Context, firstSlot uint64, pageSize uint64,
 			dbSlot := dbBlocks[dbIdx]
 			dbIdx++
 
+			epoch := chainState.EpochOfSlot(phase0.Slot(slot))
+			payloadStatus := dbSlot.PayloadStatus
+			if !chainState.IsEip7732Enabled(phase0.Epoch(epoch)) {
+				payloadStatus = dbtypes.PayloadStatusCanonical
+			}
+
 			slotData := &models.BlocksPageDataSlot{
 				Slot:                  slot,
-				Epoch:                 uint64(chainState.EpochOfSlot(phase0.Slot(slot))),
+				Epoch:                 uint64(epoch),
 				Ts:                    chainState.SlotToTime(phase0.Slot(slot)),
 				Finalized:             finalized,
 				Status:                uint8(dbSlot.Status),
+				PayloadStatus:         uint8(payloadStatus),
 				Scheduled:             slot >= uint64(currentSlot) && dbSlot.Status == dbtypes.Missing,
 				Synchronized:          dbSlot.SyncParticipation != -1,
 				Proposer:              dbSlot.Proposer,

--- a/handlers/blocks_filtered.go
+++ b/handlers/blocks_filtered.go
@@ -455,12 +455,18 @@ func buildFilteredBlocksPageData(ctx context.Context, pageIdx uint64, pageSize u
 			continue
 		}
 
+		payloadStatus := dbBlock.Block.PayloadStatus
+		if !chainState.IsEip7732Enabled(chainState.EpochOfSlot(slot)) {
+			payloadStatus = dbtypes.PayloadStatusCanonical
+		}
+
 		blockData := &models.BlocksFilteredPageDataBlock{
 			Epoch:               uint64(chainState.EpochOfSlot(slot)),
 			Slot:                uint64(slot),
 			EthBlockNumber:      *dbBlock.Block.EthBlockNumber,
 			Ts:                  chainState.SlotToTime(slot),
 			Status:              uint8(dbBlock.Block.Status),
+			PayloadStatus:       uint8(payloadStatus),
 			EthTransactionCount: dbBlock.Block.EthTransactionCount,
 			BlobCount:           dbBlock.Block.BlobCount,
 			ElExtraData:         dbBlock.Block.EthBlockExtra,

--- a/templates/blocks/blocks.html
+++ b/templates/blocks/blocks.html
@@ -134,9 +134,9 @@
                       {{ if eq $slot.Slot 0 }}
                         <span class="badge rounded-pill text-bg-info">Genesis</span>
                       {{ else if eq $slot.Status 1 }}
-                        <span class="badge rounded-pill text-bg-success">Proposed</span>
+                        <span class="badge rounded-pill text-bg-success {{ if eq $slot.PayloadStatus 0 }}split-warning{{ else if eq $slot.PayloadStatus 2 }}split-info{{ end }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ formatSlotStatusTooltip $slot.Status $slot.PayloadStatus }}">Proposed</span>
                       {{ else if eq $slot.Status 2 }}
-                        <span class="badge rounded-pill text-bg-info">Orphaned</span>
+                        <span class="badge rounded-pill text-bg-info {{ if eq $slot.PayloadStatus 0 }}split-warning{{ else if eq $slot.PayloadStatus 2 }}split-info{{ end }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ formatSlotStatusTooltip $slot.Status $slot.PayloadStatus }}">Orphaned</span>
                       {{ else if $slot.Scheduled }}
                         <span class="badge rounded-pill text-bg-secondary">Scheduled</span>
                       {{ else if not $slot.Synchronized }}
@@ -144,7 +144,7 @@
                       {{ else if eq $slot.Status 0 }}
                         <span class="badge rounded-pill text-bg-warning">Missed</span>
                       {{ else }}
-                        <span class="badge rounded-pill text-bg-dark">Unknown</span>
+                        <span class="badge rounded-pill text-bg-dark {{ if eq $slot.PayloadStatus 0 }}split-warning{{ else if eq $slot.PayloadStatus 2 }}split-info{{ end }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ formatSlotStatusTooltip $slot.Status $slot.PayloadStatus }}">Unknown</span>
                       {{ end }}
                     </td>
                     {{ end }}

--- a/templates/blocks_filtered/blocks_filtered.html
+++ b/templates/blocks_filtered/blocks_filtered.html
@@ -272,11 +272,11 @@
                     {{- if $g.DisplayStatus }}
                     <td>
                       {{- if eq $block.Status 1 }}
-                        <span class="badge rounded-pill text-bg-success">Proposed</span>
+                        <span class="badge rounded-pill text-bg-success {{ if eq $block.PayloadStatus 0 }}split-warning{{ else if eq $block.PayloadStatus 2 }}split-info{{ end }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ formatSlotStatusTooltip $block.Status $block.PayloadStatus }}">Proposed</span>
                       {{- else if eq $block.Status 2 }}
-                        <span class="badge rounded-pill text-bg-info">Orphaned</span>
+                        <span class="badge rounded-pill text-bg-info {{ if eq $block.PayloadStatus 0 }}split-warning{{ else if eq $block.PayloadStatus 2 }}split-info{{ end }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ formatSlotStatusTooltip $block.Status $block.PayloadStatus }}">Orphaned</span>
                       {{- else }}
-                        <span class="badge rounded-pill text-bg-dark">Unknown</span>
+                        <span class="badge rounded-pill text-bg-dark {{ if eq $block.PayloadStatus 0 }}split-warning{{ else if eq $block.PayloadStatus 2 }}split-info{{ end }}" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="{{ formatSlotStatusTooltip $block.Status $block.PayloadStatus }}">Unknown</span>
                       {{- end }}
                     </td>
                     {{- end }}

--- a/types/models/blocks.go
+++ b/types/models/blocks.go
@@ -61,6 +61,7 @@ type BlocksPageDataSlot struct {
 	Finalized             bool                       `json:"scheduled"`
 	Scheduled             bool                       `json:"finalized"`
 	Status                uint8                      `json:"status"`
+	PayloadStatus         uint8                      `json:"payload_status"`
 	Synchronized          bool                       `json:"synchronized"`
 	Proposer              uint64                     `json:"proposer"`
 	ProposerName          string                     `json:"proposer_name"`

--- a/types/models/blocks_filtered.go
+++ b/types/models/blocks_filtered.go
@@ -73,6 +73,7 @@ type BlocksFilteredPageDataBlock struct {
 	EthBlockNumber      uint64    `json:"eth_block_number"`
 	Ts                  time.Time `json:"ts"`
 	Status              uint8     `json:"status"`
+	PayloadStatus       uint8     `json:"payload_status"`
 	EthTransactionCount uint64    `json:"eth_transaction_count"`
 	BlobCount           uint64    `json:"blob_count"`
 	ElExtraData         []byte    `json:"el_extra_data"`


### PR DESCRIPTION
## Problem

On the **Blocks** view, the Status column showed a solid green **Proposed** badge even when the execution payload was completely missed (EIP-7732 / ePBS). This hid the missed-payload condition that the **Slots** view already surfaces via a half-yellow split bubble.

## Fix

Mirror the existing slots-view pattern on both the blocks list and the filtered blocks list:

- `types/models/blocks.go` & `types/models/blocks_filtered.go` — add `PayloadStatus uint8` field.
- `handlers/blocks.go` & `handlers/blocks_filtered.go` — populate `PayloadStatus` from the DB block, defaulting to `PayloadStatusCanonical` when EIP-7732 isn't active for that epoch (same guard as `handlers/slots.go`).
- `templates/blocks/blocks.html` & `templates/blocks_filtered/blocks_filtered.html` — apply `split-warning` (missed payload, `PayloadStatus == 0`) / `split-info` (`== 2`) classes and the `formatSlotStatusTooltip` hover tooltip to the status badges.

The `split-warning` CSS (half-yellow bubble) already exists in `static/css/layout.css`, so no style changes were needed. A missed payload on a proposed block now renders the same green/yellow split badge as the slot view.