### PR TITLE
feat(index/api): payload participation column + epoch health endpoint

### DIFF
--- a/cmd/dora-explorer/main.go
+++ b/cmd/dora-explorer/main.go
@@ -321,6 +321,7 @@ func startApi(router *mux.Router) {
 		// Epoch and slot APIs
 		{"/v1/epochs", api.APIEpochsV1, []string{"GET", "OPTIONS"}, 1},
 		{"/v1/epoch/{epoch}", api.ApiEpochV1, []string{"GET", "OPTIONS"}, 1},
+		{"/v1/epoch/{epoch}/health", api.ApiEpochHealthV1, []string{"GET", "OPTIONS"}, 1},
 		{"/v1/slot/{slotOrHash}", api.APISlotV1, []string{"GET", "OPTIONS"}, 1},
 		{"/v1/slot/{slotOrHash}/bids", api.APISlotBidsV1, []string{"GET", "OPTIONS"}, 1},
 		{"/v1/slot/{slotOrHash}/block_access_list", api.APISlotBlockAccessListV1, []string{"GET", "OPTIONS"}, 2},

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -721,6 +721,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/epoch/{epoch}/health": {
+            "get": {
+                "description": "Returns the vote, proposal and payload participation rates for an epoch. The chain is only fully healthy when all three reach 100%. Post-ePBS (EIP-7732) payloads are revealed separately from beacon blocks and may be missing.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Epoch"
+                ],
+                "summary": "Get epoch health by number, latest, finalized",
+                "operationId": "getEpochHealth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Epoch number, the string latest or the string finalized",
+                        "name": "epoch",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.ApiResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/api.APIEpochHealthResponseV1"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Failure",
+                        "schema": {
+                            "$ref": "#/definitions/api.ApiResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ApiResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/epochs": {
             "get": {
                 "description": "Returns a list of epochs with detailed information and statistics",
@@ -3211,6 +3265,47 @@ const docTemplate = `{
                 }
             }
         },
+        "api.APIEpochHealthResponseV1": {
+            "type": "object",
+            "properties": {
+                "eligible_ether": {
+                    "type": "integer"
+                },
+                "epoch": {
+                    "type": "integer"
+                },
+                "finalized": {
+                    "type": "boolean"
+                },
+                "healthy": {
+                    "type": "boolean"
+                },
+                "payload_participation": {
+                    "type": "number"
+                },
+                "proposal_participation": {
+                    "type": "number"
+                },
+                "proposed_blocks": {
+                    "type": "integer"
+                },
+                "proposed_payloads": {
+                    "type": "integer"
+                },
+                "slots": {
+                    "type": "integer"
+                },
+                "ts": {
+                    "type": "integer"
+                },
+                "vote_participation": {
+                    "type": "number"
+                },
+                "voted_ether": {
+                    "type": "integer"
+                }
+            }
+        },
         "api.APIEpochInfo": {
             "type": "object",
             "properties": {
@@ -3256,10 +3351,16 @@ const docTemplate = `{
                 "missed_blocks": {
                     "type": "integer"
                 },
+                "missed_payloads": {
+                    "type": "integer"
+                },
                 "orphaned_blocks": {
                     "type": "integer"
                 },
                 "proposed_blocks": {
+                    "type": "integer"
+                },
+                "proposed_payloads": {
                     "type": "integer"
                 },
                 "proposer_slashings": {
@@ -3333,10 +3434,16 @@ const docTemplate = `{
                 "missedblocks": {
                     "type": "integer"
                 },
+                "missedpayloads": {
+                    "type": "integer"
+                },
                 "orphanedblocks": {
                     "type": "integer"
                 },
                 "proposedblocks": {
+                    "type": "integer"
+                },
+                "proposedpayloads": {
                     "type": "integer"
                 },
                 "proposerslashingscount": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -718,6 +718,60 @@
                 }
             }
         },
+        "/v1/epoch/{epoch}/health": {
+            "get": {
+                "description": "Returns the vote, proposal and payload participation rates for an epoch. The chain is only fully healthy when all three reach 100%. Post-ePBS (EIP-7732) payloads are revealed separately from beacon blocks and may be missing.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Epoch"
+                ],
+                "summary": "Get epoch health by number, latest, finalized",
+                "operationId": "getEpochHealth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Epoch number, the string latest or the string finalized",
+                        "name": "epoch",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.ApiResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/api.APIEpochHealthResponseV1"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Failure",
+                        "schema": {
+                            "$ref": "#/definitions/api.ApiResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ApiResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/epochs": {
             "get": {
                 "description": "Returns a list of epochs with detailed information and statistics",
@@ -3208,6 +3262,47 @@
                 }
             }
         },
+        "api.APIEpochHealthResponseV1": {
+            "type": "object",
+            "properties": {
+                "eligible_ether": {
+                    "type": "integer"
+                },
+                "epoch": {
+                    "type": "integer"
+                },
+                "finalized": {
+                    "type": "boolean"
+                },
+                "healthy": {
+                    "type": "boolean"
+                },
+                "payload_participation": {
+                    "type": "number"
+                },
+                "proposal_participation": {
+                    "type": "number"
+                },
+                "proposed_blocks": {
+                    "type": "integer"
+                },
+                "proposed_payloads": {
+                    "type": "integer"
+                },
+                "slots": {
+                    "type": "integer"
+                },
+                "ts": {
+                    "type": "integer"
+                },
+                "vote_participation": {
+                    "type": "number"
+                },
+                "voted_ether": {
+                    "type": "integer"
+                }
+            }
+        },
         "api.APIEpochInfo": {
             "type": "object",
             "properties": {
@@ -3253,10 +3348,16 @@
                 "missed_blocks": {
                     "type": "integer"
                 },
+                "missed_payloads": {
+                    "type": "integer"
+                },
                 "orphaned_blocks": {
                     "type": "integer"
                 },
                 "proposed_blocks": {
+                    "type": "integer"
+                },
+                "proposed_payloads": {
                     "type": "integer"
                 },
                 "proposer_slashings": {
@@ -3330,10 +3431,16 @@
                 "missedblocks": {
                     "type": "integer"
                 },
+                "missedpayloads": {
+                    "type": "integer"
+                },
                 "orphanedblocks": {
                     "type": "integer"
                 },
                 "proposedblocks": {
+                    "type": "integer"
+                },
+                "proposedpayloads": {
                     "type": "integer"
                 },
                 "proposerslashingscount": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -528,6 +528,33 @@ definitions:
       status:
         type: string
     type: object
+  api.APIEpochHealthResponseV1:
+    properties:
+      eligible_ether:
+        type: integer
+      epoch:
+        type: integer
+      finalized:
+        type: boolean
+      healthy:
+        type: boolean
+      payload_participation:
+        type: number
+      proposal_participation:
+        type: number
+      proposed_blocks:
+        type: integer
+      proposed_payloads:
+        type: integer
+      slots:
+        type: integer
+      ts:
+        type: integer
+      vote_participation:
+        type: number
+      voted_ether:
+        type: integer
+    type: object
   api.APIEpochInfo:
     properties:
       attestations:
@@ -558,9 +585,13 @@ definitions:
         type: integer
       missed_blocks:
         type: integer
+      missed_payloads:
+        type: integer
       orphaned_blocks:
         type: integer
       proposed_blocks:
+        type: integer
+      proposed_payloads:
         type: integer
       proposer_slashings:
         type: integer
@@ -609,9 +640,13 @@ definitions:
         type: integer
       missedblocks:
         type: integer
+      missedpayloads:
+        type: integer
       orphanedblocks:
         type: integer
       proposedblocks:
+        type: integer
+      proposedpayloads:
         type: integer
       proposerslashingscount:
         type: integer
@@ -2382,6 +2417,42 @@ paths:
           schema:
             $ref: '#/definitions/api.ApiResponse'
       summary: Get epoch by number, latest, finalized
+      tags:
+      - Epoch
+  /v1/epoch/{epoch}/health:
+    get:
+      description: Returns the vote, proposal and payload participation rates for
+        an epoch. The chain is only fully healthy when all three reach 100%. Post-ePBS
+        (EIP-7732) payloads are revealed separately from beacon blocks and may be
+        missing.
+      operationId: getEpochHealth
+      parameters:
+      - description: Epoch number, the string latest or the string finalized
+        in: path
+        name: epoch
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.ApiResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/api.APIEpochHealthResponseV1'
+              type: object
+        "400":
+          description: Failure
+          schema:
+            $ref: '#/definitions/api.ApiResponse'
+        "500":
+          description: Server Error
+          schema:
+            $ref: '#/definitions/api.ApiResponse'
+      summary: Get epoch health by number, latest, finalized
       tags:
       - Epoch
   /v1/epochs:

--- a/handlers/api/epoch_health_v1.go
+++ b/handlers/api/epoch_health_v1.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/ethpandaops/dora/services"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+)
+
+// APIEpochHealthResponseV1 reports the three participation rates that together
+// describe the health of an epoch. Post-ePBS (EIP-7732) a beacon block can be
+// proposed while its execution payload is missing, so payload participation is
+// tracked separately from proposal participation. The chain is only fully
+// healthy for an epoch when all three rates reach 100%.
+type APIEpochHealthResponseV1 struct {
+	Epoch                 uint64  `json:"epoch"`
+	Ts                    uint64  `json:"ts"`
+	Finalized             bool    `json:"finalized"`
+	EligibleEther         uint64  `json:"eligible_ether"`
+	VotedEther            uint64  `json:"voted_ether"`
+	VoteParticipation     float64 `json:"vote_participation"`
+	ProposedBlocks        uint64  `json:"proposed_blocks"`
+	ProposalParticipation float64 `json:"proposal_participation"`
+	ProposedPayloads      uint64  `json:"proposed_payloads"`
+	PayloadParticipation  float64 `json:"payload_participation"`
+	Slots                 uint64  `json:"slots"`
+	Healthy               bool    `json:"healthy"`
+}
+
+// ApiEpochHealthV1 godoc
+// @Summary Get epoch health by number, latest, finalized
+// @Tags Epoch
+// @Description Returns the vote, proposal and payload participation rates for an epoch. The chain is only fully healthy when all three reach 100%. Post-ePBS (EIP-7732) payloads are revealed separately from beacon blocks and may be missing.
+// @Produce  json
+// @Param  epoch path string true "Epoch number, the string latest or the string finalized"
+// @Success 200 {object} ApiResponse{data=APIEpochHealthResponseV1} "Success"
+// @Failure 400 {object} ApiResponse "Failure"
+// @Failure 500 {object} ApiResponse "Server Error"
+// @Router /v1/epoch/{epoch}/health [get]
+// @ID getEpochHealth
+func ApiEpochHealthV1(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	vars := mux.Vars(r)
+
+	epoch, err := strconv.ParseInt(vars["epoch"], 10, 64)
+	if err != nil && vars["epoch"] != "latest" && vars["epoch"] != "finalized" {
+		sendBadRequestResponse(w, r.URL.String(), "invalid epoch provided")
+		return
+	}
+
+	chainState := services.GlobalBeaconService.GetChainState()
+	if vars["epoch"] == "latest" {
+		epoch = int64(chainState.CurrentEpoch())
+	}
+
+	finalizedEpoch, _ := chainState.GetFinalizedCheckpoint()
+	if vars["epoch"] == "finalized" {
+		epoch = int64(finalizedEpoch)
+	}
+
+	if epoch > int64(chainState.CurrentEpoch()) {
+		sendBadRequestResponse(w, r.URL.String(), fmt.Sprintf("epoch is in the future. The latest epoch is %v", chainState.CurrentEpoch()))
+		return
+	}
+
+	if epoch < 0 {
+		sendBadRequestResponse(w, r.URL.String(), "epoch must be a positive number")
+		return
+	}
+
+	data := &APIEpochHealthResponseV1{
+		Epoch:     uint64(epoch),
+		Ts:        uint64(chainState.EpochToTime(phase0.Epoch(epoch)).Unix()),
+		Finalized: finalizedEpoch >= phase0.Epoch(epoch),
+	}
+
+	dbEpochs := services.GlobalBeaconService.GetDbEpochs(r.Context(), uint64(epoch), 1)
+	dbEpoch := dbEpochs[0]
+	if dbEpoch != nil {
+		specs := chainState.GetSpecs()
+
+		// Count only the slots that have already passed so the current in-progress epoch
+		// is not penalised for slots that are still scheduled in the future.
+		currentSlot := chainState.CurrentSlot()
+		lastSlot := chainState.EpochToSlot(phase0.Epoch(epoch+1)) - 1
+		passedSlotCount := uint64(specs.SlotsPerEpoch)
+		if currentSlot < lastSlot {
+			passedSlotCount -= uint64(lastSlot - currentSlot)
+		}
+
+		// Pre-ePBS the execution payload is bundled inside the beacon block, so every
+		// canonical block carries a payload. Post-ePBS (EIP-7732) payloads are revealed
+		// separately and may be missing, so use the dedicated payload count.
+		proposedPayloads := uint64(dbEpoch.BlockCount)
+		if chainState.IsEip7732Enabled(phase0.Epoch(epoch)) {
+			proposedPayloads = dbEpoch.PayloadCount
+		}
+
+		data.EligibleEther = dbEpoch.Eligible
+		data.VotedEther = dbEpoch.VotedTarget
+		data.ProposedBlocks = uint64(dbEpoch.BlockCount)
+		data.ProposedPayloads = proposedPayloads
+		data.Slots = passedSlotCount
+
+		if dbEpoch.Eligible > 0 {
+			data.VoteParticipation = float64(dbEpoch.VotedTarget) * 100.0 / float64(dbEpoch.Eligible)
+		}
+		if passedSlotCount > 0 {
+			data.ProposalParticipation = float64(dbEpoch.BlockCount) * 100.0 / float64(passedSlotCount)
+			data.PayloadParticipation = float64(proposedPayloads) * 100.0 / float64(passedSlotCount)
+		}
+
+		// The chain is fully healthy for the epoch only when every eligible validator
+		// voted, every passed slot produced a block, and every block revealed its payload.
+		const healthyThreshold = 100.0 - 1e-9
+		data.Healthy = passedSlotCount > 0 &&
+			data.VoteParticipation >= healthyThreshold &&
+			data.ProposalParticipation >= healthyThreshold &&
+			data.PayloadParticipation >= healthyThreshold
+	}
+
+	j := json.NewEncoder(w)
+	response := &ApiResponse{}
+	response.Status = "OK"
+	response.Data = data
+
+	err = j.Encode(response)
+	if err != nil {
+		sendServerErrorResponse(w, r.URL.String(), "could not serialize data results")
+		logrus.Errorf("error serializing json data for API %v route: %v", r.URL, err)
+	}
+}

--- a/handlers/api/epoch_v1.go
+++ b/handlers/api/epoch_v1.go
@@ -26,6 +26,8 @@ type APIEpochResponseV1 struct {
 	MissedBlocks            uint64 `json:"missedblocks"`
 	OrphanedBlocks          uint64 `json:"orphanedblocks"`
 	ProposedBlocks          uint64 `json:"proposedblocks"`
+	ProposedPayloads        uint64 `json:"proposedpayloads"`
+	MissedPayloads          uint64 `json:"missedpayloads"`
 	ProposerSlashingsCount  uint64 `json:"proposerslashingscount"`
 	ScheduledBlocks         uint64 `json:"scheduledblocks"`
 	TotalValidatorBalance   uint64 `json:"totalvalidatorbalance"`
@@ -118,6 +120,18 @@ func ApiEpochV1(w http.ResponseWriter, r *http.Request) {
 		data.BlocksCount = uint64(dbEpoch.BlockCount + dbEpoch.OrphanedCount)
 		data.OrphanedBlocks = uint64(dbEpoch.OrphanedCount)
 		data.ProposedBlocks = uint64(dbEpoch.BlockCount)
+
+		// Pre-ePBS the execution payload is bundled inside the beacon block, so every
+		// canonical block carries a payload. Post-ePBS (EIP-7732) payloads are revealed
+		// separately and may be missing, so use the dedicated payload count.
+		proposedPayloads := uint64(dbEpoch.BlockCount)
+		if chainState.IsEip7732Enabled(phase0.Epoch(epoch)) {
+			proposedPayloads = dbEpoch.PayloadCount
+		}
+		data.ProposedPayloads = proposedPayloads
+		// MissedPayloads counts canonical blocks that were proposed but whose payload was
+		// not revealed (an ePBS-specific failure, distinct from MissedBlocks). Always 0 pre-ePBS.
+		data.MissedPayloads = uint64(dbEpoch.BlockCount) - proposedPayloads
 	}
 
 	j := json.NewEncoder(w)

--- a/handlers/api/epochs_v1.go
+++ b/handlers/api/epochs_v1.go
@@ -54,6 +54,8 @@ type APIEpochInfo struct {
 	ProposedBlocks        uint64  `json:"proposed_blocks"`
 	MissedBlocks          uint64  `json:"missed_blocks"`
 	OrphanedBlocks        uint64  `json:"orphaned_blocks"`
+	ProposedPayloads      uint64  `json:"proposed_payloads"`
+	MissedPayloads        uint64  `json:"missed_payloads"`
 	MinSyncCommitteeSize  uint64  `json:"min_sync_committee_size,omitempty"`
 	MaxSyncCommitteeSize  uint64  `json:"max_sync_committee_size,omitempty"`
 	WithdrawalRequests    uint64  `json:"withdrawal_requests,omitempty"`
@@ -152,6 +154,11 @@ func APIEpochsV1(w http.ResponseWriter, r *http.Request) {
 		specs := chainState.GetSpecs()
 		firstSlot := epoch * specs.SlotsPerEpoch
 
+		// Pre-ePBS the execution payload is bundled inside the beacon block, so every
+		// canonical block carries a payload. Post-ePBS (EIP-7732) payloads are revealed
+		// separately and may be missing.
+		gloasActive := chainState.IsEip7732Enabled(phase0.Epoch(epoch))
+
 		// Get blocks for this epoch
 		blocks := services.GlobalBeaconService.GetDbBlocksForSlots(r.Context(), firstSlot, uint32(specs.SlotsPerEpoch), true, true)
 
@@ -166,6 +173,12 @@ func APIEpochsV1(w http.ResponseWriter, r *http.Request) {
 
 			// Canonical block
 			epochInfo.ProposedBlocks++
+			if !gloasActive || slot.PayloadStatus == dbtypes.PayloadStatusCanonical {
+				epochInfo.ProposedPayloads++
+			} else {
+				// proposed block whose payload was not revealed (ePBS-specific failure)
+				epochInfo.MissedPayloads++
+			}
 			epochInfo.Attestations += slot.AttestationCount
 			epochInfo.Deposits += slot.DepositCount
 			epochInfo.ProposerSlashings += slot.ProposerSlashingCount

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -420,6 +420,19 @@ func buildIndexPageRecentEpochsData(ctx context.Context, pageData *models.IndexP
 		if specs.SlotsPerEpoch > 0 {
 			proposalParticipation = float64(epochData.BlockCount) * 100.0 / float64(specs.SlotsPerEpoch)
 		}
+
+		// Pre-ePBS the execution payload is bundled inside the beacon block, so every
+		// canonical block implicitly carries a payload. Post-ePBS (EIP-7732) payloads are
+		// revealed separately and may be missing, so use the dedicated payload count.
+		payloadCount := uint64(epochData.BlockCount)
+		if chainState.IsEip7732Enabled(phase0.Epoch(epochData.Epoch)) {
+			payloadCount = epochData.PayloadCount
+		}
+		payloadParticipation := float64(0)
+		if specs.SlotsPerEpoch > 0 {
+			payloadParticipation = float64(payloadCount) * 100.0 / float64(specs.SlotsPerEpoch)
+		}
+
 		pageData.RecentEpochs = append(pageData.RecentEpochs, &models.IndexPageDataEpochs{
 			Epoch:                 epochData.Epoch,
 			Ts:                    chainState.EpochToTime(phase0.Epoch(epochData.Epoch)),
@@ -431,6 +444,8 @@ func buildIndexPageRecentEpochsData(ctx context.Context, pageData *models.IndexP
 			BlockCount:            uint64(epochData.BlockCount),
 			SlotsPerEpoch:         specs.SlotsPerEpoch,
 			ProposalParticipation: proposalParticipation,
+			PayloadCount:          payloadCount,
+			PayloadParticipation:  payloadParticipation,
 		})
 	}
 	pageData.RecentEpochCount = uint64(len(pageData.RecentEpochs))

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -15,9 +15,9 @@
               <th data-timecol="duration">Time</th>
               <th>Final</th>
               <th>Eligible (ETH)</th>
-              <th>Voted</th>
-              <th><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Beacon block proposals">Proposals</span></th>
-              <th><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Execution payloads revealed. Post-ePBS a block can be proposed while its payload is missing.">Payloads</span></th>
+              <th style="width: 160px;">Voted</th>
+              <th style="width: 160px;"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Beacon block proposals">Proposals</span></th>
+              <th style="width: 160px;"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Execution payloads revealed. Post-ePBS a block can be proposed while its payload is missing.">Payloads</span></th>
             </tr>
           </thead>
           <tbody class="template-tbody">

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -15,9 +15,9 @@
               <th data-timecol="duration">Time</th>
               <th>Final</th>
               <th>Eligible (ETH)</th>
-              <th style="width: 160px;">Voted</th>
-              <th style="width: 160px;"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Beacon block proposals">Proposals</span></th>
-              <th style="width: 160px;"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Execution payloads revealed. Post-ePBS a block can be proposed while its payload is missing.">Payloads</span></th>
+              <th>Voted</th>
+              <th><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Beacon block proposals">Proposals</span></th>
+              <th><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Execution payloads revealed. Post-ePBS a block can be proposed while its payload is missing.">Payloads</span></th>
             </tr>
           </thead>
           <tbody class="template-tbody">

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -37,7 +37,7 @@
                 <div style="position:relative;width:inherit;height:inherit;">
                   <small><span data-bind="text: $root.formatEth(voted)"></span> <span class="text-muted" data-bind="text: '(' + $root.formatFloat(votep, 2) + '%)'"></span></small>
                   <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(votep, 2)+'%'}, css: {'bg-warning': votep < 100}, attr: {'aria-valuenow': $root.formatFloat(votep, 2)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(votep, 2)+'%'}, attr: {'aria-valuenow': $root.formatFloat(votep, 2)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </td>
@@ -45,7 +45,7 @@
                 <div style="position:relative;width:inherit;height:inherit;">
                   <span data-bind="text: blocks + '/' + slots_per_epoch"></span> <small class="text-muted ml-1" data-bind="text: '(' + $root.formatFloat(proposalp, 1) + '%)'"></small>
                   <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(proposalp, 1)+'%'}, css: {'bg-warning': proposalp < 100}, attr: {'aria-valuenow': $root.formatFloat(proposalp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(proposalp, 1)+'%'}, attr: {'aria-valuenow': $root.formatFloat(proposalp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </td>
@@ -53,7 +53,7 @@
                 <div style="position:relative;width:inherit;height:inherit;">
                   <span data-bind="text: payloads + '/' + slots_per_epoch"></span> <small class="text-muted ml-1" data-bind="text: '(' + $root.formatFloat(payloadp, 1) + '%)'"></small>
                   <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(payloadp, 1)+'%'}, css: {'bg-warning': payloadp < 100}, attr: {'aria-valuenow': $root.formatFloat(payloadp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(payloadp, 1)+'%'}, attr: {'aria-valuenow': $root.formatFloat(payloadp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </td>
@@ -85,7 +85,7 @@
                     <div style="position:relative;width:inherit;height:inherit;">
                       <small>{{ formatEthAddCommasFromGwei $epoch.TargetVoted }} <span class="text-muted">({{ formatFloat $epoch.VoteParticipation 2 }}%)</span></small>
                       <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                        <div class="progress-bar {{ if lt $epoch.VoteParticipation 100.0 }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.VoteParticipation 2 }}%;" aria-valuenow="{{ formatFloat $epoch.VoteParticipation 2 }}%" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div class="progress-bar" role="progressbar" style="width: {{ formatFloat $epoch.VoteParticipation 2 }}%;" aria-valuenow="{{ formatFloat $epoch.VoteParticipation 2 }}%" aria-valuemin="0" aria-valuemax="100"></div>
                       </div>
                     </div>
                   </td>
@@ -93,7 +93,7 @@
                     <div style="position:relative;width:inherit;height:inherit;">
                       {{ $epoch.BlockCount }}/{{ $epoch.SlotsPerEpoch }} <small class="text-muted ml-1">({{ formatFloat $epoch.ProposalParticipation 1 }}%)</small>
                       <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                        <div class="progress-bar {{ if lt $epoch.ProposalParticipation 100.0 }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.ProposalParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.ProposalParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div class="progress-bar" role="progressbar" style="width: {{ formatFloat $epoch.ProposalParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.ProposalParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
                       </div>
                     </div>
                   </td>
@@ -101,7 +101,7 @@
                     <div style="position:relative;width:inherit;height:inherit;">
                       {{ $epoch.PayloadCount }}/{{ $epoch.SlotsPerEpoch }} <small class="text-muted ml-1">({{ formatFloat $epoch.PayloadParticipation 1 }}%)</small>
                       <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                        <div class="progress-bar {{ if lt $epoch.PayloadParticipation 100.0 }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.PayloadParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.PayloadParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div class="progress-bar" role="progressbar" style="width: {{ formatFloat $epoch.PayloadParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.PayloadParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
                       </div>
                     </div>
                   </td>

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -16,7 +16,8 @@
               <th>Final</th>
               <th>Eligible (ETH)</th>
               <th>Voted</th>
-              <th>Proposals</th>
+              <th><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Beacon block proposals">Proposals</span></th>
+              <th><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Execution payloads revealed. Post-ePBS a block can be proposed while its payload is missing.">Payloads</span></th>
             </tr>
           </thead>
           <tbody class="template-tbody">
@@ -48,11 +49,19 @@
                   </div>
                 </div>
               </td>
+              <td>
+                <div style="position:relative;width:inherit;height:inherit;">
+                  <span data-bind="text: payloads + '/' + slots_per_epoch"></span> <small class="text-muted ml-1" data-bind="text: '(' + $root.formatFloat(payloadp, 1) + '%)'"></small>
+                  <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
+                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(payloadp, 1)+'%'}, css: {'bg-warning': payloadp < proposalp}, attr: {'aria-valuenow': $root.formatFloat(payloadp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
+                  </div>
+                </div>
+              </td>
             </tr>
             {{ html "<!-- /ko -->" }}
             {{ html "<!-- ko if: epochs().length == 0 -->" }}
             <tr class="template-row">
-              <td style="text-align: center;" colspan="6">
+              <td style="text-align: center;" colspan="7">
                 no epochs found
               </td>
             </tr>
@@ -88,11 +97,19 @@
                       </div>
                     </div>
                   </td>
+                  <td>
+                    <div style="position:relative;width:inherit;height:inherit;">
+                      {{ $epoch.PayloadCount }}/{{ $epoch.SlotsPerEpoch }} <small class="text-muted ml-1">({{ formatFloat $epoch.PayloadParticipation 1 }}%)</small>
+                      <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
+                        <div class="progress-bar {{ if lt $epoch.PayloadParticipation $epoch.ProposalParticipation }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.PayloadParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.PayloadParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
+                      </div>
+                    </div>
+                  </td>
                 </tr>
               {{ end }}
             {{ else }}
               <tr>
-                <td style="text-align: center;" colspan="6">
+                <td style="text-align: center;" colspan="7">
                   no epochs found
                 </td>
               </tr>

--- a/templates/index/recentEpochs.html
+++ b/templates/index/recentEpochs.html
@@ -37,7 +37,7 @@
                 <div style="position:relative;width:inherit;height:inherit;">
                   <small><span data-bind="text: $root.formatEth(voted)"></span> <span class="text-muted" data-bind="text: '(' + $root.formatFloat(votep, 2) + '%)'"></span></small>
                   <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(votep, 2)+'%'}, attr: {'aria-valuenow': $root.formatFloat(votep, 2)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(votep, 2)+'%'}, css: {'bg-warning': votep < 100}, attr: {'aria-valuenow': $root.formatFloat(votep, 2)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </td>
@@ -45,7 +45,7 @@
                 <div style="position:relative;width:inherit;height:inherit;">
                   <span data-bind="text: blocks + '/' + slots_per_epoch"></span> <small class="text-muted ml-1" data-bind="text: '(' + $root.formatFloat(proposalp, 1) + '%)'"></small>
                   <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(proposalp, 1)+'%'}, attr: {'aria-valuenow': $root.formatFloat(proposalp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(proposalp, 1)+'%'}, css: {'bg-warning': proposalp < 100}, attr: {'aria-valuenow': $root.formatFloat(proposalp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </td>
@@ -53,7 +53,7 @@
                 <div style="position:relative;width:inherit;height:inherit;">
                   <span data-bind="text: payloads + '/' + slots_per_epoch"></span> <small class="text-muted ml-1" data-bind="text: '(' + $root.formatFloat(payloadp, 1) + '%)'"></small>
                   <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(payloadp, 1)+'%'}, css: {'bg-warning': payloadp < proposalp}, attr: {'aria-valuenow': $root.formatFloat(payloadp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
+                    <div class="progress-bar" role="progressbar" data-bind="style: {width: $root.formatFloat(payloadp, 1)+'%'}, css: {'bg-warning': payloadp < 100}, attr: {'aria-valuenow': $root.formatFloat(payloadp, 1)+'%'}" aria-valuemin="0" aria-valuemax="100"></div>
                   </div>
                 </div>
               </td>
@@ -85,7 +85,7 @@
                     <div style="position:relative;width:inherit;height:inherit;">
                       <small>{{ formatEthAddCommasFromGwei $epoch.TargetVoted }} <span class="text-muted">({{ formatFloat $epoch.VoteParticipation 2 }}%)</span></small>
                       <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                        <div class="progress-bar" role="progressbar" style="width: {{ formatFloat $epoch.VoteParticipation 2 }}%;" aria-valuenow="{{ formatFloat $epoch.VoteParticipation 2 }}%" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div class="progress-bar {{ if lt $epoch.VoteParticipation 100.0 }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.VoteParticipation 2 }}%;" aria-valuenow="{{ formatFloat $epoch.VoteParticipation 2 }}%" aria-valuemin="0" aria-valuemax="100"></div>
                       </div>
                     </div>
                   </td>
@@ -93,7 +93,7 @@
                     <div style="position:relative;width:inherit;height:inherit;">
                       {{ $epoch.BlockCount }}/{{ $epoch.SlotsPerEpoch }} <small class="text-muted ml-1">({{ formatFloat $epoch.ProposalParticipation 1 }}%)</small>
                       <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                        <div class="progress-bar" role="progressbar" style="width: {{ formatFloat $epoch.ProposalParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.ProposalParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div class="progress-bar {{ if lt $epoch.ProposalParticipation 100.0 }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.ProposalParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.ProposalParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
                       </div>
                     </div>
                   </td>
@@ -101,7 +101,7 @@
                     <div style="position:relative;width:inherit;height:inherit;">
                       {{ $epoch.PayloadCount }}/{{ $epoch.SlotsPerEpoch }} <small class="text-muted ml-1">({{ formatFloat $epoch.PayloadParticipation 1 }}%)</small>
                       <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
-                        <div class="progress-bar {{ if lt $epoch.PayloadParticipation $epoch.ProposalParticipation }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.PayloadParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.PayloadParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
+                        <div class="progress-bar {{ if lt $epoch.PayloadParticipation 100.0 }}bg-warning{{ end }}" role="progressbar" style="width: {{ formatFloat $epoch.PayloadParticipation 1 }}%;" aria-valuenow="{{ formatFloat $epoch.PayloadParticipation 1 }}%" aria-valuemin="0" aria-valuemax="100"></div>
                       </div>
                     </div>
                   </td>

--- a/types/models/indexPage.go
+++ b/types/models/indexPage.go
@@ -65,6 +65,8 @@ type IndexPageDataEpochs struct {
 	BlockCount            uint64    `json:"blocks"`
 	SlotsPerEpoch         uint64    `json:"slots_per_epoch"`
 	ProposalParticipation float64   `json:"proposalp"`
+	PayloadCount          uint64    `json:"payloads"`
+	PayloadParticipation  float64   `json:"payloadp"`
 }
 
 type IndexPageDataBlocks struct {


### PR DESCRIPTION

<img width="848" height="420" alt="Screenshot 2026-06-26 at 13 29 09" src="https://github.com/user-attachments/assets/7fd3b6d7-7744-4ba7-8ac7-c282a0b78b03" />



## What

Adds a third **Payloads** column to the **Most recent epochs** widget on the home page, next to **Voted** and **Proposals**, and exposes the metric on the API.

Post-ePBS (EIP-7732) a beacon block can be proposed while its execution payload is missing. So the chain is only fully healthy for an epoch when **all three columns are at 100%**: validators voted, every slot produced a block, and every block revealed its payload.

Pre-ePBS the payload is bundled inside the beacon block, so the Payloads column mirrors Proposals (no behavioural change on older networks).

## UI

`templates/index/recentEpochs.html`:
- New **Payloads** column (`payloads/slots_per_epoch (xx%)` with a progress bar), in both the live Knockout row and the server-rendered fallback.
- The payload bar turns yellow (`bg-warning`) when payload participation drops below proposal participation — i.e. blocks landed but payloads went missing.
- Header tooltips clarify "Beacon block proposals" vs "Execution payloads revealed".

`Payloads %` uses the same denominator as Proposals (`slots_per_epoch`), so `Payloads ≤ Proposals ≤ 100%` and a fully-missed epoch reads 0%.

## Data

- `types/models/indexPage.go` — `IndexPageDataEpochs` gains `PayloadCount` / `PayloadParticipation`.
- `handlers/index.go` — computes payload count (`= block_count` pre-ePBS, `= payload_count` post-ePBS) and participation.

## API

- `GET /v1/epoch/{epoch}` and `GET /v1/epochs` gain `proposedpayloads` / `missedpayloads` (resp. `proposed_payloads` / `missed_payloads`). `MissedPayloads` counts proposed blocks whose payload was not revealed (ePBS-specific; always 0 pre-ePBS).
- **New** `GET /v1/epoch/{epoch}/health` returns the consolidated health view:

```json
{
  "epoch": 25,
  "vote_participation": 62.5,
  "proposal_participation": 75.0,
  "payload_participation": 62.5,
  "healthy": false
}
```

`healthy` is true only when all three participation rates reach 100%. Proposals/payloads are measured against *passed* slots so the in-progress epoch isn't penalised for future slots.

Swagger docs regenerated (`make api-docs`).

## Verification

- `go build ./...` and `go vet` clean.
- `recentEpochs.html` parse-checked against the real template func map.
- New endpoint + fields present in `docs/swagger.json`.

Not running against a live devnet here — happy to if you want a screenshot before merge. Also left the full `/epochs` page untouched (separate larger table); can add a matching column there as a follow-up if you'd like.