### PR TITLE
fix(ui): show '-' for execution columns when payload is missing

### DIFF
--- a/templates/blocks/blocks.html
+++ b/templates/blocks/blocks.html
@@ -104,6 +104,7 @@
                 {{ $treeWidth := .ForkTreeWidth }}
                 {{ $g := . }}
                 {{ range $i, $slot := .Blocks }}
+                  {{ $noPayload := and (not (eq $slot.Status 0)) (eq $slot.PayloadStatus 0) }}
                   <tr>
                     {{ if $g.DisplayChain }}
                     <td class="graph-container" style="min-width: {{ $treeWidth }}px;">
@@ -121,7 +122,7 @@
                       {{ end }}
                     </td>
                     {{ end }}
-                    {{ if $g.DisplayNumber }}<td>{{ ethBlockLink $slot.EthBlockNumber }}</td>{{ end }}
+                    {{ if $g.DisplayNumber }}<td>{{ if $noPayload }}-{{ else }}{{ ethBlockLink $slot.EthBlockNumber }}{{ end }}</td>{{ end }}
                     {{ if $g.DisplaySlot }}
                       {{ if eq $slot.Status 2 }}
                         <td><a href="/slot/0x{{ printf "%x" $slot.BlockRoot }}">{{ formatAddCommas $slot.Slot }}</a></td>
@@ -154,15 +155,15 @@
                       {{ if $g.DisplayAttestations }}<td class="d-none d-md-table-cell">{{ if not (eq $slot.Status 0) }}{{ $slot.AttestationCount }}{{ end }}</td>{{ end }}
                       {{ if $g.DisplayDeposits }}<td>{{ if not (eq $slot.Status 0) }}{{ $slot.DepositCount }} / {{ $slot.ExitCount }}{{ end }}</td>{{ end }}
                       {{ if $g.DisplaySlashings }}<td>{{ if not (eq $slot.Status 0) }}{{ $slot.ProposerSlashingCount }} / {{ $slot.AttesterSlashingCount }}{{ end }}</td>{{ end }}
-                      {{ if $g.DisplayTxCount }}<td>{{ if not (eq $slot.Status 0) }}{{ $slot.EthTransactionCount }} / {{ $slot.BlobCount }}{{ end }}</td>{{ end }}
-                      {{ if $g.DisplayGasUsage }}<td>{{ if not (eq $slot.Status 0) }}
+                      {{ if $g.DisplayTxCount }}<td>{{ if not (eq $slot.Status 0) }}{{ if $noPayload }}-{{ else }}{{ $slot.EthTransactionCount }} / {{ $slot.BlobCount }}{{ end }}{{ end }}</td>{{ end }}
+                      {{ if $g.DisplayGasUsage }}<td>{{ if not (eq $slot.Status 0) }}{{ if $noPayload }}-{{ else }}
                         <div style="position:relative;width:inherit;height:inherit;">
                           {{ formatAddCommas $slot.GasUsed }} <small class="text-muted ml-3">({{ formatFloat (percentage $slot.GasUsed $slot.GasLimit) 2 }}%)</small>
                           <div class="progress" style="position:absolute;bottom:-6px;width:100%;height:4px;">
                             <div class="progress-bar" role="progressbar" style="width: {{ percentage $slot.GasUsed $slot.GasLimit }}%;" aria-valuenow="{{ $slot.GasUsed }}" aria-valuemin="0" aria-valuemax="{{ $slot.GasLimit }}"></div>
                           </div>
                         </div>
-                      {{ end }}</td>{{ end }}
+                      {{ end }}{{ end }}</td>{{ end }}
                       {{ if $g.DisplaySyncAgg }}<td>{{ if not (eq $slot.Status 0) }}{{ formatPercentageAlert $slot.SyncParticipation 2 95 80 }}{{ end }}</td>{{ end }}
                       {{ if $g.DisplayBuilder }}<td>{{ if not (eq $slot.Status 0) }}
                         {{ if $slot.HasBuilder }}
@@ -176,7 +177,7 @@
                           <span class="badge rounded-pill text-bg-secondary">No</span>
                         {{ end }}
                       {{ end }}</td>{{ end }}
-                      {{ if $g.DisplayGasLimit }}<td>{{ if not (eq $slot.Status 0) }}{{ formatFloat (div (float64 $slot.GasLimit) 1000000) 2 }} M{{ end }}</td>{{ end }}
+                      {{ if $g.DisplayGasLimit }}<td>{{ if not (eq $slot.Status 0) }}{{ if $noPayload }}-{{ else }}{{ formatFloat (div (float64 $slot.GasLimit) 1000000) 2 }} M{{ end }}{{ end }}</td>{{ end }}
                       {{ if $g.DisplayBlockSize }}<td>{{ if not (eq $slot.Status 0) }}{{ formatByteAmount $slot.BlockSize }}{{ end }}</td>{{ end }}
                       {{ if $g.DisplayRecvDelay }}<td>{{ if not (eq $slot.Status 0) }}{{ formatRecvDelay $slot.RecvDelay }}{{ end }}</td>{{ end }}
                       {{ if $g.DisplayExecTime }}<td>{{ if not (eq $slot.Status 0) }}
@@ -187,7 +188,7 @@
                         {{ end }}
                       {{ end }}</td>{{ end }}
                       {{ if $g.DisplayGraffiti }}<td>{{ if not (eq $slot.Status 0) }}{{ formatGraffiti $slot.Graffiti }}{{ end }}</td>{{ end }}
-                      {{ if $g.DisplayElExtraData }}<td>{{ if not (eq $slot.Status 0) }}{{ formatGraffiti $slot.ElExtraData }}{{ end }}</td>{{ end }}
+                      {{ if $g.DisplayElExtraData }}<td>{{ if not (eq $slot.Status 0) }}{{ if $noPayload }}-{{ else }}{{ formatGraffiti $slot.ElExtraData }}{{ end }}{{ end }}</td>{{ end }}
                     {{ else }}
                       {{ $colCount := 0 }}
                       {{ if $g.DisplayProposer }}{{ $colCount = add $colCount 1 }}{{ end }}


### PR DESCRIPTION
## Problem

Post-ePBS (EIP-7732) a beacon block can be proposed while its execution payload is missing (the half-yellow **Proposed** badge). For those rows the execution-derived columns fall back to zero values — Number `0`, Txs/Blobs `0/…`, Gas Usage `0 (0%)`, Gas Limit `0 M` — which reads like a real empty block rather than a missing payload.

## Fix

`templates/blocks/blocks.html`: add a row-level `$noPayload` flag (`Status != Missed && PayloadStatus == Missing`) and render `-` instead of the zero values for the payload-derived columns:

- Number (execution block number)
- Txs / Blobs
- Gas Usage
- Gas Limit
- EL Extra Data

Beacon-level columns (Block Size, Proposer, Attestations, Builder, etc.) are unaffected. Pre-ePBS `PayloadStatus` is always `Canonical`, so there is no behavioural change on older networks.

The filtered blocks page (`/blocks/filtered`) is unaffected — its handler skips blocks without an execution block number, so payload-less rows never appear there.

## Verification

- `blocks.html` parse-checked against the real template func map.