### PR TITLE
fix system contract queued tx matcher for post-gloas behavior

### DIFF
--- a/indexer/execution/system_contracts/transaction_matcher.go
+++ b/indexer/execution/system_contracts/transaction_matcher.go
@@ -97,6 +97,15 @@ func (ds *transactionMatcher[MatchType]) runTransactionMatcher(indexerBlock uint
 		}
 	}
 
+	// Only match dequeue blocks strictly below the target height. In Gloas the requests
+	// dequeued in block D are processed by the CL block built on top of it (whose own payload
+	// is block D+1), so the operation row for dequeue block D only exists once block D+1 has
+	// been indexed. Holding back the boundary block guarantees the following block is available;
+	// it is matched on the next run once the target height has advanced past it.
+	if matchTargetHeight > 0 {
+		matchTargetHeight--
+	}
+
 	t1 := time.Now()
 	persistedHeight := ds.state.MatchHeight
 


### PR DESCRIPTION
# Fix system contract queued tx matcher for post-Gloas behavior

## Summary

Fixes scattered single-slot gaps in the EL↔CL request matching (builder deposits,
deposits, withdrawals, consolidations, builder exits) that appear on long-running
post-Gloas instances. Affected operations render with no matched execution-layer
transaction even though the originating tx was indexed.

Example (builder deposits page on `glamsterdam-devnet-6`): slots `1664`, `1667`,
`7302` show unmatched entries while their immediate neighbours match correctly.

https://dora.glamsterdam-devnet-6.ethpandaops.io/builders/deposits

## Root cause

The shared transaction matcher (`indexer/execution/system_contracts/transaction_matcher.go`)
matches an EL request tx with `DequeueBlock = D` against the CL operation row whose
`BlockNumber = D`.

In Gloas, blocks are decoupled from payloads. The requests dequeued from a system
contract in EL block `D` are not processed by the CL block that *carries* payload `D`,
but by the **followup** CL block built on top of it — the one whose own payload is
block `D+1`. Accordingly, `getProcessedExecutionRequests` (`indexer/beacon/writedb.go`)
records the CL operation row with `BlockNumber = payload.BlockNumber - 1`. The row for
dequeue block `D` therefore only exists once block `D+1` has been indexed.

`runTransactionMatcher` set its `matchTargetHeight` to the finalized EL block number
and matched **inclusively** up to it (`GetBuilderDepositTxsByDequeueRange` uses
`dequeue_block >= from AND dequeue_block <= to`). When `D == finalizedBlock` at a given
matcher tick (the loop runs every 30s), block `D+1`'s CL block was not finalized/indexed
yet, so there was no operation row to match. Because `MatchHeight` advances
**unconditionally** after each range, that single boundary block was never revisited —
leaving a permanent single-slot gap at every run's tip. Over a long-running instance
this accumulates into the scattered isolated gaps observed.

## Fix

Hold back the boundary block: decrement `matchTargetHeight` by one so the matcher only
considers dequeue blocks strictly below the finalization tip. This guarantees that for
any matched dequeue block `D`, block `D+1` (which carries the processed requests, and
thus the CL operation row) is already indexed. The boundary block is matched on the next
run once the tip has advanced past it.

```go
// Only match dequeue blocks strictly below the target height. In Gloas the requests
// dequeued in block D are processed by the CL block built on top of it (whose own payload
// is block D+1), so the operation row for dequeue block D only exists once block D+1 has
// been indexed. Holding back the boundary block guarantees the following block is available;
// it is matched on the next run once the target height has advanced past it.
if matchTargetHeight > 0 {
    matchTargetHeight--
}
```

The change lives in the generic matcher, so it covers all five request types
(builder deposits, deposits, withdrawals, consolidations, builder exits) at once. It is
harmless pre-Gloas — it merely defers matching of the single tip block by one slot.

## Notes

- **Existing gaps do not self-heal.** The persisted matcher height has already advanced
  past previously-skipped blocks. To backfill historical gaps, reset the relevant
  `explorer_state` matcher keys (e.g. `indexer.builderdepositmatcher`) to a block before
  the earliest gap. Re-running is safe and idempotent: `matchBlockRange` skips operations
  that already have a `TxHash` and only fills in the missing ones.

## Test plan

- [x] `go build ./indexer/...`
- [x] Deploy to a post-Gloas instance and confirm no new single-slot matching gaps appear.
- [ ] Optionally backfill existing gaps by resetting the matcher state keys and verify
      the previously-unmatched operations resolve to their txs.
