### PR TITLE
Fix remaining post-Gloas builder deposit gaps (payload-less blocks + onboarded fork id)

### DIFF
--- a/cmd/dora-utils/s3_cleanup.go
+++ b/cmd/dora-utils/s3_cleanup.go
@@ -860,18 +860,20 @@ func prefixHasObjects(ctx context.Context, client *minio.Client, bucket, prefix 
 	listCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	for obj := range client.ListObjects(listCtx, bucket, minio.ListObjectsOptions{
+	// Peek the first listed object: closed channel means the prefix is empty.
+	obj, ok := <-client.ListObjects(listCtx, bucket, minio.ListObjectsOptions{
 		Prefix:       prefix + "/",
 		Recursive:    true,
 		WithVersions: true,
 		MaxKeys:      1,
-	}) {
-		if obj.Err != nil {
-			return false, fmt.Errorf("error listing %q: %w", prefix, obj.Err)
-		}
-		return true, nil
+	})
+	if !ok {
+		return false, nil
 	}
-	return false, nil
+	if obj.Err != nil {
+		return false, fmt.Errorf("error listing %q: %w", prefix, obj.Err)
+	}
+	return true, nil
 }
 
 // quickSample counts up to maxQuickSample current objects under a prefix for a

--- a/cmd/dora-utils/s3_cleanup.go
+++ b/cmd/dora-utils/s3_cleanup.go
@@ -1,0 +1,918 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"text/tabwriter"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/minio/minio-go/v7/pkg/lifecycle"
+	"github.com/minio/minio-go/v7/pkg/signer"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	dtypes "github.com/ethpandaops/dora/types"
+)
+
+// cleanupRuleIDPrefix namespaces the lifecycle rules created by this tool so we
+// never touch unrelated (e.g. bucket-wide) rules already present on the bucket.
+const cleanupRuleIDPrefix = "dora-cleanup-"
+
+// defaultDomainTemplate maps a devnet prefix name to the dora URL used to probe
+// whether the devnet is still alive. %s is replaced with the prefix name.
+const defaultDomainTemplate = "https://dora.%s.ethpandaops.io"
+
+// defaultDoraMarker is searched for in the probe response body. A devnet is only
+// considered active when it returns HTTP 200 AND serves a real dora (this string
+// in the page) - a torn-down devnet still answers 404/503 from the ingress.
+const defaultDoraMarker = "Dora the Explorer"
+
+// defaultDevnetPattern matches the feature-devnet-n naming scheme. Anything that
+// does not match (and is not in the keep list) is left untouched.
+const defaultDevnetPattern = `^.+-devnet-[0-9]+$`
+
+// defaultKeepPrefixes are static networks that must never be cleaned up.
+var defaultKeepPrefixes = []string{"mainnet", "sepolia", "hoodi"}
+
+// maxQuickSample bounds the per-prefix object listing used for display so we
+// never block on a full recursive scan of a huge prefix.
+const maxQuickSample = 1000
+
+type prefixClass int
+
+const (
+	classKeepStatic prefixClass = iota
+	classActiveDevnet
+	classInactiveDevnet
+	classUnknown
+)
+
+func (c prefixClass) String() string {
+	switch c {
+	case classKeepStatic:
+		return "keep (static)"
+	case classActiveDevnet:
+		return "keep (active)"
+	case classInactiveDevnet:
+		return "INACTIVE"
+	default:
+		return "keep (unknown)"
+	}
+}
+
+// prefixInfo holds the classification result for one top-level prefix.
+type prefixInfo struct {
+	Name   string
+	Class  prefixClass
+	URL    string
+	Status string // probe outcome, human readable
+}
+
+// s3-cleanup walks the bucket, classifies prefixes and schedules cleanup of
+// inactive devnets. Policy management (inspect/undo/prune the rules it creates)
+// lives in the separate s3-policy command.
+var s3CleanupCmd = &cobra.Command{
+	Use:   "s3-cleanup",
+	Short: "Classify shared-bucket prefixes and clean up inactive devnets",
+	Long: `Walk every top-level prefix of a shared dora S3 bucket and decide, per
+prefix, whether the devnet it belongs to is still in use.
+
+Static networks (mainnet, sepolia, hoodi) are never touched. Devnet prefixes
+matching the feature-devnet-n pattern are probed via their dora URL
+(https://dora.<prefix>.ethpandaops.io); a prefix is only kept when it serves a
+live dora (HTTP 200 with the dora page marker). Everything else is an
+inactive-cleanup candidate, confirmed per-prefix before any change.
+
+Cleanup defaults to a server-side lifecycle rule (prefix-filtered expiration)
+instead of deleting objects one by one. Inspect, undo or prune those rules with
+the s3-policy command.
+
+Example:
+  dora-utils s3-cleanup -c config.yaml --dry-run
+  dora-utils s3-cleanup -c config.yaml
+  dora-utils s3-cleanup -c config.yaml --yes --direct-delete`,
+	RunE: runS3CleanupScan,
+}
+
+// s3-policy manages the lifecycle rules created by s3-cleanup.
+var s3PolicyCmd = &cobra.Command{
+	Use:   "s3-policy",
+	Short: "Manage the cleanup lifecycle rules on the shared S3 bucket",
+	Long: `Inspect and manage the prefix-expiration lifecycle rules that s3-cleanup
+creates. Use 'list' to see scheduled cleanups, 'cancel' to undo one (e.g. a
+revived devnet), and 'prune' to drop rules whose prefix has already drained.`,
+}
+
+func init() {
+	rootCmd.AddCommand(s3CleanupCmd)
+	rootCmd.AddCommand(s3PolicyCmd)
+
+	// s3-cleanup (flat scan command).
+	s3CleanupCmd.Flags().StringP("config", "c", "", "Path to a config file with blockDb.s3 settings (required)")
+	s3CleanupCmd.Flags().BoolP("verbose", "v", false, "Verbose output")
+	s3CleanupCmd.Flags().Bool("dry-run", false, "Only classify and report; never prompt or modify anything")
+	s3CleanupCmd.Flags().BoolP("yes", "y", false, "Auto-confirm cleanup for every inactive devnet (unattended)")
+	s3CleanupCmd.Flags().Bool("direct-delete", false, "Delete objects directly instead of adding a lifecycle expiration rule")
+	s3CleanupCmd.Flags().Int("expire-days", 1, "Days after which the lifecycle rule expires objects under a prefix")
+	s3CleanupCmd.Flags().String("domain", defaultDomainTemplate, "URL template for the dora probe (%s = prefix name)")
+	s3CleanupCmd.Flags().String("marker", defaultDoraMarker, "Body marker that proves a live dora is served")
+	s3CleanupCmd.Flags().String("devnet-pattern", defaultDevnetPattern, "Regex identifying devnet prefixes")
+	s3CleanupCmd.Flags().StringSlice("keep", nil, "Additional static prefixes to never clean up (merged with defaults)")
+	s3CleanupCmd.Flags().Duration("http-timeout", 10*time.Second, "Per-probe HTTP timeout")
+	if err := s3CleanupCmd.MarkFlagRequired("config"); err != nil {
+		panic(err)
+	}
+
+	// s3-policy (shared creds via persistent flags, inherited by subcommands).
+	s3PolicyCmd.PersistentFlags().StringP("config", "c", "", "Path to a config file with blockDb.s3 settings (required)")
+	s3PolicyCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose output")
+	if err := s3PolicyCmd.MarkPersistentFlagRequired("config"); err != nil {
+		panic(err)
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the cleanup lifecycle rules currently set on the bucket",
+		RunE:  runS3PolicyList,
+	}
+	s3PolicyCmd.AddCommand(listCmd)
+
+	cancelCmd := &cobra.Command{
+		Use:   "cancel <prefix> [prefix...]",
+		Short: "Remove cleanup lifecycle rules for the given prefixes (undo a scheduled cleanup)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  runS3PolicyCancel,
+	}
+	s3PolicyCmd.AddCommand(cancelCmd)
+
+	pruneCmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove cleanup rules whose prefix has already drained (no objects left)",
+		RunE:  runS3PolicyPrune,
+	}
+	pruneCmd.Flags().Bool("dry-run", false, "Only report which rules would be pruned")
+	pruneCmd.Flags().BoolP("yes", "y", false, "Auto-confirm pruning")
+	s3PolicyCmd.AddCommand(pruneCmd)
+}
+
+// s3CleanupFileConfig is the minimal slice of the dora config we need: just the
+// blockDb.s3 credentials/bucket. We read it directly (instead of utils.ReadConfig)
+// so a blockDb-only settings file without beacon endpoints is accepted.
+type s3CleanupFileConfig struct {
+	BlockDb struct {
+		S3 dtypes.S3BlockDBConfig `yaml:"s3"`
+	} `yaml:"blockDb"`
+}
+
+func loadS3CleanupConfig(path string) (dtypes.S3BlockDBConfig, error) {
+	var fileCfg s3CleanupFileConfig
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return dtypes.S3BlockDBConfig{}, fmt.Errorf("error reading config file: %w", err)
+	}
+	if err := yaml.Unmarshal(data, &fileCfg); err != nil {
+		return dtypes.S3BlockDBConfig{}, fmt.Errorf("error parsing config file: %w", err)
+	}
+
+	// Allow BLOCKDB_S3_* env vars to override file values (matches main config).
+	if err := envconfig.Process("", &fileCfg.BlockDb.S3); err != nil {
+		return dtypes.S3BlockDBConfig{}, fmt.Errorf("error processing env config: %w", err)
+	}
+
+	s3Cfg := fileCfg.BlockDb.S3
+	if s3Cfg.Endpoint == "" {
+		return dtypes.S3BlockDBConfig{}, fmt.Errorf("blockDb.s3.endpoint is required")
+	}
+	if s3Cfg.Bucket == "" {
+		return dtypes.S3BlockDBConfig{}, fmt.Errorf("blockDb.s3.bucket is required")
+	}
+
+	return s3Cfg, nil
+}
+
+// s3CleanupSetup loads the config, builds the client and verifies the bucket.
+func s3CleanupSetup(cmd *cobra.Command) (*minio.Client, dtypes.S3BlockDBConfig, *logrus.Logger, error) {
+	configPath, _ := cmd.Flags().GetString("config")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+
+	logger := logrus.New()
+	if verbose {
+		logger.SetLevel(logrus.DebugLevel)
+	} else {
+		logger.SetLevel(logrus.InfoLevel)
+	}
+
+	s3Cfg, err := loadS3CleanupConfig(configPath)
+	if err != nil {
+		return nil, s3Cfg, nil, err
+	}
+
+	client, err := minio.New(s3Cfg.Endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(s3Cfg.AccessKey, s3Cfg.SecretKey, ""),
+		Secure: bool(s3Cfg.Secure),
+		Region: s3Cfg.Region,
+	})
+	if err != nil {
+		return nil, s3Cfg, nil, fmt.Errorf("failed to create S3 client: %w", err)
+	}
+
+	exists, err := client.BucketExists(cmd.Context(), s3Cfg.Bucket)
+	if err != nil {
+		return nil, s3Cfg, nil, fmt.Errorf("failed to check bucket: %w", err)
+	}
+	if !exists {
+		return nil, s3Cfg, nil, fmt.Errorf("bucket %q does not exist", s3Cfg.Bucket)
+	}
+
+	logger.WithFields(logrus.Fields{
+		"bucket":   s3Cfg.Bucket,
+		"endpoint": s3Cfg.Endpoint,
+	}).Debug("connected to S3")
+
+	return client, s3Cfg, logger, nil
+}
+
+func runS3CleanupScan(cmd *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Minute)
+	defer cancel()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	autoYes, _ := cmd.Flags().GetBool("yes")
+	directDelete, _ := cmd.Flags().GetBool("direct-delete")
+	expireDays, _ := cmd.Flags().GetInt("expire-days")
+	domainTpl, _ := cmd.Flags().GetString("domain")
+	marker, _ := cmd.Flags().GetString("marker")
+	pattern, _ := cmd.Flags().GetString("devnet-pattern")
+	extraKeep, _ := cmd.Flags().GetStringSlice("keep")
+	httpTimeout, _ := cmd.Flags().GetDuration("http-timeout")
+
+	devnetRe, err := regexp.Compile(pattern)
+	if err != nil {
+		return fmt.Errorf("invalid devnet-pattern: %w", err)
+	}
+	if expireDays < 1 {
+		return fmt.Errorf("expire-days must be >= 1")
+	}
+
+	client, s3Cfg, logger, err := s3CleanupSetup(cmd)
+	if err != nil {
+		return err
+	}
+	bucket := s3Cfg.Bucket
+
+	keep := keepSet(extraKeep)
+
+	prefixes, err := listTopPrefixes(ctx, client, bucket)
+	if err != nil {
+		return err
+	}
+	logger.WithField("count", len(prefixes)).Info("discovered top-level prefixes")
+
+	infos := classifyPrefixes(ctx, prefixes, keep, devnetRe, domainTpl, marker, httpTimeout)
+	printClassification(infos)
+
+	candidates := make([]prefixInfo, 0)
+	for _, info := range infos {
+		if info.Class == classInactiveDevnet {
+			candidates = append(candidates, info)
+		}
+	}
+
+	if len(candidates) == 0 {
+		logger.Info("no inactive devnets to clean up")
+		return nil
+	}
+
+	mode := "lifecycle expiration rule"
+	if directDelete {
+		mode = "direct delete"
+	}
+	logger.WithFields(logrus.Fields{
+		"candidates": len(candidates),
+		"mode":       mode,
+	}).Info("inactive devnets found")
+
+	if dryRun {
+		logger.Info("dry-run: no changes made")
+		return nil
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	confirmed := make([]prefixInfo, 0, len(candidates))
+	for _, c := range candidates {
+		count, truncated, err := quickSample(ctx, client, bucket, c.Name)
+		sizeStr := describeSample(count, truncated, err)
+
+		if autoYes {
+			logger.WithFields(logrus.Fields{"prefix": c.Name, "objects": sizeStr}).Info("auto-confirmed cleanup")
+			confirmed = append(confirmed, c)
+			continue
+		}
+
+		prompt := fmt.Sprintf("Clean up %q (%s, ~%s)? [y/N]: ", c.Name, c.Status, sizeStr)
+		if confirm(reader, prompt) {
+			confirmed = append(confirmed, c)
+		} else {
+			logger.WithField("prefix", c.Name).Info("skipped")
+		}
+	}
+
+	if len(confirmed) == 0 {
+		logger.Info("nothing confirmed; no changes made")
+		return nil
+	}
+
+	if directDelete {
+		return directDeletePrefixes(ctx, logger, client, bucket, confirmed)
+	}
+	return scheduleLifecycleCleanup(ctx, logger, client, s3Cfg, confirmed, expireDays)
+}
+
+// keepSet merges the default static networks with any user-provided extras.
+func keepSet(extra []string) map[string]bool {
+	keep := make(map[string]bool, len(defaultKeepPrefixes)+len(extra))
+	for _, k := range defaultKeepPrefixes {
+		keep[k] = true
+	}
+	for _, k := range extra {
+		k = strings.TrimSuffix(strings.TrimSpace(k), "/")
+		if k != "" {
+			keep[k] = true
+		}
+	}
+	return keep
+}
+
+// listTopPrefixes returns the top-level "folder" names (without trailing slash).
+func listTopPrefixes(ctx context.Context, client *minio.Client, bucket string) ([]string, error) {
+	prefixes := make([]string, 0)
+	for obj := range client.ListObjects(ctx, bucket, minio.ListObjectsOptions{Recursive: false}) {
+		if obj.Err != nil {
+			return nil, fmt.Errorf("error listing prefixes: %w", obj.Err)
+		}
+		// Common prefixes arrive as keys ending in "/"; bare objects are ignored.
+		if strings.HasSuffix(obj.Key, "/") {
+			prefixes = append(prefixes, strings.TrimSuffix(obj.Key, "/"))
+		}
+	}
+	sort.Strings(prefixes)
+	return prefixes, nil
+}
+
+// classifyPrefixes classifies every prefix, probing devnets concurrently.
+func classifyPrefixes(
+	ctx context.Context,
+	prefixes []string,
+	keep map[string]bool,
+	devnetRe *regexp.Regexp,
+	domainTpl, marker string,
+	httpTimeout time.Duration,
+) []prefixInfo {
+	infos := make([]prefixInfo, len(prefixes))
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8)
+
+	for i, name := range prefixes {
+		info := prefixInfo{Name: name}
+
+		switch {
+		case keep[name]:
+			info.Class = classKeepStatic
+			info.Status = "static network"
+			infos[i] = info
+		case !devnetRe.MatchString(name):
+			info.Class = classUnknown
+			info.Status = "does not match devnet pattern"
+			infos[i] = info
+		default:
+			info.URL = fmt.Sprintf(domainTpl, name)
+			wg.Add(1)
+			go func(idx int, info prefixInfo) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				active, status := probeDevnet(ctx, info.URL, marker, httpTimeout)
+				if active {
+					info.Class = classActiveDevnet
+				} else {
+					info.Class = classInactiveDevnet
+				}
+				info.Status = status
+				infos[idx] = info
+			}(i, info)
+		}
+	}
+
+	wg.Wait()
+	return infos
+}
+
+// probeDevnet fetches the dora URL and reports whether a live dora is served.
+// Active requires HTTP 200 plus the dora page marker - a torn-down devnet still
+// answers 404/503 from the ingress, so the status code alone is not enough.
+func probeDevnet(ctx context.Context, url, marker string, timeout time.Duration) (bool, string) {
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Sprintf("request error: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, "unreachable (DNS/connection failed)"
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Sprintf("HTTP %d (no live dora)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return false, fmt.Sprintf("HTTP 200 but read error: %v", err)
+	}
+	if !strings.Contains(string(body), marker) {
+		return false, "HTTP 200 but not a dora page"
+	}
+
+	return true, "HTTP 200, live dora"
+}
+
+func printClassification(infos []prefixInfo) {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "PREFIX\tCLASS\tDETAIL")
+	for _, info := range infos {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", info.Name, info.Class, info.Status)
+	}
+	tw.Flush()
+	fmt.Println()
+}
+
+// scheduleLifecycleCleanup merges prefix-filtered expiration rules into the
+// bucket's existing lifecycle configuration (preserving all other rules) and
+// writes it back in a single request.
+func scheduleLifecycleCleanup(
+	ctx context.Context,
+	logger *logrus.Logger,
+	client *minio.Client,
+	s3Cfg dtypes.S3BlockDBConfig,
+	confirmed []prefixInfo,
+	expireDays int,
+) error {
+	bucket := s3Cfg.Bucket
+	cfg, err := getLifecycle(ctx, client, bucket)
+	if err != nil {
+		return err
+	}
+
+	existing := make(map[string]bool, len(cfg.Rules))
+	for _, r := range cfg.Rules {
+		existing[r.ID] = true
+	}
+
+	added := 0
+	for _, c := range confirmed {
+		ruleID := cleanupRuleIDPrefix + c.Name
+		if existing[ruleID] {
+			logger.WithField("prefix", c.Name).Info("lifecycle rule already present; skipping")
+			continue
+		}
+
+		cfg.Rules = append(cfg.Rules, lifecycle.Rule{
+			ID:         ruleID,
+			Status:     "Enabled",
+			RuleFilter: lifecycle.Filter{Prefix: c.Name + "/"},
+			Expiration: lifecycle.Expiration{
+				Days: lifecycle.ExpirationDays(expireDays),
+			},
+			NoncurrentVersionExpiration: lifecycle.NoncurrentVersionExpiration{
+				NoncurrentDays: lifecycle.ExpirationDays(expireDays),
+			},
+		})
+		added++
+		logger.WithFields(logrus.Fields{
+			"prefix": c.Name,
+			"ruleID": ruleID,
+			"days":   expireDays,
+		}).Info("scheduled lifecycle expiration")
+	}
+
+	if added == 0 {
+		logger.Info("no new lifecycle rules to apply")
+		return nil
+	}
+
+	if err := putBucketLifecycle(ctx, client, s3Cfg, cfg); err != nil {
+		return err
+	}
+
+	logger.WithField("added", added).Info("lifecycle rules applied; objects will expire server-side")
+	return nil
+}
+
+// directDeletePrefixes removes all object versions under each confirmed prefix.
+func directDeletePrefixes(
+	ctx context.Context,
+	logger *logrus.Logger,
+	client *minio.Client,
+	bucket string,
+	confirmed []prefixInfo,
+) error {
+	for _, c := range confirmed {
+		log := logger.WithField("prefix", c.Name)
+		log.Info("deleting objects (including versions)")
+
+		objCh := client.ListObjects(ctx, bucket, minio.ListObjectsOptions{
+			Prefix:       c.Name + "/",
+			Recursive:    true,
+			WithVersions: true,
+		})
+
+		deleteCh := make(chan minio.ObjectInfo, 1000)
+		var queued atomic.Int64
+		var listErr error
+		go func() {
+			defer close(deleteCh)
+			for obj := range objCh {
+				if obj.Err != nil {
+					listErr = fmt.Errorf("error listing objects: %w", obj.Err)
+					return
+				}
+				deleteCh <- obj
+				queued.Add(1)
+			}
+		}()
+
+		// RemoveObjects only emits failures on its channel; successes are silent.
+		// Count actual deletions as queued-minus-failed.
+		var failed int64
+		for rerr := range client.RemoveObjects(ctx, bucket, deleteCh, minio.RemoveObjectsOptions{}) {
+			if rerr.Err != nil {
+				log.WithError(rerr.Err).WithField("key", rerr.ObjectName).Warn("failed to delete object")
+				failed++
+			}
+		}
+		if listErr != nil {
+			return listErr
+		}
+
+		log.WithFields(logrus.Fields{
+			"deleted": queued.Load() - failed,
+			"failed":  failed,
+		}).Info("prefix cleared")
+	}
+	return nil
+}
+
+func runS3PolicyList(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	client, s3Cfg, logger, err := s3CleanupSetup(cmd)
+	if err != nil {
+		return err
+	}
+	bucket := s3Cfg.Bucket
+
+	cfg, err := getLifecycle(ctx, client, bucket)
+	if err != nil {
+		return err
+	}
+
+	cleanupRules := make([]lifecycle.Rule, 0)
+	otherRules := make([]string, 0)
+	for _, r := range cfg.Rules {
+		if strings.HasPrefix(r.ID, cleanupRuleIDPrefix) {
+			cleanupRules = append(cleanupRules, r)
+		} else {
+			otherRules = append(otherRules, r.ID)
+		}
+	}
+
+	if len(otherRules) > 0 {
+		logger.WithField("rules", strings.Join(otherRules, ", ")).Info("other (non-cleanup) lifecycle rules present")
+	}
+
+	if len(cleanupRules) == 0 {
+		logger.Info("no cleanup lifecycle rules currently set")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "RULE ID\tPREFIX\tEXPIRE DAYS\tSTATUS\tOBJECTS LEFT")
+	for _, r := range cleanupRules {
+		prefix := strings.TrimSuffix(r.RuleFilter.Prefix, "/")
+		hasObjects, _ := prefixHasObjects(ctx, client, bucket, prefix)
+		left := "no (drained)"
+		if hasObjects {
+			left = "yes"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n", r.ID, prefix, int(r.Expiration.Days), r.Status, left)
+	}
+	tw.Flush()
+	return nil
+}
+
+func runS3PolicyCancel(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	client, s3Cfg, logger, err := s3CleanupSetup(cmd)
+	if err != nil {
+		return err
+	}
+	bucket := s3Cfg.Bucket
+
+	// Accept either a bare prefix name or a full rule ID.
+	wanted := make(map[string]bool, len(args))
+	for _, a := range args {
+		a = strings.TrimSuffix(strings.TrimSpace(a), "/")
+		wanted[cleanupRuleIDPrefix+strings.TrimPrefix(a, cleanupRuleIDPrefix)] = true
+	}
+
+	cfg, err := getLifecycle(ctx, client, bucket)
+	if err != nil {
+		return err
+	}
+
+	kept := make([]lifecycle.Rule, 0, len(cfg.Rules))
+	removed := 0
+	for _, r := range cfg.Rules {
+		if wanted[r.ID] {
+			logger.WithField("ruleID", r.ID).Info("removing cleanup rule")
+			removed++
+			continue
+		}
+		kept = append(kept, r)
+	}
+
+	if removed == 0 {
+		logger.Info("no matching cleanup rules found")
+		return nil
+	}
+
+	cfg.Rules = kept
+	if err := putBucketLifecycle(ctx, client, s3Cfg, cfg); err != nil {
+		return err
+	}
+
+	logger.WithField("removed", removed).Info("cleanup rules cancelled")
+	return nil
+}
+
+func runS3PolicyPrune(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	autoYes, _ := cmd.Flags().GetBool("yes")
+
+	client, s3Cfg, logger, err := s3CleanupSetup(cmd)
+	if err != nil {
+		return err
+	}
+	bucket := s3Cfg.Bucket
+
+	cfg, err := getLifecycle(ctx, client, bucket)
+	if err != nil {
+		return err
+	}
+
+	drained := make(map[string]bool)
+	for _, r := range cfg.Rules {
+		if !strings.HasPrefix(r.ID, cleanupRuleIDPrefix) {
+			continue
+		}
+		prefix := strings.TrimSuffix(r.RuleFilter.Prefix, "/")
+		hasObjects, err := prefixHasObjects(ctx, client, bucket, prefix)
+		if err != nil {
+			return err
+		}
+		if !hasObjects {
+			drained[r.ID] = true
+			logger.WithFields(logrus.Fields{"ruleID": r.ID, "prefix": prefix}).Info("rule prefix drained")
+		}
+	}
+
+	if len(drained) == 0 {
+		logger.Info("no drained cleanup rules to prune")
+		return nil
+	}
+
+	if dryRun {
+		logger.WithField("count", len(drained)).Info("dry-run: rules that would be pruned")
+		return nil
+	}
+
+	if !autoYes {
+		reader := bufio.NewReader(os.Stdin)
+		if !confirm(reader, fmt.Sprintf("Prune %d drained cleanup rule(s)? [y/N]: ", len(drained))) {
+			logger.Info("aborted")
+			return nil
+		}
+	}
+
+	kept := make([]lifecycle.Rule, 0, len(cfg.Rules))
+	for _, r := range cfg.Rules {
+		if drained[r.ID] {
+			continue
+		}
+		kept = append(kept, r)
+	}
+	cfg.Rules = kept
+
+	if err := putBucketLifecycle(ctx, client, s3Cfg, cfg); err != nil {
+		return err
+	}
+
+	logger.WithField("pruned", len(drained)).Info("drained cleanup rules removed")
+	return nil
+}
+
+// putBucketLifecycle writes the lifecycle configuration back to the bucket.
+//
+// It does not use minio's SetBucketLifecycle directly: minio's XML marshaller
+// omits the <Filter> element for match-all rules (an empty filter is treated as
+// null), but S3 (e.g. OVH) requires every rule to carry a <Filter>. A rule with
+// ExpiredObjectDeleteMarker may only carry an *empty* filter, which the struct
+// cannot express. So we let minio marshal the document, inject an empty
+// <Filter></Filter> into any rule that lacks one, and PUT the corrected body
+// with a request signed by minio's own v4 signer.
+func putBucketLifecycle(ctx context.Context, client *minio.Client, s3Cfg dtypes.S3BlockDBConfig, cfg *lifecycle.Configuration) error {
+	bucket := s3Cfg.Bucket
+
+	// An empty configuration removes the lifecycle entirely; minio handles that.
+	if cfg == nil || len(cfg.Rules) == 0 {
+		if err := client.SetBucketLifecycle(ctx, bucket, lifecycle.NewConfiguration()); err != nil {
+			return fmt.Errorf("failed to remove bucket lifecycle: %w", err)
+		}
+		return nil
+	}
+
+	raw, err := xml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal lifecycle config: %w", err)
+	}
+	body := injectEmptyFilters(raw)
+
+	region, err := client.GetBucketLocation(ctx, bucket)
+	if err != nil {
+		return fmt.Errorf("failed to resolve bucket region: %w", err)
+	}
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	scheme := "https"
+	if !bool(s3Cfg.Secure) {
+		scheme = "http"
+	}
+	url := fmt.Sprintf("%s://%s/%s?lifecycle=", scheme, s3Cfg.Endpoint, bucket)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to build lifecycle request: %w", err)
+	}
+	req.ContentLength = int64(len(body))
+
+	// S3 requires a Content-MD5 on lifecycle PUTs, and the signer reads the
+	// payload hash from X-Amz-Content-Sha256.
+	sha := sha256.Sum256(body)
+	req.Header.Set("X-Amz-Content-Sha256", hex.EncodeToString(sha[:]))
+	sum := md5.Sum(body)
+	req.Header.Set("Content-Md5", base64.StdEncoding.EncodeToString(sum[:]))
+
+	signed := signer.SignV4(*req, s3Cfg.AccessKey, s3Cfg.SecretKey, "", region)
+
+	resp, err := http.DefaultClient.Do(signed)
+	if err != nil {
+		return fmt.Errorf("lifecycle PUT failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("lifecycle PUT returned %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+	return nil
+}
+
+// injectEmptyFilters inserts an empty <Filter></Filter> into any <Rule> that was
+// marshalled without a filter or prefix, making match-all rules valid for S3.
+func injectEmptyFilters(marshalled []byte) []byte {
+	const ruleEnd = "</Rule>"
+	s := string(marshalled)
+
+	var out strings.Builder
+	for {
+		i := strings.Index(s, ruleEnd)
+		if i < 0 {
+			out.WriteString(s)
+			break
+		}
+		rule := s[:i]
+		if !strings.Contains(rule, "<Filter") && !strings.Contains(rule, "<Prefix>") {
+			rule += "<Filter></Filter>"
+		}
+		out.WriteString(rule)
+		out.WriteString(ruleEnd)
+		s = s[i+len(ruleEnd):]
+	}
+	return []byte(out.String())
+}
+
+// getLifecycle returns the bucket lifecycle config, or an empty config when the
+// bucket has none set yet.
+func getLifecycle(ctx context.Context, client *minio.Client, bucket string) (*lifecycle.Configuration, error) {
+	cfg, err := client.GetBucketLifecycle(ctx, bucket)
+	if err != nil {
+		if minio.ToErrorResponse(err).Code == "NoSuchLifecycleConfiguration" {
+			return lifecycle.NewConfiguration(), nil
+		}
+		return nil, fmt.Errorf("failed to get bucket lifecycle: %w", err)
+	}
+	if cfg == nil {
+		cfg = lifecycle.NewConfiguration()
+	}
+	return cfg, nil
+}
+
+// prefixHasObjects reports whether any object version exists under the prefix.
+func prefixHasObjects(ctx context.Context, client *minio.Client, bucket, prefix string) (bool, error) {
+	listCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for obj := range client.ListObjects(listCtx, bucket, minio.ListObjectsOptions{
+		Prefix:       prefix + "/",
+		Recursive:    true,
+		WithVersions: true,
+		MaxKeys:      1,
+	}) {
+		if obj.Err != nil {
+			return false, fmt.Errorf("error listing %q: %w", prefix, obj.Err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// quickSample counts up to maxQuickSample current objects under a prefix for a
+// fast, bounded indication of how much data a cleanup would affect.
+func quickSample(ctx context.Context, client *minio.Client, bucket, prefix string) (int, bool, error) {
+	listCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	count := 0
+	for obj := range client.ListObjects(listCtx, bucket, minio.ListObjectsOptions{
+		Prefix:    prefix + "/",
+		Recursive: true,
+	}) {
+		if obj.Err != nil {
+			return count, false, fmt.Errorf("error listing %q: %w", prefix, obj.Err)
+		}
+		count++
+		if count >= maxQuickSample {
+			return count, true, nil
+		}
+	}
+	return count, false, nil
+}
+
+func describeSample(count int, truncated bool, err error) string {
+	if err != nil {
+		return "size unknown"
+	}
+	if truncated {
+		return fmt.Sprintf(">=%d objects", count)
+	}
+	return fmt.Sprintf("%d objects", count)
+}
+
+// confirm prompts on stdin and returns true only on an explicit yes.
+func confirm(reader *bufio.Reader, prompt string) bool {
+	fmt.Print(prompt)
+	line, err := reader.ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}

--- a/cmd/dora-utils/s3_clear.go
+++ b/cmd/dora-utils/s3_clear.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethpandaops/dora/types"
@@ -142,8 +143,10 @@ func runS3ClearDryRun(logger *logrus.Logger, objectsCh <-chan minio.ObjectInfo) 
 }
 
 func runS3ClearDelete(ctx context.Context, logger *logrus.Logger, client *minio.Client, bucket string, objectsCh <-chan minio.ObjectInfo) error {
-	// Feed objects into a delete channel
+	// Feed objects into a delete channel, tracking how many bytes we queue.
 	deleteCh := make(chan minio.ObjectInfo, 1000)
+	var queued atomic.Int64
+	var queuedSize atomic.Int64
 	var listErr error
 
 	go func() {
@@ -154,18 +157,19 @@ func runS3ClearDelete(ctx context.Context, logger *logrus.Logger, client *minio.
 				return
 			}
 			deleteCh <- obj
+			queued.Add(1)
+			queuedSize.Add(obj.Size)
 		}
 	}()
 
-	var totalDeleted int64
-	var totalSize int64
-
+	// RemoveObjects only emits failures on its channel; successes are silent.
+	// Count actual deletions as queued-minus-failed.
+	var failed int64
 	for err := range client.RemoveObjects(ctx, bucket, deleteCh, minio.RemoveObjectsOptions{}) {
 		if err.Err != nil {
 			logger.WithError(err.Err).WithField("key", err.ObjectName).Warn("failed to delete object")
-			continue
+			failed++
 		}
-		totalDeleted++
 	}
 
 	if listErr != nil {
@@ -173,8 +177,9 @@ func runS3ClearDelete(ctx context.Context, logger *logrus.Logger, client *minio.
 	}
 
 	logger.WithFields(logrus.Fields{
-		"deleted":   totalDeleted,
-		"totalSize": formatBytes(totalSize),
+		"deleted":   queued.Load() - failed,
+		"failed":    failed,
+		"totalSize": formatBytes(queuedSize.Load()),
 	}).Info("S3 path cleared")
 
 	return nil

--- a/db/builder_deposits.go
+++ b/db/builder_deposits.go
@@ -62,6 +62,19 @@ func InsertBuilderDeposits(ctx context.Context, tx *sqlx.Tx, deposits []*dbtypes
 	return nil
 }
 
+// UpdateOnboardedBuilderDepositForkId re-attributes the upgrade_to_gloas onboarded builder deposit
+// copies of a public key (all attributed to the fork epoch's onboarding slot) to the supplied fork
+// id and marks them non-orphaned. The copies are written once at the fork boundary with the
+// then-unfinalized fork id; this is called when the source validator deposit is persisted
+// canonically so the copy tracks the same fork id and no longer shows up as orphaned.
+func UpdateOnboardedBuilderDepositForkId(ctx context.Context, tx *sqlx.Tx, publicKey []byte, slotNumber uint64, forkId uint64) error {
+	_, err := tx.ExecContext(ctx, `UPDATE builder_deposits SET fork_id = $1, orphaned = false WHERE public_key = $2 AND slot_number = $3`, forkId, publicKey, slotNumber)
+	if err != nil {
+		return fmt.Errorf("error updating onboarded builder deposit fork id: %v", err)
+	}
+	return nil
+}
+
 func GetBuilderDepositsFiltered(ctx context.Context, offset uint64, limit uint32, canonicalForkIds []uint64, filter *dbtypes.BuilderDepositFilter) ([]*dbtypes.BuilderDeposit, uint64, error) {
 	var sql strings.Builder
 	args := []interface{}{}

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -748,12 +748,14 @@ func (dbw *dbWriter) persistBlockDepositRequests(tx *sqlx.Tx, block *Block, orph
 // In Gloas/EIP-7732 a block processes its parent's payload requests
 // (parent_execution_requests) at this block's slot, so the requests are attributed to this
 // block's slot (matching the beacon state's PendingDeposit.slot). They were included in the
-// parent payload, which is the direct EL parent of this block's payload, so its block
-// number is this block's payload number minus one. Reading the requests from the block body
-// keeps them available even when the payload envelope is missing. The first Gloas block
-// carries an empty parent_execution_requests, so the last pre-Gloas requests are not counted
-// twice. In earlier forks the requests live in the block body and were included in the
-// block's own payload.
+// parent payload, so the EL block number they were dequeued in is the parent block's execution
+// block number. When this block reveals a payload that equals its own payload number minus one;
+// when this block is payload-less (the builder did not reveal a payload for this slot) its own
+// payload is absent, so the parent block's execution number is used directly. Reading the
+// requests from the block body keeps them available even when the payload envelope is missing.
+// The first Gloas block carries an empty parent_execution_requests, so the last pre-Gloas
+// requests are not counted twice. In earlier forks the requests live in the block body and were
+// included in the block's own payload.
 func (dbw *dbWriter) getProcessedExecutionRequests(block *Block) (*all.ExecutionRequests, uint64) {
 	chainState := dbw.indexer.consensusPool.GetChainState()
 
@@ -767,6 +769,21 @@ func (dbw *dbWriter) getProcessedExecutionRequests(block *Block) (*all.Execution
 		var blockNumber uint64
 		if payload := block.GetExecutionPayload(dbw.indexer.ctx); payload != nil && payload.Message.Payload.BlockNumber > 0 {
 			blockNumber = payload.Message.Payload.BlockNumber - 1
+		} else if parentRoot := block.GetParentRoot(); parentRoot != nil {
+			// payload-less block: the processed requests come from the parent block's payload,
+			// so use the parent's execution block number as the dequeue block.
+			if parentBlock := dbw.indexer.GetBlockByRoot(*parentRoot); parentBlock != nil {
+				if parentIndex := parentBlock.GetBlockIndex(dbw.indexer.ctx); parentIndex != nil {
+					blockNumber = parentIndex.ExecutionNumber
+				}
+			}
+			if blockNumber == 0 {
+				// the parent may be pruned from the block cache (e.g. first slot of a finalized
+				// epoch), so fall back to the database.
+				if parentSlot := db.GetSlotByRoot(dbw.indexer.ctx, parentRoot[:]); parentSlot != nil && parentSlot.EthBlockNumber != nil {
+					blockNumber = *parentSlot.EthBlockNumber
+				}
+			}
 		}
 		return body.ParentExecutionRequests, blockNumber
 	}

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -682,6 +682,41 @@ func (dbw *dbWriter) persistBlockDeposits(tx *sqlx.Tx, block *Block, depositInde
 		if err != nil {
 			return fmt.Errorf("error inserting deposits: %v", err)
 		}
+
+		if overrideForkId != nil {
+			if err := dbw.reconcileOnboardedBuilderDeposits(tx, dbDeposits, *overrideForkId); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// reconcileOnboardedBuilderDeposits keeps the upgrade_to_gloas onboarded builder deposit copies in
+// sync with their source validator deposits. The copies are written once at the fork boundary with
+// the then-unfinalized fork id and are not re-persisted per block, so when a source deposit (a
+// pre-gloas builder 0x03 deposit) is persisted canonically its matching copy is moved onto the same
+// fork id; otherwise the copy keeps its unfinalized fork id and later shows up as orphaned. It only
+// runs once the fork has activated (i.e. the copy exists).
+func (dbw *dbWriter) reconcileOnboardedBuilderDeposits(tx *sqlx.Tx, deposits []*dbtypes.Deposit, forkId ForkKey) error {
+	chainState := dbw.indexer.consensusPool.GetChainState()
+	gloasForkEpoch := chainState.GetSpecs().GloasForkEpoch
+	if gloasForkEpoch == nil || chainState.CurrentEpoch() < phase0.Epoch(*gloasForkEpoch) {
+		return nil
+	}
+
+	onboardingSlot := uint64(chainState.EpochToSlot(phase0.Epoch(*gloasForkEpoch)))
+	for _, deposit := range deposits {
+		// only pre-gloas builder (0x03) deposits are onboarded into builder_deposits by the fork
+		// transition, so only those have a copy to reconcile.
+		if deposit.CredType != 0x03 || uint64(chainState.EpochOfSlot(phase0.Slot(deposit.SlotNumber))) >= *gloasForkEpoch {
+			continue
+		}
+
+		if err := db.UpdateOnboardedBuilderDepositForkId(dbw.indexer.ctx, tx, deposit.PublicKey, onboardingSlot, uint64(forkId)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -736,6 +771,12 @@ func (dbw *dbWriter) persistBlockDepositRequests(tx *sqlx.Tx, block *Block, orph
 		err := db.InsertDeposits(dbw.indexer.ctx, tx, dbDeposits)
 		if err != nil {
 			return fmt.Errorf("error inserting deposit requests: %v", err)
+		}
+
+		if overrideForkId != nil {
+			if err := dbw.reconcileOnboardedBuilderDeposits(tx, dbDeposits, *overrideForkId); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
# Fix remaining post-Gloas builder deposit gaps (payload-less blocks + onboarded fork id)

Follow-up to #772. That PR fixed the matcher boundary-timing bug (it held back the
finalization-tip block so a dequeue block `D` is only matched once block `D+1` is indexed),
which removed most of the scattered single-slot gaps. But two distinct issues remained that
#772 did not address — this PR fixes both.

## Fix 1 — payload-less Gloas blocks indexed with `block_number = 0`

**Symptom.** On `glamsterdam-devnet-6` some builder deposits still rendered with no matched
tx (e.g. slots `1667`, `7302`) after #772.

**Root cause.** Those slots are **payload-less Gloas blocks** — the builder never revealed a
payload, so the EL chain skips that slot (e.g. `1547 → 1548`, `6303 → 6304`). The beacon
block still exists and still processes its **parent's** `parent_execution_requests`, but
`getProcessedExecutionRequests` derived the dequeue block from *this* block's own payload
(`payload.BlockNumber - 1`). With no payload, `block_number` was written as `0`, so the
operation could never match any tx (no tx has `dequeue_block = 0`).

The correct dequeue block is the **parent block's** execution number. Confirmed against the
DB: slot 1667's three deposits match txs with `dequeue_block = 1547` (= parent slot 1666's
`eth_block_number`); slot 7302's deposit matches a tx with `dequeue_block = 6303` (= parent
slot 7301's `eth_block_number`).

**Fix** (`indexer/beacon/writedb.go`, `getProcessedExecutionRequests`). When the block reveals
a payload, keep `payload.BlockNumber - 1`. When it is payload-less, fall back to the parent
block's execution number — via the block cache, and via `db.GetSlotByRoot` when the parent has
been pruned from cache (e.g. the first slot of a finalized epoch). Centralized, so it corrects
`block_number` for all five request types (deposits, builder deposits, builder exits,
withdrawals, consolidations) at once.

## Fix 2 — onboarded builder deposits stuck on an unfinalized fork id (shown orphaned)

**Symptom.** The pre-Gloas builders onboarded at the fork transition (e.g. slot 960 on the
devnet) render as **Orphaned** on the builder deposit page.

**Root cause.** `persistGloasOnboardedBuilderDeposits` copies the pre-Gloas `0x03`-credential
deposits from the `pending_deposits` queue into `builder_deposits` once, at the fork boundary,
while unfinalized — stamping them with the then-current (unfinalized) fork id (e.g. `4`).
Regular block deposits get their `fork_id` reset to `0` on finalization because every canonical
block is re-persisted with `overrideForkId = 0`. The onboarded copies are not attached to a
block, so nothing ever re-touched them. Once that fork was pruned, the page's canonical check
(`isCanonicalForkId`, rooted at fork `0`) no longer matched → they were treated as orphaned
forever.

**Fix** (`indexer/beacon/writedb.go` + `db/builder_deposits.go`). Reconcile the onboarded copy
with its source deposit, riding the existing deposit upsert: when a source validator deposit
(pre-Gloas, `cred_type == 0x03`) is persisted **canonically** at finalization/sync
(`overrideForkId != nil`), `reconcileOnboardedBuilderDeposits` moves the matching onboarded
copy (matched by `public_key` + the fork-epoch onboarding slot, via
`db.UpdateOnboardedBuilderDepositForkId`) onto the same canonical fork id. Gated on
`CurrentEpoch() >= GloasForkEpoch` so it is a no-op until the fork (and thus the copy) exists.
The copy now tracks its source deposit's fork-id lifecycle instead of keeping a stale
unfinalized id.

**Coverage.** Heals on full re-sync (every deposit is re-persisted with head past Gloas), and
on live nodes for deposits whose source block finalizes after Gloas activates. Deposits whose
source block finalized *before* Gloas activated (the deep-historical / genesis batch) only heal
on the next re-sync — an accepted limitation, since those blocks are never re-persisted on a
live node.

Minor edge: if a reorg at the Gloas boundary left onboarded copies under two dependent roots
for the same pubkey, the `public_key` + slot match would canonicalize both — rare and
low-impact.

## Existing data

Neither fix retroactively rewrites already-persisted rows on a running instance:

- Payload-less `block_number = 0` rows must be **re-indexed** for `getProcessedExecutionRequests`
  to run again.
- Onboarded copies stuck on an old fork id heal on **re-sync**, or directly via SQL, e.g.:
  `UPDATE builder_deposits SET fork_id = 0, orphaned = false WHERE slot_number = 960 AND fork_id = 4;`

## Test plan

- [x] `go build ./...`
- [ ] Re-index / re-sync the affected epochs on a post-Gloas instance and confirm slots `1667`,
      `7302` resolve to their txs and the onboarded builders (slot `960`) no longer show as
      orphaned.
