### PR TITLE
implement ENS name resolver for execution addresses

### DIFF
--- a/.hack/devnet/run.sh
+++ b/.hack/devnet/run.sh
@@ -183,6 +183,11 @@ executionIndexer:
   detailsEnabled: true
   tracesEnabled: true
   detailsMaxSize: "100GB"
+ensResolver:
+  enabled: true
+  # no dedicated endpoints -> resolve against the devnet's own EL pool
+  registryAddresses:
+    - "0xf7CFC9E18166c1BBae0749373C5fC80CabCaDD25"
 txsig:
   cbtBaseUrl: "https://cbt-api-mainnet.analytics.production.platform.ethpandaops.io/api/v1/dim_function_signature"
 database:

--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -189,3 +189,22 @@ rpcProxy:
     - "eth_chainId"          # Network chain ID
     - "net_version"          # Network version
 
+# Optional ENS resolver: resolves execution addresses to their primary ENS name.
+ensResolver:
+  enabled: false # enable ENS name resolution & display
+  # optional dedicated EL RPC endpoints (usually Ethereum mainnet). If empty, an
+  # available client from the main execution pool is used.
+  endpoints: []
+  #  - url: "https://ethereum-rpc.publicnode.com"
+  #    name: "mainnet"
+  # ENS registries to query, in priority order (first verified name wins). Each is
+  # probed for bytecode on the target chain and skipped if not deployed.
+  registryAddresses:
+    - "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" # ENS registry (mainnet)
+  multicallAddress: "0xcA11bde05977b3631167028862bE2a173976CA11" # Multicall3 (batches lookups when deployed)
+  refreshPositive: 24h # re-resolve interval for addresses that have a name
+  refreshNegative: 6h  # re-resolve interval for addresses without a name
+  batchSize: 100       # addresses resolved per worker batch
+  queueSize: 50000     # capped in-memory queue of pending addresses
+  cacheSize: 50000     # in-memory LRU name cache size
+

--- a/db/ens_names.go
+++ b/db/ens_names.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/jmoiron/sqlx"
+)
+
+// GetEnsNamesByAddresses retrieves persisted ENS lookups (positive and negative)
+// for multiple addresses in a single query. Returns a map from address (hex string)
+// to the stored entry for efficient lookup.
+func GetEnsNamesByAddresses(ctx context.Context, addresses [][]byte) (map[string]*dbtypes.EnsName, error) {
+	if len(addresses) == 0 {
+		return make(map[string]*dbtypes.EnsName), nil
+	}
+
+	var sql strings.Builder
+	args := make([]any, len(addresses))
+
+	fmt.Fprint(&sql, "SELECT address, name, resolved_time FROM ens_names WHERE address IN (")
+	for i, addr := range addresses {
+		args[i] = addr
+	}
+	appendDollarPlaceholders(&sql, 1, len(addresses), ", ")
+	fmt.Fprint(&sql, ")")
+
+	names := []*dbtypes.EnsName{}
+	err := ReaderDb.SelectContext(ctx, &names, sql.String(), args...)
+	if err != nil {
+		logger.Errorf("Error while fetching ens names by addresses: %v", err)
+		return nil, err
+	}
+
+	result := make(map[string]*dbtypes.EnsName, len(names))
+	for _, name := range names {
+		result[byteSliceMapKey(name.Address)] = name
+	}
+	return result, nil
+}
+
+// InsertEnsNames upserts a batch of ENS lookups (positive and negative), refreshing
+// the name and resolved_time for addresses that already exist.
+func InsertEnsNames(ctx context.Context, dbTx *sqlx.Tx, names []*dbtypes.EnsName) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	var sql strings.Builder
+	args := make([]any, 0, len(names)*3)
+
+	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
+		dbtypes.DBEnginePgsql:  "INSERT INTO ens_names (address, name, resolved_time) VALUES ",
+		dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO ens_names (address, name, resolved_time) VALUES ",
+	}))
+
+	for i, name := range names {
+		if i > 0 {
+			fmt.Fprint(&sql, ", ")
+		}
+		argIdx := len(args) + 1
+		fmt.Fprintf(&sql, "($%d, $%d, $%d)", argIdx, argIdx+1, argIdx+2)
+		args = append(args, name.Address, name.Name, name.ResolvedTime)
+	}
+
+	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
+		dbtypes.DBEnginePgsql: " ON CONFLICT (address) DO UPDATE SET name = excluded.name, resolved_time = excluded.resolved_time",
+	}))
+
+	_, err := dbTx.ExecContext(ctx, sql.String(), args...)
+	if err != nil {
+		return fmt.Errorf("error inserting ens names: %w", err)
+	}
+	return nil
+}

--- a/db/schema/pgsql/20260704000000_ens-names.sql
+++ b/db/schema/pgsql/20260704000000_ens-names.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS public."ens_names" (
+    address bytea NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    resolved_time BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT ens_names_pkey PRIMARY KEY (address)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS public."ens_names";
+-- +goose StatementEnd

--- a/db/schema/sqlite/20260704000000_ens-names.sql
+++ b/db/schema/sqlite/20260704000000_ens-names.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS "ens_names" (
+    address BLOB NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    resolved_time INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT ens_names_pkey PRIMARY KEY (address)
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS "ens_names";
+-- +goose StatementEnd

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -656,6 +656,14 @@ type ElAccount struct {
 	LastBlockUid uint64 `db:"last_block_uid"`
 }
 
+// EnsName holds a resolved primary ENS name for an execution address.
+// An empty Name is a persisted negative result (address has no primary name).
+type EnsName struct {
+	Address      []byte `db:"address"`
+	Name         string `db:"name"`
+	ResolvedTime int64  `db:"resolved_time"`
+}
+
 // Token type constants
 const (
 	TokenTypeERC20   = 1

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/mux v1.8.1
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -78,7 +79,6 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect

--- a/handlers/address.go
+++ b/handlers/address.go
@@ -291,6 +291,27 @@ func buildAddressPageData(ctx context.Context, addressBytes []byte, tabView stri
 		}
 	}
 
+	// Collect execution addresses shown on the page for ENS name resolution.
+	ensAddrs := make([][]byte, 0, len(pageData.Transactions)*2+len(pageData.TokenBalances)+2)
+	ensAddrs = append(ensAddrs, pageData.Address, pageData.FundedBy)
+	for _, tb := range pageData.TokenBalances {
+		ensAddrs = append(ensAddrs, tb.Contract)
+	}
+	for _, tx := range pageData.Transactions {
+		ensAddrs = append(ensAddrs, tx.FromAddr, tx.ToAddr)
+	}
+	for _, t := range pageData.ERC20Transfers {
+		ensAddrs = append(ensAddrs, t.FromAddr, t.ToAddr, t.Contract)
+	}
+	for _, t := range pageData.NFTTransfers {
+		ensAddrs = append(ensAddrs, t.FromAddr, t.ToAddr, t.Contract)
+	}
+	ensNames := resolveEnsNames(ctx, ensAddrs)
+	pageData.SetEnsNames(ensNames)
+	// The page's own address is rendered full (not as a swappable link), so surface its
+	// name explicitly for the header to show alongside the address.
+	pageData.AddressEnsName = ensNames[strings.ToLower(common.BytesToAddress(pageData.Address).Hex())]
+
 	return pageData, 2 * time.Minute
 }
 

--- a/handlers/blocks_filtered.go
+++ b/handlers/blocks_filtered.go
@@ -509,6 +509,12 @@ func buildFilteredBlocksPageData(ctx context.Context, pageIdx uint64, pageSize u
 		pageData.TotalPages++
 	}
 
+	ensAddrs := make([][]byte, 0, len(pageData.Blocks))
+	for _, block := range pageData.Blocks {
+		ensAddrs = append(ensAddrs, block.FeeRecipient)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	pageData.UrlParams = make([]models.UrlParam, 0, len(filterArgs)+1)
 	for key, values := range filterArgs {
 		if len(values) > 0 {

--- a/handlers/builder.go
+++ b/handlers/builder.go
@@ -354,6 +354,25 @@ func buildBuilderPageData(ctx context.Context, builder *gloas.Builder, builderIn
 		pageData.WithdrawalCount = uint64(len(pageData.Withdrawals))
 	}
 
+	ensAddrs := make([][]byte, 0, 1+len(pageData.RecentBlocks)+len(pageData.RecentBids)+len(pageData.RecentDeposits))
+	ensAddrs = append(ensAddrs, pageData.ExecutionAddress)
+	for _, block := range pageData.RecentBlocks {
+		ensAddrs = append(ensAddrs, block.FeeRecipient)
+	}
+	for _, bid := range pageData.RecentBids {
+		ensAddrs = append(ensAddrs, bid.FeeRecipient)
+	}
+	for _, deposit := range pageData.RecentDeposits {
+		ensAddrs = append(ensAddrs, deposit.DepositorAddress)
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	if pageData.ExitReasonTxDetails != nil {
+		ensAddrs = appendEnsHexAddrs(ensAddrs, pageData.ExitReasonTxDetails.TxOrigin, pageData.ExitReasonTxDetails.TxTarget)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	return pageData, 10 * time.Minute
 }
 

--- a/handlers/builder_deposits.go
+++ b/handlers/builder_deposits.go
@@ -283,6 +283,14 @@ func buildBuilderDepositsPageData(ctx context.Context, pageIdx uint64, pageSize 
 	pageData.NextPageLink = fmt.Sprintf("/builders/deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)
 	pageData.LastPageLink = fmt.Sprintf("/builders/deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.LastPageIndex)
 
+	ensAddrs := make([][]byte, 0, len(pageData.Deposits)*2)
+	for _, deposit := range pageData.Deposits {
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	return pageData
 }
 
@@ -471,6 +479,14 @@ func buildBuilderDepositsProjectionPageData(ctx context.Context, pageIdx uint64,
 	pageData.PrevPageLink = fmt.Sprintf("/builders/deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.PrevPageIndex)
 	pageData.NextPageLink = fmt.Sprintf("/builders/deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.NextPageIndex)
 	pageData.LastPageLink = fmt.Sprintf("/builders/deposits?f&%v&c=%v&p=%v", filterArgs.Encode(), pageData.PageSize, pageData.LastPageIndex)
+
+	ensAddrs := make([][]byte, 0, len(pageData.Deposits)*2)
+	for _, deposit := range pageData.Deposits {
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
 
 	return pageData
 }

--- a/handlers/builder_exits.go
+++ b/handlers/builder_exits.go
@@ -222,6 +222,15 @@ func buildBuilderExitsPageData(ctx context.Context, pageIdx uint64, pageSize uin
 	}
 	pageData.ExitCount = uint64(len(pageData.Exits))
 
+	ensAddrs := make([][]byte, 0, len(pageData.Exits))
+	for _, exit := range pageData.Exits {
+		ensAddrs = append(ensAddrs, exit.SourceAddress)
+		if exit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, exit.TransactionDetails.TxOrigin, exit.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	if pageData.ExitCount > 0 {
 		pageData.FirstIndex = pageData.Exits[0].SlotNumber
 		pageData.LastIndex = pageData.Exits[pageData.ExitCount-1].SlotNumber

--- a/handlers/builders.go
+++ b/handlers/builders.go
@@ -278,6 +278,12 @@ func buildBuildersPageData(ctx context.Context, pageNumber uint64, pageSize uint
 	pageData.FirstBuilder = pageNumber * pageSize
 	pageData.LastBuilder = pageData.FirstBuilder + uint64(len(pageData.Builders))
 
+	ensAddrs := make([][]byte, 0, len(pageData.Builders))
+	for _, builder := range pageData.Builders {
+		ensAddrs = append(ensAddrs, builder.ExecutionAddress)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	// Populate UrlParams for page jump functionality
 	pageData.UrlParams = make(map[string]string)
 	for key, values := range filterArgs {

--- a/handlers/consolidations.go
+++ b/handlers/consolidations.go
@@ -177,6 +177,12 @@ func buildConsolidationsPageData(ctx context.Context, firstEpoch uint64, pageSiz
 		}
 		pageData.RecentConsolidationCount = uint64(len(pageData.RecentConsolidations))
 
+		ensAddrs := make([][]byte, 0, len(pageData.RecentConsolidations))
+		for _, consolidation := range pageData.RecentConsolidations {
+			ensAddrs = append(ensAddrs, consolidation.SourceAddr)
+		}
+		pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	case "queue":
 		// Load consolidation queue
 		queueConsolidations, _ := services.GlobalBeaconService.GetConsolidationQueueByFilter(ctx, &services.ConsolidationQueueFilter{}, 0, 20)

--- a/handlers/debug_cache.go
+++ b/handlers/debug_cache.go
@@ -55,6 +55,7 @@ type DebugPageData struct {
 	Database      *DatabaseDebugData
 	System        *SystemDebugData
 	ExecIndexer   *ExecIndexerDebugData
+	EnsResolver   *services.EnsResolverStats
 }
 
 // FrontendCacheDebugData holds frontend cache statistics.
@@ -282,6 +283,9 @@ func buildDebugPageData() *DebugPageData {
 
 	// Execution indexer stats
 	data.ExecIndexer = buildExecIndexerDebugData()
+
+	// ENS resolver stats
+	data.EnsResolver = services.GlobalBeaconService.GetEnsResolver().GetDebugStats()
 
 	// System stats
 	data.System = buildSystemDebugData()

--- a/handlers/deposits.go
+++ b/handlers/deposits.go
@@ -476,5 +476,22 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 		}
 	}
 
+	ensAddrs := make([][]byte, 0, len(pageData.InitiatedDeposits)+len(pageData.IncludedDeposits))
+	for _, deposit := range pageData.InitiatedDeposits {
+		ensAddrs = append(ensAddrs, deposit.Address)
+	}
+	for _, deposit := range pageData.IncludedDeposits {
+		ensAddrs = append(ensAddrs, deposit.DepositorAddress)
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	for _, deposit := range pageData.QueuedDeposits {
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	return pageData, 1 * time.Minute
 }

--- a/handlers/el_consolidations.go
+++ b/handlers/el_consolidations.go
@@ -276,6 +276,15 @@ func buildFilteredElConsolidationsPageData(ctx context.Context, pageIdx uint64, 
 
 	pageData.RequestCount = uint64(len(pageData.ElRequests))
 
+	ensAddrs := make([][]byte, 0, len(pageData.ElRequests))
+	for _, elConsolidation := range pageData.ElRequests {
+		ensAddrs = append(ensAddrs, elConsolidation.SourceAddr)
+		if elConsolidation.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, elConsolidation.TransactionDetails.TxOrigin, elConsolidation.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	if pageData.RequestCount > 0 {
 		pageData.FirstIndex = pageData.ElRequests[0].SlotNumber
 		pageData.LastIndex = pageData.ElRequests[pageData.RequestCount-1].SlotNumber

--- a/handlers/el_withdrawals.go
+++ b/handlers/el_withdrawals.go
@@ -298,6 +298,15 @@ func buildFilteredElWithdrawalsPageData(ctx context.Context, pageIdx uint64, pag
 
 	pageData.RequestCount = uint64(len(pageData.ElRequests))
 
+	ensAddrs := make([][]byte, 0, len(pageData.ElRequests))
+	for _, elWithdrawal := range pageData.ElRequests {
+		ensAddrs = append(ensAddrs, elWithdrawal.SourceAddr)
+		if elWithdrawal.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, elWithdrawal.TransactionDetails.TxOrigin, elWithdrawal.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	if pageData.RequestCount > 0 {
 		pageData.FirstIndex = pageData.ElRequests[0].SlotNumber
 		pageData.LastIndex = pageData.ElRequests[pageData.RequestCount-1].SlotNumber

--- a/handlers/exits.go
+++ b/handlers/exits.go
@@ -284,6 +284,12 @@ func buildExitsPageData(ctx context.Context, firstEpoch uint64, pageSize uint64,
 		}
 		pageData.RecentExitRequestCount = uint64(len(pageData.RecentExitRequests))
 
+		ensAddrs := make([][]byte, 0, len(pageData.RecentExitRequests))
+		for _, exitReq := range pageData.RecentExitRequests {
+			ensAddrs = append(ensAddrs, exitReq.SourceAddr)
+		}
+		pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	case "exiting":
 		// Load exiting validators (limit to first 20 for tab)
 		count := uint64(len(nonConsolidatingValidators))

--- a/handlers/included_deposits.go
+++ b/handlers/included_deposits.go
@@ -327,6 +327,15 @@ func buildFilteredIncludedDepositsPageData(ctx context.Context, pageIdx uint64, 
 	}
 	pageData.DepositCount = uint64(len(pageData.Deposits))
 
+	ensAddrs := make([][]byte, 0, len(pageData.Deposits))
+	for _, deposit := range pageData.Deposits {
+		ensAddrs = append(ensAddrs, deposit.DepositorAddress)
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	if pageData.DepositCount > 0 {
 		pageData.FirstIndex = pageData.Deposits[0].Index
 		pageData.LastIndex = pageData.Deposits[pageData.DepositCount-1].Index

--- a/handlers/initiated_deposits.go
+++ b/handlers/initiated_deposits.go
@@ -256,6 +256,12 @@ func buildFilteredInitiatedDepositsPageData(ctx context.Context, pageIdx uint64,
 	}
 	pageData.DepositCount = uint64(len(pageData.Deposits))
 
+	ensAddrs := make([][]byte, 0, len(pageData.Deposits))
+	for _, deposit := range pageData.Deposits {
+		ensAddrs = append(ensAddrs, deposit.Address)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	if pageData.DepositCount > 0 {
 		pageData.FirstIndex = pageData.Deposits[0].Index
 		pageData.LastIndex = pageData.Deposits[pageData.DepositCount-1].Index

--- a/handlers/mev_blocks.go
+++ b/handlers/mev_blocks.go
@@ -263,6 +263,12 @@ func buildFilteredMevBlocksPageData(ctx context.Context, pageIdx uint64, pageSiz
 	}
 	pageData.BlockCount = uint64(len(pageData.MevBlocks))
 
+	ensAddrs := make([][]byte, 0, len(pageData.MevBlocks))
+	for _, mevBlock := range pageData.MevBlocks {
+		ensAddrs = append(ensAddrs, mevBlock.FeeRecipient)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	if pageData.BlockCount > 0 {
 		pageData.FirstIndex = pageData.MevBlocks[0].SlotNumber
 		pageData.LastIndex = pageData.MevBlocks[pageData.BlockCount-1].SlotNumber

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -392,4 +393,31 @@ func handleTemplateError(w http.ResponseWriter, r *http.Request, fileIdentifier 
 		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
 	}
 	return err
+}
+
+// resolveEnsNames resolves the primary ENS names for the given execution addresses via
+// the ENS resolver service. It returns an address->name map (empty when the resolver is
+// disabled) and enqueues unresolved/stale addresses for asynchronous resolution.
+//
+// Handlers call this once per page build with all addresses shown on the page; the
+// result is stored on the page model (models.EnsNameData) and rendered client-side.
+func resolveEnsNames(ctx context.Context, addrs [][]byte) map[string]string {
+	ensResolver := services.GlobalBeaconService.GetEnsResolver()
+	if ensResolver == nil {
+		return nil
+	}
+	return ensResolver.ResolveNames(ctx, addrs)
+}
+
+// appendEnsHexAddrs appends the 20-byte form of 0x-hex address strings to dst, skipping
+// empty or invalid entries. Used to include addresses that page models carry as hex
+// strings (e.g. the TxOrigin/TxTarget in tx-detail callouts) in the ENS resolve set.
+func appendEnsHexAddrs(dst [][]byte, hexAddrs ...string) [][]byte {
+	for _, hexAddr := range hexAddrs {
+		if hexAddr == "" || !common.IsHexAddress(hexAddr) {
+			continue
+		}
+		dst = append(dst, common.HexToAddress(hexAddr).Bytes())
+	}
+	return dst
 }

--- a/handlers/queued_deposits.go
+++ b/handlers/queued_deposits.go
@@ -313,5 +313,14 @@ func buildQueuedDepositsPageData(ctx context.Context, pageIdx uint64, pageSize u
 	pageData.DepositsFrom = start + 1
 	pageData.DepositsTo = end
 	pageData.DepositCount = uint64(len(pageData.Deposits))
+
+	ensAddrs := make([][]byte, 0, len(pageData.Deposits)*2)
+	for _, deposit := range pageData.Deposits {
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	return pageData, cacheTimeout
 }

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -375,6 +375,33 @@ func buildSlotPageData(ctx context.Context, blockSlot int64, blockRoot []byte) (
 		}
 	}
 
+	if pageData.Block != nil {
+		block := pageData.Block
+		ensAddrs := make([][]byte, 0)
+		if block.ExecutionData != nil {
+			ensAddrs = append(ensAddrs, block.ExecutionData.FeeRecipient)
+		}
+		for _, tx := range block.Transactions {
+			ensAddrs = append(ensAddrs, tx.From, tx.To)
+		}
+		for _, wd := range block.Withdrawals {
+			ensAddrs = append(ensAddrs, wd.Address)
+		}
+		for _, change := range block.BLSChanges {
+			ensAddrs = append(ensAddrs, change.Address)
+		}
+		for _, req := range block.WithdrawalRequests {
+			ensAddrs = append(ensAddrs, req.Address)
+		}
+		for _, req := range block.ConsolidationRequests {
+			ensAddrs = append(ensAddrs, req.Address)
+		}
+		for _, req := range block.BuilderExitRequests {
+			ensAddrs = append(ensAddrs, req.SourceAddress)
+		}
+		pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+	}
+
 	return pageData, cacheTimeout
 }
 

--- a/handlers/token.go
+++ b/handlers/token.go
@@ -158,6 +158,13 @@ func buildTokenPageData(ctx context.Context, contract []byte, beforeTxUid uint64
 	dbTransfers, hasNext, _ := db.GetElTokenTransfersFiltered(ctx, filter, beforeTxUid, beforeTxIdx, uint32(pageSize))
 	pageData.Transfers = enrichElTokenTransferRows(ctx, dbTransfers)
 
+	ensAddrs := make([][]byte, 0, len(pageData.Transfers)*3+1)
+	ensAddrs = append(ensAddrs, pageData.Contract)
+	for _, t := range pageData.Transfers {
+		ensAddrs = append(ensAddrs, t.FromAddr, t.ToAddr, t.Contract)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	tokenHex := common.BytesToAddress(token.Contract).Hex()
 	suffix := fmt.Sprintf("c=%v", pageSize)
 	if filterSuffix != "" {

--- a/handlers/tokens.go
+++ b/handlers/tokens.go
@@ -124,6 +124,12 @@ func buildTokensPageData(ctx context.Context, pageIdx uint64, pageSize uint64, s
 		})
 	}
 
+	ensAddrs := make([][]byte, 0, len(pageData.Tokens))
+	for _, t := range pageData.Tokens {
+		ensAddrs = append(ensAddrs, t.Contract)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	// Pagination via the shared offset pager (preserves page size + search).
 	params := []models.UrlParam{{Key: "c", Value: strconv.FormatUint(pageSize, 10)}}
 	if search != "" {

--- a/handlers/transaction.go
+++ b/handlers/transaction.go
@@ -174,17 +174,20 @@ func buildTransactionPageData(ctx context.Context, txHash []byte, tabView string
 		if time.Since(blockTime) > 5*time.Minute {
 			cacheTimeout = 15 * time.Minute
 		}
+		setTransactionEnsNames(ctx, pageData)
 		return pageData, cacheTimeout
 	}
 
 	// Not in DB - reconstruct from blockdb (relational row pruned but still
 	// within the longer blockdb/details retention).
 	if buildTransactionPageDataFromBlockdb(ctx, pageData, txHash, chainState) {
+		setTransactionEnsNames(ctx, pageData)
 		return pageData, 15 * time.Minute
 	}
 
 	// Not in DB or blockdb - try to fetch from EL client
 	if buildTransactionPageDataFromEL(ctx, pageData, txHash, chainState) {
+		setTransactionEnsNames(ctx, pageData)
 		return pageData, 30 * time.Minute
 	}
 
@@ -192,6 +195,34 @@ func buildTransactionPageData(ctx context.Context, txHash []byte, tabView string
 	pageData.TxNotFound = true
 	pageData.ViewMode = models.TxViewModeNone
 	return pageData, 1 * time.Minute
+}
+
+// setTransactionEnsNames collects every execution address shown on the transaction
+// detail page (main from/to plus the events, token-transfer, internal-tx, access-list,
+// state-change and authorization sub-lists of the active tab) and resolves their ENS
+// names once for client-side display.
+func setTransactionEnsNames(ctx context.Context, pageData *models.TransactionPageData) {
+	ensAddrs := make([][]byte, 0, 8)
+	ensAddrs = append(ensAddrs, pageData.FromAddr, pageData.ToAddr)
+	for _, event := range pageData.Events {
+		ensAddrs = append(ensAddrs, event.SourceAddr, event.EthTransferFrom, event.EthTransferTo)
+	}
+	for _, transfer := range pageData.TokenTransfers {
+		ensAddrs = append(ensAddrs, transfer.Contract, transfer.FromAddr, transfer.ToAddr)
+	}
+	for _, itx := range pageData.InternalTxs {
+		ensAddrs = append(ensAddrs, itx.FromAddr, itx.ToAddr)
+	}
+	for _, entry := range pageData.AccessListEntries {
+		ensAddrs = append(ensAddrs, entry.Address)
+	}
+	for _, change := range pageData.StateChanges {
+		ensAddrs = append(ensAddrs, change.Address)
+	}
+	for _, auth := range pageData.Authorizations {
+		ensAddrs = append(ensAddrs, auth.AuthorityAddr, auth.DelegateAddr)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
 }
 
 // buildTransactionPageDataFromDB builds page data from database entries.

--- a/handlers/transactions.go
+++ b/handlers/transactions.go
@@ -262,6 +262,12 @@ func buildTransactionsPageData(ctx context.Context, beforeTxUid uint64, pageNum 
 	dbTxs, hasNext, _ := db.GetElTransactionsFiltered(ctx, filter, beforeTxUid, uint32(pageSize))
 	pageData.Transactions = enrichElTransactionRows(ctx, dbTxs)
 
+	ensAddrs := make([][]byte, 0, len(pageData.Transactions)*2)
+	for _, tx := range pageData.Transactions {
+		ensAddrs = append(ensAddrs, tx.FromAddr, tx.ToAddr)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	suffix := fmt.Sprintf("c=%v", pageSize)
 	if filterSuffix != "" {
 		suffix += "&" + filterSuffix

--- a/handlers/transfers.go
+++ b/handlers/transfers.go
@@ -227,6 +227,12 @@ func buildTransfersPageData(ctx context.Context, beforeTxUid uint64, beforeTxIdx
 	dbTransfers, hasNext, _ := db.GetElTokenTransfersFiltered(ctx, filter, beforeTxUid, beforeTxIdx, uint32(pageSize))
 	pageData.Transfers = enrichElTokenTransferRows(ctx, dbTransfers)
 
+	ensAddrs := make([][]byte, 0, len(pageData.Transfers)*3)
+	for _, t := range pageData.Transfers {
+		ensAddrs = append(ensAddrs, t.FromAddr, t.ToAddr, t.Contract)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	suffix := fmt.Sprintf("c=%v", pageSize)
 	if filterSuffix != "" {
 		suffix += "&" + filterSuffix

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -882,5 +882,33 @@ func buildValidatorPageData(ctx context.Context, validatorIndex uint64, tabView 
 		}
 	}
 
+	ensAddrs := make([][]byte, 0)
+	ensAddrs = append(ensAddrs, pageData.WithdrawAddress)
+	for _, deposit := range pageData.RecentDeposits {
+		ensAddrs = append(ensAddrs, deposit.DepositorAddress)
+		if deposit.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, deposit.TransactionDetails.TxOrigin, deposit.TransactionDetails.TxTarget)
+		}
+	}
+	for _, request := range pageData.WithdrawalRequests {
+		ensAddrs = append(ensAddrs, request.SourceAddr)
+		if request.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, request.TransactionDetails.TxOrigin, request.TransactionDetails.TxTarget)
+		}
+	}
+	for _, consolidation := range pageData.ConsolidationRequests {
+		ensAddrs = append(ensAddrs, consolidation.SourceAddr)
+		if consolidation.TransactionDetails != nil {
+			ensAddrs = appendEnsHexAddrs(ensAddrs, consolidation.TransactionDetails.TxOrigin, consolidation.TransactionDetails.TxTarget)
+		}
+	}
+	for _, withdrawal := range pageData.Withdrawals {
+		ensAddrs = append(ensAddrs, withdrawal.Address)
+	}
+	if pageData.ExitReasonTxDetails != nil {
+		ensAddrs = appendEnsHexAddrs(ensAddrs, pageData.ExitReasonTxDetails.TxOrigin, pageData.ExitReasonTxDetails.TxTarget)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	return pageData, 10 * time.Minute
 }

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -334,6 +334,12 @@ func buildValidatorsPageData(ctx context.Context, pageNumber uint64, pageSize ui
 	pageData.FirstValidator = pageNumber * pageSize
 	pageData.LastValidator = pageData.FirstValidator + uint64(len(pageData.Validators))
 
+	ensAddrs := make([][]byte, 0, len(pageData.Validators))
+	for _, validator := range pageData.Validators {
+		ensAddrs = append(ensAddrs, validator.WithdrawAddress)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	// Populate UrlParams for page jump functionality
 	pageData.UrlParams = make([]models.UrlParam, 0)
 	for key, values := range filterArgs {

--- a/handlers/validators_withdrawal_dashboard.go
+++ b/handlers/validators_withdrawal_dashboard.go
@@ -214,6 +214,13 @@ func buildValidatorsWithdrawalDashboardPageData(query string) (*models.Validator
 	}
 	pageData.HealthStatus = validatorsWithdrawalDashboardHealth(pageData.ParticipationRate)
 
+	ensAddrs := make([][]byte, 0, len(pageData.Validators)+1)
+	ensAddrs = append(ensAddrs, pageData.NormalizedAddress)
+	for _, validator := range pageData.Validators {
+		ensAddrs = append(ensAddrs, validator.WithdrawalAddress)
+	}
+	pageData.SetEnsNames(resolveEnsNames(context.Background(), ensAddrs))
+
 	return pageData, cacheTime
 }
 

--- a/handlers/withdrawals.go
+++ b/handlers/withdrawals.go
@@ -319,5 +319,14 @@ func buildWithdrawalsPageData(ctx context.Context, firstEpoch uint64, pageSize u
 		pageData.QueuedTabCount = uint64(len(pageData.QueuedWithdrawals))
 	}
 
+	ensAddrs := make([][]byte, 0, len(pageData.RecentWithdrawals)+len(pageData.BeaconWithdrawals))
+	for _, withdrawal := range pageData.RecentWithdrawals {
+		ensAddrs = append(ensAddrs, withdrawal.SourceAddr)
+	}
+	for _, withdrawal := range pageData.BeaconWithdrawals {
+		ensAddrs = append(ensAddrs, withdrawal.Address)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	return pageData, 1 * time.Minute
 }

--- a/handlers/withdrawals_list.go
+++ b/handlers/withdrawals_list.go
@@ -345,6 +345,12 @@ func buildFilteredWithdrawalsListPageData(ctx context.Context, pageIdx uint64, p
 	}
 	pageData.WithdrawalCount = uint64(len(pageData.Withdrawals))
 
+	ensAddrs := make([][]byte, 0, len(pageData.Withdrawals))
+	for _, withdrawal := range pageData.Withdrawals {
+		ensAddrs = append(ensAddrs, withdrawal.Address)
+	}
+	pageData.SetEnsNames(resolveEnsNames(ctx, ensAddrs))
+
 	if pageData.WithdrawalCount > 0 {
 		pageData.FirstIndex = pageData.Withdrawals[0].SlotNumber
 		pageData.LastIndex = pageData.Withdrawals[pageData.WithdrawalCount-1].SlotNumber

--- a/services/chainservice.go
+++ b/services/chainservice.go
@@ -48,6 +48,7 @@ type ChainService struct {
 	mevRelayIndexer       *mevrelay.MevIndexer
 	snooperManager        *snooper.SnooperManager
 	txIndexer             *txindexer.TxIndexer
+	ensResolver           *EnsResolver
 	started               bool
 }
 
@@ -68,6 +69,7 @@ func InitChainService(ctx context.Context, logger logrus.FieldLogger) {
 	buildoorInventory := NewBuildoorInventory(ctx)
 	mevRelayIndexer := mevrelay.NewMevIndexer(ctx, logger.WithField("service", "mev-relay"), beaconIndexer, chainState)
 	snooperManager := snooper.NewSnooperManager(ctx, logger.WithField("service", "snooper-manager"), beaconIndexer)
+	ensResolver := NewEnsResolver(ctx, logger.WithField("service", "ens-resolver"), executionPool)
 
 	// Set execution time provider
 	beaconIndexer.SetExecutionTimeProvider(snooper.NewExecutionTimeProvider(snooperManager.GetCache()))
@@ -82,6 +84,7 @@ func InitChainService(ctx context.Context, logger logrus.FieldLogger) {
 		buildoorInventory: buildoorInventory,
 		mevRelayIndexer:   mevRelayIndexer,
 		snooperManager:    snooperManager,
+		ensResolver:       ensResolver,
 	}
 }
 
@@ -388,7 +391,21 @@ func (cs *ChainService) StartService() error {
 	// start MEV relay indexer
 	cs.mevRelayIndexer.StartUpdater()
 
+	// start optional ENS resolver
+	if utils.Config.EnsResolver.Enabled {
+		cs.ensResolver.StartUpdater()
+	}
+
 	return nil
+}
+
+// GetEnsResolver returns the ENS resolver service (always non-nil; a no-op when the
+// feature is disabled).
+func (bs *ChainService) GetEnsResolver() *EnsResolver {
+	if bs == nil {
+		return nil
+	}
+	return bs.ensResolver
 }
 
 func (bs *ChainService) StopService() {

--- a/services/ensresolver.go
+++ b/services/ensresolver.go
@@ -1,0 +1,462 @@
+package services
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/jmoiron/sqlx"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/dora/clients/execution"
+	exerpc "github.com/ethpandaops/dora/clients/execution/rpc"
+	"github.com/ethpandaops/dora/clients/sshtunnel"
+	"github.com/ethpandaops/dora/db"
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/utils"
+)
+
+var logger_ens = logrus.StandardLogger().WithField("module", "ens_resolver")
+
+// EnsResolver resolves execution addresses to their primary ENS name. Resolution is
+// batched, asynchronous and persisted to the ens_names table. Handlers call
+// ResolveNames once per page to warm the in-memory cache and feed the resolve queue.
+type EnsResolver struct {
+	ctx      context.Context
+	logger   logrus.FieldLogger
+	execPool *execution.Pool
+
+	started atomic.Bool
+	cache   *lru.Cache[common.Address, *ensCacheEntry]
+
+	queue   chan common.Address
+	pending sync.Map // common.Address -> struct{}
+
+	// dedicated RPC clients built from EnsResolver.Endpoints (lazy init)
+	dedicatedInit    sync.Once
+	dedicatedClients []*ensEndpointClient
+
+	// probe results (worker-goroutine only, guarded by probeMutex until probed)
+	probeMutex       sync.Mutex
+	probed           bool
+	registries       []common.Address
+	multicallAddress common.Address
+	multicallReady   bool
+}
+
+// ensCacheEntry is a cached lookup result. An empty name is a negative result.
+type ensCacheEntry struct {
+	name         string
+	resolvedTime int64
+}
+
+// ensEndpointClient is a dedicated ENS RPC client with its configured name (for logs).
+type ensEndpointClient struct {
+	name   string
+	client *exerpc.ExecutionClient
+}
+
+func NewEnsResolver(ctx context.Context, logger logrus.FieldLogger, execPool *execution.Pool) *EnsResolver {
+	return &EnsResolver{
+		ctx:      ctx,
+		logger:   logger.WithField("service", "ens-resolver"),
+		execPool: execPool,
+	}
+}
+
+// EnsResolverStats is a snapshot of the ENS resolver's runtime state for the debug page.
+type EnsResolverStats struct {
+	Enabled              bool
+	Probed               bool
+	QueueLen             int
+	QueueCap             int
+	CacheLen             int
+	CacheCap             int
+	ConfiguredRegistries int
+	Registries           []string // usable (bytecode-probed) registries, in priority order
+	MulticallReady       bool
+	MulticallAddress     string
+	RefreshPositive      time.Duration
+	RefreshNegative      time.Duration
+}
+
+// GetDebugStats returns a snapshot of the resolver's queue, cache and probed registries
+// for the /debug/cache page. Safe to call when the resolver is disabled (nil-safe).
+func (e *EnsResolver) GetDebugStats() *EnsResolverStats {
+	stats := &EnsResolverStats{}
+	if e == nil {
+		return stats
+	}
+
+	cfg := &utils.Config.EnsResolver
+	stats.Enabled = e.started.Load()
+	stats.ConfiguredRegistries = len(cfg.RegistryAddresses)
+	stats.RefreshPositive = cfg.RefreshPositive
+	stats.RefreshNegative = cfg.RefreshNegative
+
+	if e.queue != nil {
+		stats.QueueLen = len(e.queue)
+		stats.QueueCap = cap(e.queue)
+	}
+	if e.cache != nil {
+		stats.CacheLen = e.cache.Len()
+		stats.CacheCap = cfg.CacheSize
+	}
+
+	e.probeMutex.Lock()
+	stats.Probed = e.probed
+	stats.MulticallReady = e.multicallReady
+	if e.multicallReady {
+		stats.MulticallAddress = e.multicallAddress.Hex()
+	}
+	for _, registry := range e.registries {
+		stats.Registries = append(stats.Registries, registry.Hex())
+	}
+	e.probeMutex.Unlock()
+
+	return stats
+}
+
+// StartUpdater applies defaults, initializes the cache/queue and starts the worker.
+func (e *EnsResolver) StartUpdater() {
+	if e.started.Load() {
+		return
+	}
+
+	cfg := &utils.Config.EnsResolver
+	if cfg.RefreshPositive == 0 {
+		cfg.RefreshPositive = 24 * time.Hour
+	}
+	if cfg.RefreshNegative == 0 {
+		cfg.RefreshNegative = 6 * time.Hour
+	}
+	if cfg.BatchSize == 0 {
+		cfg.BatchSize = 100
+	}
+	if cfg.QueueSize == 0 {
+		cfg.QueueSize = 50000
+	}
+	if cfg.CacheSize == 0 {
+		cfg.CacheSize = 50000
+	}
+	if len(cfg.RegistryAddresses) == 0 {
+		cfg.RegistryAddresses = []string{"0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"}
+	}
+	if cfg.MulticallAddress == "" {
+		cfg.MulticallAddress = "0xcA11bde05977b3631167028862bE2a173976CA11"
+	}
+
+	cache, err := lru.New[common.Address, *ensCacheEntry](cfg.CacheSize)
+	if err != nil {
+		e.logger.Errorf("failed to create ens name cache: %v", err)
+		return
+	}
+
+	e.cache = cache
+	e.queue = make(chan common.Address, cfg.QueueSize)
+	e.started.Store(true)
+
+	go e.runUpdaterLoop()
+}
+
+// ResolveNames returns the known primary names for the given addresses (keyed by
+// lowercase 0x-hex), warming the cache with one batched DB query for cache misses and
+// enqueuing unresolved or stale addresses for asynchronous resolution.
+//
+// It is called by page handlers in the (uncached) build path — never from templates.
+func (e *EnsResolver) ResolveNames(ctx context.Context, addrs [][]byte) map[string]string {
+	result := make(map[string]string)
+	if e == nil || !e.started.Load() || len(addrs) == 0 {
+		return result
+	}
+
+	now := time.Now().Unix()
+	seen := make(map[common.Address]struct{}, len(addrs))
+	misses := make([][]byte, 0)
+
+	for _, raw := range addrs {
+		if len(raw) != 20 {
+			continue
+		}
+		addr := common.BytesToAddress(raw)
+		if _, ok := seen[addr]; ok {
+			continue
+		}
+		seen[addr] = struct{}{}
+
+		if entry, ok := e.cache.Get(addr); ok {
+			if entry.name != "" {
+				result[strings.ToLower(addr.Hex())] = entry.name
+			}
+			if e.isStale(entry, now) {
+				e.enqueue(addr)
+			}
+			continue
+		}
+
+		misses = append(misses, addr.Bytes())
+	}
+
+	if len(misses) == 0 {
+		return result
+	}
+
+	dbEntries, err := db.GetEnsNamesByAddresses(ctx, misses)
+	if err != nil {
+		e.logger.Warnf("failed to load ens names from db: %v", err)
+		dbEntries = nil
+	}
+
+	for _, raw := range misses {
+		addr := common.BytesToAddress(raw)
+		dbEntry, ok := dbEntries[hex.EncodeToString(raw)]
+		if !ok {
+			// never resolved yet
+			e.enqueue(addr)
+			continue
+		}
+
+		entry := &ensCacheEntry{name: dbEntry.Name, resolvedTime: dbEntry.ResolvedTime}
+		e.cache.Add(addr, entry)
+		if entry.name != "" {
+			result[strings.ToLower(addr.Hex())] = entry.name
+		}
+		if e.isStale(entry, now) {
+			e.enqueue(addr)
+		}
+	}
+
+	return result
+}
+
+// isStale reports whether an entry is older than its refresh interval and should be
+// re-resolved (positive and negative results use separate intervals).
+func (e *EnsResolver) isStale(entry *ensCacheEntry, now int64) bool {
+	refresh := utils.Config.EnsResolver.RefreshPositive
+	if entry.name == "" {
+		refresh = utils.Config.EnsResolver.RefreshNegative
+	}
+	if refresh <= 0 {
+		return false
+	}
+	return now-entry.resolvedTime > int64(refresh/time.Second)
+}
+
+// enqueue adds an address to the capped resolve queue, de-duplicating pending entries
+// and dropping (best-effort) when the queue is full.
+func (e *EnsResolver) enqueue(addr common.Address) {
+	if _, loaded := e.pending.LoadOrStore(addr, struct{}{}); loaded {
+		return
+	}
+	select {
+	case e.queue <- addr:
+	default:
+		e.pending.Delete(addr)
+	}
+}
+
+func (e *EnsResolver) runUpdaterLoop() {
+	defer utils.HandleSubroutinePanic("EnsResolver.runUpdaterLoop", e.runUpdaterLoop)
+
+	for {
+		select {
+		case <-e.ctx.Done():
+			return
+		case first := <-e.queue:
+			e.pending.Delete(first)
+			batch := e.gatherBatch(first)
+			if err := e.processBatch(batch); err != nil {
+				e.logger.Errorf("ens resolve batch error: %v, retrying in 30 sec...", err)
+				// re-queue the batch and back off before trying again
+				for _, addr := range batch {
+					e.enqueue(addr)
+				}
+				time.Sleep(30 * time.Second)
+			}
+		}
+	}
+}
+
+// gatherBatch collects up to BatchSize queued addresses, starting with first.
+func (e *EnsResolver) gatherBatch(first common.Address) []common.Address {
+	batchSize := utils.Config.EnsResolver.BatchSize
+	batch := make([]common.Address, 0, batchSize)
+	batch = append(batch, first)
+
+	for len(batch) < batchSize {
+		select {
+		case addr := <-e.queue:
+			e.pending.Delete(addr)
+			batch = append(batch, addr)
+		default:
+			return batch
+		}
+	}
+	return batch
+}
+
+// processBatch resolves a batch of addresses and persists the results (positive and
+// negative) to the cache and DB.
+func (e *EnsResolver) processBatch(batch []common.Address) error {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(e.ctx, 60*time.Second)
+	defer cancel()
+
+	ethClient, err := e.getEthClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := e.ensureProbed(ctx, ethClient); err != nil {
+		return err
+	}
+
+	names := map[common.Address]string{}
+	if len(e.registries) > 0 {
+		names = e.resolveBatch(ctx, ethClient, batch)
+	}
+	// with no usable registry, all addresses are persisted as negative so they aren't
+	// re-queued until RefreshNegative elapses (avoids spinning on chains without ENS).
+
+	now := time.Now().Unix()
+	dbNames := make([]*dbtypes.EnsName, 0, len(batch))
+	for _, addr := range batch {
+		name := names[addr]
+		e.cache.Add(addr, &ensCacheEntry{name: name, resolvedTime: now})
+		dbNames = append(dbNames, &dbtypes.EnsName{Address: addr.Bytes(), Name: name, ResolvedTime: now})
+	}
+
+	err = db.RunDBTransaction(func(tx *sqlx.Tx) error {
+		return db.InsertEnsNames(e.ctx, tx, dbNames)
+	})
+	if err != nil {
+		e.logger.Warnf("failed to persist ens names: %v", err)
+	}
+
+	return nil
+}
+
+// ensureProbed checks (once) which configured registries and the Multicall3 contract
+// are actually deployed on the target chain. A client error is treated as transient
+// (returns error, leaves unprobed); missing bytecode marks the contract unusable.
+func (e *EnsResolver) ensureProbed(ctx context.Context, ethClient *ethclient.Client) error {
+	e.probeMutex.Lock()
+	defer e.probeMutex.Unlock()
+
+	if e.probed {
+		return nil
+	}
+
+	cfg := &utils.Config.EnsResolver
+	registries := make([]common.Address, 0, len(cfg.RegistryAddresses))
+	for _, raw := range cfg.RegistryAddresses {
+		if !common.IsHexAddress(raw) {
+			e.logger.Warnf("invalid ens registry address %q, skipping", raw)
+			continue
+		}
+		addr := common.HexToAddress(raw)
+		code, err := ethClient.CodeAt(ctx, addr, nil)
+		if err != nil {
+			return fmt.Errorf("probing ens registry %s: %w", raw, err)
+		}
+		if len(code) == 0 {
+			e.logger.Warnf("ens registry %s has no bytecode on this chain, skipping", raw)
+			continue
+		}
+		registries = append(registries, addr)
+	}
+
+	multicallReady := false
+	if common.IsHexAddress(cfg.MulticallAddress) {
+		mc := common.HexToAddress(cfg.MulticallAddress)
+		code, err := ethClient.CodeAt(ctx, mc, nil)
+		if err != nil {
+			return fmt.Errorf("probing multicall %s: %w", cfg.MulticallAddress, err)
+		}
+		if len(code) > 0 {
+			e.multicallAddress = mc
+			multicallReady = true
+		} else {
+			e.logger.Warnf("multicall %s not deployed, falling back to individual calls", cfg.MulticallAddress)
+		}
+	}
+
+	e.registries = registries
+	e.multicallReady = multicallReady
+	e.probed = true
+	e.logger.Infof("ens resolver ready: %d usable registries, multicall=%v", len(registries), multicallReady)
+	return nil
+}
+
+// getEthClient returns an eth client for ENS lookups, preferring dedicated endpoints
+// and falling back to a ready client from the main execution pool.
+func (e *EnsResolver) getEthClient(ctx context.Context) (*ethclient.Client, error) {
+	if len(utils.Config.EnsResolver.Endpoints) > 0 {
+		e.dedicatedInit.Do(e.initDedicatedClients)
+		for _, ec := range e.dedicatedClients {
+			if err := ec.client.Initialize(ctx); err != nil {
+				e.logger.Warnf("ens endpoint %s init failed: %v", ec.name, err)
+				continue
+			}
+			if ethClient := ec.client.GetEthClient(); ethClient != nil {
+				return ethClient, nil
+			}
+		}
+		return nil, fmt.Errorf("no usable dedicated ens endpoint")
+	}
+
+	client := e.execPool.GetReadyEndpoint(execution.AnyClient)
+	if client == nil {
+		return nil, fmt.Errorf("no ready execution client available for ens resolution")
+	}
+	ethClient := client.GetRPCClient().GetEthClient()
+	if ethClient == nil {
+		return nil, fmt.Errorf("execution client has no eth client")
+	}
+	return ethClient, nil
+}
+
+// initDedicatedClients builds RPC clients from the configured ENS endpoints.
+func (e *EnsResolver) initDedicatedClients() {
+	endpoints := utils.Config.EnsResolver.Endpoints
+	clients := make([]*ensEndpointClient, 0, len(endpoints))
+
+	for i := range endpoints {
+		endpoint := endpoints[i]
+		processed, err := applyAuthGroupToEndpoint(&endpoint)
+		if err != nil {
+			e.logger.Warnf("could not apply authGroup to ens endpoint %q: %v", endpoint.Name, err)
+			processed = &endpoint
+		}
+
+		var sshConfig *sshtunnel.SshConfig
+		if processed.Ssh != nil {
+			sshConfig = &sshtunnel.SshConfig{
+				Host:     processed.Ssh.Host,
+				Port:     processed.Ssh.Port,
+				User:     processed.Ssh.User,
+				Password: processed.Ssh.Password,
+				Keyfile:  processed.Ssh.Keyfile,
+			}
+		}
+
+		client, err := exerpc.NewExecutionClient(processed.Name, processed.Url, processed.Headers, sshConfig, e.logger.WithField("ens-endpoint", processed.Name))
+		if err != nil {
+			e.logger.Warnf("could not create ens endpoint %q: %v", processed.Name, err)
+			continue
+		}
+		clients = append(clients, &ensEndpointClient{name: processed.Name, client: client})
+	}
+
+	e.dedicatedClients = clients
+}

--- a/services/ensresolver.go
+++ b/services/ensresolver.go
@@ -23,8 +23,6 @@ import (
 	"github.com/ethpandaops/dora/utils"
 )
 
-var logger_ens = logrus.StandardLogger().WithField("module", "ens_resolver")
-
 // EnsResolver resolves execution addresses to their primary ENS name. Resolution is
 // batched, asynchronous and persisted to the ens_names table. Handlers call
 // ResolveNames once per page to warm the in-memory cache and feed the resolve queue.

--- a/services/ensresolver_ens.go
+++ b/services/ensresolver_ens.go
@@ -1,0 +1,325 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// ENS resolution mechanics: reverse resolution (address -> primary name) with a
+// forward-verification step, batched via Multicall3 when available.
+//
+// Reverse lookup for an address A:
+//  1. node   = namehash("<lowerhex(A)>.addr.reverse")
+//  2. resolver = ENSRegistry.resolver(node)
+//  3. name     = resolver.name(node)
+// Forward verification (anti-spoof): the claimed name must resolve back to A:
+//  4. fwdResolver = ENSRegistry.resolver(namehash(name))
+//  5. addr        = fwdResolver.addr(namehash(name)) ; keep name only if addr == A
+
+// Function selectors.
+var (
+	selectorResolver = common.Hex2Bytes("0178b8bf") // resolver(bytes32)
+	selectorEnsName  = common.Hex2Bytes("691f3431") // name(bytes32)
+	selectorEnsAddr  = common.Hex2Bytes("3b3b57de") // addr(bytes32)
+)
+
+// multicall3ABI is the minimal ABI needed to batch calls via Multicall3.aggregate3.
+var multicall3ABI = mustParseABI(`[{"type":"function","name":"aggregate3","stateMutability":"payable","inputs":[{"name":"calls","type":"tuple[]","components":[{"name":"target","type":"address"},{"name":"allowFailure","type":"bool"},{"name":"callData","type":"bytes"}]}],"outputs":[{"name":"returnData","type":"tuple[]","components":[{"name":"success","type":"bool"},{"name":"returnData","type":"bytes"}]}]}]`)
+
+type multicall3Call struct {
+	Target       common.Address
+	AllowFailure bool
+	CallData     []byte
+}
+
+// ensCall is a single low-level eth_call (target contract + calldata).
+type ensCall struct {
+	target common.Address
+	data   []byte
+}
+
+// ensCallResult is the outcome of an ensCall.
+type ensCallResult struct {
+	success bool
+	data    []byte
+}
+
+func mustParseABI(def string) abi.ABI {
+	parsed, err := abi.JSON(strings.NewReader(def))
+	if err != nil {
+		panic(fmt.Sprintf("invalid multicall abi: %v", err))
+	}
+	return parsed
+}
+
+// namehash implements the ENS namehash algorithm (EIP-137).
+func namehash(name string) [32]byte {
+	node := make([]byte, 32)
+	if name != "" {
+		labels := strings.Split(name, ".")
+		for i := len(labels) - 1; i >= 0; i-- {
+			labelHash := crypto.Keccak256([]byte(labels[i]))
+			node = crypto.Keccak256(node, labelHash)
+		}
+	}
+
+	var out [32]byte
+	copy(out[:], node)
+	return out
+}
+
+// reverseNode returns the namehash of "<lowerhexaddr>.addr.reverse".
+func reverseNode(addr common.Address) [32]byte {
+	return namehash(strings.ToLower(addr.Hex()[2:]) + ".addr.reverse")
+}
+
+// resolveBatch resolves primary ENS names for the given addresses, trying the usable
+// registries in configured order and keeping the first verified name per address.
+func (e *EnsResolver) resolveBatch(ctx context.Context, ethClient *ethclient.Client, addrs []common.Address) map[common.Address]string {
+	result := make(map[common.Address]string, len(addrs))
+	pending := addrs
+
+	for _, registry := range e.registries {
+		if len(pending) == 0 {
+			break
+		}
+
+		resolved := e.resolveWithRegistry(ctx, ethClient, registry, pending)
+
+		remaining := make([]common.Address, 0, len(pending))
+		for _, addr := range pending {
+			if name, ok := resolved[addr]; ok && name != "" {
+				result[addr] = name
+			} else {
+				remaining = append(remaining, addr)
+			}
+		}
+		pending = remaining
+	}
+
+	return result
+}
+
+// resolveWithRegistry runs the full reverse+verify flow against a single registry.
+func (e *EnsResolver) resolveWithRegistry(ctx context.Context, ethClient *ethclient.Client, registry common.Address, addrs []common.Address) map[common.Address]string {
+	out := make(map[common.Address]string)
+
+	// stage 1: registry.resolver(reverseNode) -> reverse resolver address
+	revNodes := make([][32]byte, len(addrs))
+	calls := make([]ensCall, len(addrs))
+	for i, addr := range addrs {
+		revNodes[i] = reverseNode(addr)
+		calls[i] = ensCall{target: registry, data: appendNode(selectorResolver, revNodes[i])}
+	}
+
+	res, err := e.callBatch(ctx, ethClient, calls)
+	if err != nil {
+		e.logger.Warnf("ens stage1 (resolver) failed: %v", err)
+		return out
+	}
+
+	type ensWork struct {
+		addr        common.Address
+		revNode     [32]byte
+		revResolver common.Address
+		name        string
+		fwdNode     [32]byte
+		fwdResolver common.Address
+	}
+
+	works := make([]*ensWork, 0, len(addrs))
+	for i, addr := range addrs {
+		if !res[i].success {
+			continue
+		}
+		revResolver := decodeAddress(res[i].data)
+		if revResolver == (common.Address{}) {
+			continue
+		}
+		works = append(works, &ensWork{addr: addr, revNode: revNodes[i], revResolver: revResolver})
+	}
+	if len(works) == 0 {
+		return out
+	}
+
+	// stage 2: reverseResolver.name(reverseNode) -> candidate name
+	calls = make([]ensCall, len(works))
+	for i, w := range works {
+		calls[i] = ensCall{target: w.revResolver, data: appendNode(selectorEnsName, w.revNode)}
+	}
+
+	res, err = e.callBatch(ctx, ethClient, calls)
+	if err != nil {
+		e.logger.Warnf("ens stage2 (name) failed: %v", err)
+		return out
+	}
+
+	named := make([]*ensWork, 0, len(works))
+	for i, w := range works {
+		if !res[i].success {
+			continue
+		}
+		name := decodeENSString(res[i].data)
+		if name == "" {
+			continue
+		}
+		w.name = name
+		w.fwdNode = namehash(strings.ToLower(name))
+		named = append(named, w)
+	}
+	if len(named) == 0 {
+		return out
+	}
+
+	// stage 3: registry.resolver(fwdNode) -> forward resolver address
+	calls = make([]ensCall, len(named))
+	for i, w := range named {
+		calls[i] = ensCall{target: registry, data: appendNode(selectorResolver, w.fwdNode)}
+	}
+
+	res, err = e.callBatch(ctx, ethClient, calls)
+	if err != nil {
+		e.logger.Warnf("ens stage3 (fwd resolver) failed: %v", err)
+		return out
+	}
+
+	verify := make([]*ensWork, 0, len(named))
+	for i, w := range named {
+		if !res[i].success {
+			continue
+		}
+		fwdResolver := decodeAddress(res[i].data)
+		if fwdResolver == (common.Address{}) {
+			continue
+		}
+		w.fwdResolver = fwdResolver
+		verify = append(verify, w)
+	}
+	if len(verify) == 0 {
+		return out
+	}
+
+	// stage 4: forwardResolver.addr(fwdNode) -> must equal the original address
+	calls = make([]ensCall, len(verify))
+	for i, w := range verify {
+		calls[i] = ensCall{target: w.fwdResolver, data: appendNode(selectorEnsAddr, w.fwdNode)}
+	}
+
+	res, err = e.callBatch(ctx, ethClient, calls)
+	if err != nil {
+		e.logger.Warnf("ens stage4 (addr) failed: %v", err)
+		return out
+	}
+
+	for i, w := range verify {
+		if !res[i].success {
+			continue
+		}
+		if decodeAddress(res[i].data) == w.addr {
+			out[w.addr] = w.name
+		}
+	}
+
+	return out
+}
+
+// callBatch executes a set of eth_calls, using Multicall3 when available and falling
+// back to individual calls otherwise.
+func (e *EnsResolver) callBatch(ctx context.Context, ethClient *ethclient.Client, calls []ensCall) ([]ensCallResult, error) {
+	if len(calls) == 0 {
+		return nil, nil
+	}
+
+	if e.multicallReady {
+		return e.callBatchMulticall(ctx, ethClient, calls)
+	}
+
+	results := make([]ensCallResult, len(calls))
+	for i := range calls {
+		target := calls[i].target
+		data, err := ethClient.CallContract(ctx, ethereum.CallMsg{To: &target, Data: calls[i].data}, nil)
+		if err != nil {
+			continue
+		}
+		results[i] = ensCallResult{success: len(data) > 0, data: data}
+	}
+	return results, nil
+}
+
+// callBatchMulticall batches all calls into a single Multicall3.aggregate3 eth_call.
+func (e *EnsResolver) callBatchMulticall(ctx context.Context, ethClient *ethclient.Client, calls []ensCall) ([]ensCallResult, error) {
+	mcCalls := make([]multicall3Call, len(calls))
+	for i, c := range calls {
+		mcCalls[i] = multicall3Call{Target: c.target, AllowFailure: true, CallData: c.data}
+	}
+
+	input, err := multicall3ABI.Pack("aggregate3", mcCalls)
+	if err != nil {
+		return nil, fmt.Errorf("pack aggregate3: %w", err)
+	}
+
+	target := e.multicallAddress
+	output, err := ethClient.CallContract(ctx, ethereum.CallMsg{To: &target, Data: input}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("multicall eth_call: %w", err)
+	}
+
+	var decoded struct {
+		ReturnData []struct {
+			Success    bool
+			ReturnData []byte
+		}
+	}
+	if err := multicall3ABI.UnpackIntoInterface(&decoded, "aggregate3", output); err != nil {
+		return nil, fmt.Errorf("unpack aggregate3: %w", err)
+	}
+	if len(decoded.ReturnData) != len(calls) {
+		return nil, fmt.Errorf("multicall returned %d results for %d calls", len(decoded.ReturnData), len(calls))
+	}
+
+	results := make([]ensCallResult, len(calls))
+	for i, r := range decoded.ReturnData {
+		results[i] = ensCallResult{success: r.Success && len(r.ReturnData) > 0, data: r.ReturnData}
+	}
+	return results, nil
+}
+
+// appendNode returns selector ++ node (the standard 32-byte-arg calldata).
+func appendNode(selector []byte, node [32]byte) []byte {
+	data := make([]byte, 0, len(selector)+32)
+	data = append(data, selector...)
+	data = append(data, node[:]...)
+	return data
+}
+
+// decodeAddress reads a 20-byte address from a 32-byte-aligned return word.
+func decodeAddress(data []byte) common.Address {
+	if len(data) < 32 {
+		return common.Address{}
+	}
+	return common.BytesToAddress(data[12:32])
+}
+
+// decodeENSString decodes a single ABI-encoded string return value.
+func decodeENSString(data []byte) string {
+	if len(data) < 64 {
+		return ""
+	}
+	offset := new(big.Int).SetBytes(data[:32]).Uint64()
+	if offset+32 > uint64(len(data)) {
+		return ""
+	}
+	length := new(big.Int).SetBytes(data[offset : offset+32]).Uint64()
+	if length == 0 || offset+32+length > uint64(len(data)) {
+		return ""
+	}
+	return strings.TrimRight(string(data[offset+32:offset+32+length]), "\x00")
+}

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -368,6 +368,18 @@ span.validator-label {
   font-size: 0.65rem;
 }
 
+/* ENS name swapped in for an address (static/js/explorer.js applyEnsNames): cap the
+   displayed width so long names can't break table layouts; the full name + address
+   are shown in the tooltip on hover. */
+.ens-name {
+  display: inline-block;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
 /* Highlight equal address links across rows on hover (set by explorer.js). */
 .el-data-table .addr-cell a,
 .itx-wrap .itx-addr a {

--- a/static/js/explorer.js
+++ b/static/js/explorer.js
@@ -78,6 +78,24 @@
     return address ? (ensNamesMap[String(address).toLowerCase()] || null) : null;
   }
 
+  // setEnsTooltip sets a node's tooltip to "<name><br><address>" using Bootstrap's
+  // data-bs-title (NOT the native `title`, which would show a second browser tooltip that
+  // renders the <br> literally). Any already-initialized tooltip is disposed so it is
+  // recreated with the ENS content instead of keeping the stale address-only text.
+  function setEnsTooltip(node, name, addr) {
+    var existing = bootstrap.Tooltip.getInstance(node);
+    if (existing) existing.dispose();
+    var oldIdx = node.getAttribute('data-tooltip-idx');
+    if (oldIdx && tooltipDict[oldIdx]) delete tooltipDict[oldIdx];
+    $(node).removeData('tooltip-init');
+    node.removeAttribute('data-tooltip-idx');
+    node.removeAttribute('title');
+    node.removeAttribute('data-bs-original-title');
+    node.setAttribute('data-bs-toggle', 'tooltip');
+    node.setAttribute('data-bs-html', 'true');
+    node.setAttribute('data-bs-title', escapeHtml(name) + '<br>' + String(addr).toLowerCase());
+  }
+
   // applyEnsToNode swaps a single element's text for the ENS name of `address` (if any),
   // adding the ellipsis class and a full-name+address tooltip. Copy/href stay untouched.
   // Returns true when a name was applied. Used for client-rendered callouts.
@@ -87,9 +105,7 @@
     if (!name) return false;
     node.textContent = name;
     node.classList.add('ens-name');
-    node.setAttribute('data-bs-toggle', 'tooltip');
-    node.setAttribute('data-bs-html', 'true');
-    node.setAttribute('title', escapeHtml(name) + '<br>' + String(address).toLowerCase());
+    setEnsTooltip(node, name, address);
     return true;
   }
 
@@ -108,8 +124,7 @@
       if (!name) return;
       node.textContent = name;
       node.classList.add('ens-name');
-      node.setAttribute('data-bs-html', 'true');
-      node.setAttribute('title', escapeHtml(name) + '<br>' + addr);
+      setEnsTooltip(node, name, addr);
       node.setAttribute('data-ens-applied', '1');
     });
   }

--- a/static/js/explorer.js
+++ b/static/js/explorer.js
@@ -37,6 +37,8 @@
     checkRefreshCooldown: checkRefreshCooldown,
     serverNow: serverNow,
     updateServerTime: updateServerTime,
+    ensNameFor: ensNameFor,
+    applyEnsToNode: applyEnsToNode,
   };
 
   function modalFixes() {
@@ -53,7 +55,68 @@
     });
   }
 
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function(c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+
+  // ensNamesMap holds the merged address->name lookup from every `.ens-names` JSON block
+  // in the DOM (the layout carries one; lazy-loaded fragments carry their own).
+  var ensNamesMap = {};
+  function refreshEnsNamesMap() {
+    document.querySelectorAll('script.ens-names').forEach(function(blob) {
+      try {
+        var parsed = JSON.parse(blob.textContent || '{}');
+        if (parsed && typeof parsed === 'object') {
+          for (var key in parsed) ensNamesMap[key.toLowerCase()] = parsed[key];
+        }
+      } catch (e) { /* ignore malformed block */ }
+    });
+  }
+  function ensNameFor(address) {
+    return address ? (ensNamesMap[String(address).toLowerCase()] || null) : null;
+  }
+
+  // applyEnsToNode swaps a single element's text for the ENS name of `address` (if any),
+  // adding the ellipsis class and a full-name+address tooltip. Copy/href stay untouched.
+  // Returns true when a name was applied. Used for client-rendered callouts.
+  function applyEnsToNode(node, address) {
+    if (!node) return false;
+    var name = ensNameFor(address);
+    if (!name) return false;
+    node.textContent = name;
+    node.classList.add('ens-name');
+    node.setAttribute('data-bs-toggle', 'tooltip');
+    node.setAttribute('data-bs-html', 'true');
+    node.setAttribute('title', escapeHtml(name) + '<br>' + String(address).toLowerCase());
+    return true;
+  }
+
+  // applyEnsNames swaps the displayed text of address elements for their resolved ENS
+  // name. It merges every `.ens-names` block (so it works after lazy content is injected)
+  // and is idempotent (skips already-swapped nodes) and re-runnable — it is called from
+  // initControls, which runs again after lazy content loads. href/clipboard stay raw.
+  function applyEnsNames() {
+    refreshEnsNamesMap();
+    if (Object.keys(ensNamesMap).length === 0) return;
+
+    document.querySelectorAll('.ens-addr[data-address]').forEach(function(node) {
+      if (node.getAttribute('data-ens-applied')) return;
+      var addr = (node.getAttribute('data-address') || '').toLowerCase();
+      var name = ensNamesMap[addr];
+      if (!name) return;
+      node.textContent = name;
+      node.classList.add('ens-name');
+      node.setAttribute('data-bs-html', 'true');
+      node.setAttribute('title', escapeHtml(name) + '<br>' + addr);
+      node.setAttribute('data-ens-applied', '1');
+    });
+  }
+
   function initControls() {
+    // swap addresses for ENS names before tooltips are initialized
+    applyEnsNames();
     // init tooltips:
     // NOTE: `data-bs-toogle="tooltip"`` tooltips will also get cleaned up if their relevant element is removed from the DOM
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(initTooltip);

--- a/templates/_layout/layout.html
+++ b/templates/_layout/layout.html
@@ -59,6 +59,7 @@
       </div>
       <script src="/js/typeahead.min.js"></script>
       <script src="/js/clipboard.min.js"></script>
+      <script type="application/json" class="ens-names">{{ ensNamesJson .Data }}</script>
       <script src="/js/explorer.js?{{ $buildTime }}"></script>
       {{ template "js" .Data }}
     </body>

--- a/templates/_shared/txDetailsModal.html
+++ b/templates/_shared/txDetailsModal.html
@@ -81,9 +81,14 @@
     // container is reused across opens, so stale ENS state is reset first.
     function setTxDetailAddr(el, addr) {
       if (!el) return;
+      // reset any ENS state left from a previous open (the container is reused)
+      var existing = bootstrap.Tooltip.getInstance(el);
+      if (existing) existing.dispose();
       el.classList.remove('ens-name');
       el.removeAttribute('data-bs-html');
       el.removeAttribute('data-bs-toggle');
+      el.removeAttribute('data-bs-title');
+      el.removeAttribute('data-bs-original-title');
       el.removeAttribute('title');
       el.textContent = addr || '';
       if (addr && window.explorer.applyEnsToNode) {

--- a/templates/_shared/txDetailsModal.html
+++ b/templates/_shared/txDetailsModal.html
@@ -76,6 +76,21 @@
   $(document).ready(function() {
     var lastPopover = null;
 
+    // setTxDetailAddr renders an address in the callout, swapping it for its ENS name
+    // when one is known (the copy button still copies the raw address). The shared
+    // container is reused across opens, so stale ENS state is reset first.
+    function setTxDetailAddr(el, addr) {
+      if (!el) return;
+      el.classList.remove('ens-name');
+      el.removeAttribute('data-bs-html');
+      el.removeAttribute('data-bs-toggle');
+      el.removeAttribute('title');
+      el.textContent = addr || '';
+      if (addr && window.explorer.applyEnsToNode) {
+        window.explorer.applyEnsToNode(el, addr);
+      }
+    }
+
     $(window).on('click', function(evt) {
       if($(evt.target).is('.tx-details-btn') > 0 || $(evt.target).closest('.tx-details-btn').length > 0) {
         var target = $(evt.target);
@@ -94,9 +109,9 @@
         var blockTimeAbsolute = new Date(txdetails.block_time * 1000).toISOString();
         container.find(".txdetails-time").text(blockTimeRelative);
         container.find(".txdetails-time-copy").attr("data-clipboard-text", blockTimeAbsolute);
-        container.find(".txdetails-txorigin").text(txdetails.tx_origin);
+        setTxDetailAddr(container.find(".txdetails-txorigin").get(0), txdetails.tx_origin);
         container.find(".txdetails-txorigin-copy").attr("data-clipboard-text", txdetails.tx_origin);
-        container.find(".txdetails-txtarget").text(txdetails.tx_target);
+        setTxDetailAddr(container.find(".txdetails-txtarget").get(0), txdetails.tx_target);
         container.find(".txdetails-txtarget-copy").attr("data-clipboard-text", txdetails.tx_target);
 
         var txDetailsContent = container.html();

--- a/templates/address/address.html
+++ b/templates/address/address.html
@@ -1,7 +1,7 @@
 {{ define "page" }}
   <div class="container mt-2">
     <div class="d-md-flex py-2 justify-content-md-between">
-      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-wallet mx-2"></i> Address {{ formatEthAddressFull .Address }}</h1>
+      <h1 class="h4 mb-1 mb-md-0"><i class="fas fa-wallet mx-2"></i> Address {{ formatEthAddressFull .Address }}{{ if .AddressEnsName }} <span class="badge rounded-pill text-bg-primary align-middle ens-name" data-bs-toggle="tooltip" title="{{ .AddressEnsName }}"><i class="fa fa-tag me-1"></i>{{ .AddressEnsName }}</span>{{ end }}</h1>
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb font-size-1 mb-0" style="padding:0; background-color:transparent;">
           <li class="breadcrumb-item"><a href="/" title="Home">Home</a></li>
@@ -21,6 +21,15 @@
                 <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ formatEthAddressFull .Address }}"></i>
               </div>
             </div>
+            {{ if .AddressEnsName }}
+            <div class="row border-bottom p-2 mx-0">
+              <div class="col-md-3"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Primary ENS name">ENS Name:</span></div>
+              <div class="col-md-9 text-monospace">
+                {{ .AddressEnsName }}
+                <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .AddressEnsName }}"></i>
+              </div>
+            </div>
+            {{ end }}
             {{ if .IsContract }}
             <div class="row border-bottom p-2 mx-0">
               <div class="col-md-3"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Type of address">Type:</span></div>
@@ -195,6 +204,7 @@
   </div>
 {{ end }}
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "transactions" }}
     {{ template "transactions" . }}
   {{ else if eq .TabView "contract" }}

--- a/templates/builder/builder.html
+++ b/templates/builder/builder.html
@@ -263,6 +263,7 @@
   </div>
 {{ end }}
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "blocks" }}
     {{ template "recentBlocks" . }}
   {{ else if eq .TabView "bids" }}

--- a/templates/consolidations/consolidations.html
+++ b/templates/consolidations/consolidations.html
@@ -87,6 +87,7 @@
 {{ end }}
 
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "recent" }}
     {{ template "recentConsolidations" . }}
   {{ else if eq .TabView "queue" }}

--- a/templates/debug_cache/debug_cache.html
+++ b/templates/debug_cache/debug_cache.html
@@ -41,6 +41,11 @@
       </a>
     </li>
     <li class="nav-item">
+      <a class="nav-link" id="ens-tab" data-bs-toggle="tab" data-bs-target="#ens" href="#ens" role="tab">
+        <i class="fa fa-tag me-1"></i> ENS Resolver
+      </a>
+    </li>
+    <li class="nav-item">
       <a class="nav-link" id="database-tab" data-bs-toggle="tab" data-bs-target="#database" href="#database" role="tab">
         <i class="fa fa-server me-1"></i> Database
       </a>
@@ -71,6 +76,11 @@
     <!-- Execution Tab -->
     <div class="tab-pane fade" id="execution" role="tabpanel">
       {{ template "debugExecutionTab" . }}
+    </div>
+
+    <!-- ENS Resolver Tab -->
+    <div class="tab-pane fade" id="ens" role="tabpanel">
+      {{ template "debugEnsTab" . }}
     </div>
 
     <!-- Database Tab -->
@@ -156,6 +166,56 @@
         </div>
       </div>
     </div>
+  </div>
+</div>
+{{ end }}
+{{ end }}
+
+<!-- ENS Resolver Tab -->
+{{ define "debugEnsTab" }}
+{{ with .EnsResolver }}
+<div class="card mt-0" style="border-top:none; border-top-left-radius:0; border-top-right-radius:0;">
+  <div class="card-body">
+    {{ if not .Enabled }}
+    <div class="alert alert-secondary mb-0">
+      <i class="fa fa-info-circle me-1"></i> The ENS resolver is disabled. Enable it via the <code>ensResolver</code> config block.
+    </div>
+    {{ else }}
+    <div class="row">
+      <div class="col-md-6 mb-4">
+        <h5 class="card-title mb-3"><i class="fa fa-tasks me-1"></i> Queue &amp; Cache</h5>
+        <table class="table table-sm table-borderless">
+          <tbody>
+            <tr><td class="text-muted" style="width:220px;">Resolve Queue (pending / cap)</td><td>{{ formatNumber .QueueLen }} / {{ formatNumber .QueueCap }}</td></tr>
+            <tr><td class="text-muted">Name Cache (LRU / cap)</td><td>{{ formatNumber .CacheLen }} / {{ formatNumber .CacheCap }}</td></tr>
+            <tr><td class="text-muted">Refresh — found</td><td>{{ .RefreshPositive }}</td></tr>
+            <tr><td class="text-muted">Refresh — not found</td><td>{{ .RefreshNegative }}</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="col-md-6 mb-4">
+        <h5 class="card-title mb-3"><i class="fa fa-network-wired me-1"></i> Registries &amp; Multicall</h5>
+        <table class="table table-sm table-borderless">
+          <tbody>
+            <tr><td class="text-muted" style="width:220px;">Probed</td><td>{{ if .Probed }}<span class="badge bg-success">yes</span>{{ else }}<span class="badge bg-secondary">pending</span>{{ end }}</td></tr>
+            <tr><td class="text-muted">Registries (usable / configured)</td><td>{{ len .Registries }} / {{ .ConfiguredRegistries }}</td></tr>
+            <tr><td class="text-muted">Multicall3</td><td>{{ if .MulticallReady }}<span class="badge bg-success">enabled</span> <code>{{ .MulticallAddress }}</code>{{ else }}<span class="badge bg-secondary">individual calls</span>{{ end }}</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <h6 class="mt-2 mb-2">Working Registries</h6>
+    {{ if .Registries }}
+    <ul class="list-unstyled mb-0">
+      {{ range $i, $r := .Registries }}
+      <li class="mb-1"><span class="badge bg-primary me-1">{{ add $i 1 }}</span><code>{{ $r }}</code></li>
+      {{ end }}
+    </ul>
+    {{ else }}
+    <div class="text-muted">{{ if .Probed }}No usable registries found on the target chain.{{ else }}Not probed yet — the first resolve batch probes the configured registries.{{ end }}</div>
+    {{ end }}
+    {{ end }}
   </div>
 </div>
 {{ end }}

--- a/templates/deposits/deposits.html
+++ b/templates/deposits/deposits.html
@@ -94,6 +94,7 @@
 {{ end }}
 
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "included" }}
     {{ template "includedDeposits" . }}
   {{ else if eq .TabView "transactions" }}

--- a/templates/exits/exits.html
+++ b/templates/exits/exits.html
@@ -101,6 +101,7 @@
 {{ end }}
 
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "recent" }}
     {{ template "recentExits" . }}
   {{ else if eq .TabView "exitrequests" }}

--- a/templates/transaction/transaction.html
+++ b/templates/transaction/transaction.html
@@ -398,6 +398,7 @@
   </div>
 {{ end }}
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "events" }}
     {{ template "events" . }}
   {{ else if eq .TabView "statechanges" }}

--- a/templates/validator/validator.html
+++ b/templates/validator/validator.html
@@ -286,6 +286,7 @@
   </div>
 {{ end }}
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "blocks" }}
     {{ template "recentBlocks" . }}
   {{ else if eq .TabView "attestations" }}

--- a/templates/withdrawals/withdrawals.html
+++ b/templates/withdrawals/withdrawals.html
@@ -101,6 +101,7 @@
 {{ end }}
 
 {{ define "lazyPage" }}
+  <script type="application/json" class="ens-names">{{ ensNamesJson . }}</script>
   {{ if eq .TabView "recent" }}
     {{ template "recentWithdrawals" . }}
   {{ else if eq .TabView "queue" }}

--- a/types/config.go
+++ b/types/config.go
@@ -213,6 +213,21 @@ type Config struct {
 		LogRequests       bool          `yaml:"logRequests" envconfig:"RPC_PROXY_LOG_REQUESTS"`
 		AllowedMethods    []string      `yaml:"allowedMethods" envconfig:"RPC_PROXY_ALLOWED_METHODS"`
 	} `yaml:"rpcProxy"`
+
+	// EnsResolver optionally resolves execution addresses to their primary ENS name.
+	// ENS lives on Ethereum mainnet, so Endpoints usually point at a mainnet RPC; when
+	// empty the resolver falls back to an available client from the main execution pool.
+	EnsResolver struct {
+		Enabled           bool             `yaml:"enabled" envconfig:"ENSRESOLVER_ENABLED"`
+		Endpoints         []EndpointConfig `yaml:"endpoints"`
+		RegistryAddresses []string         `yaml:"registryAddresses" envconfig:"ENSRESOLVER_REGISTRY_ADDRESSES"` // tried in config order; first verified name wins
+		MulticallAddress  string           `yaml:"multicallAddress" envconfig:"ENSRESOLVER_MULTICALL_ADDRESS"`   // used to batch lookups when deployed
+		RefreshPositive   time.Duration    `yaml:"refreshPositive" envconfig:"ENSRESOLVER_REFRESH_POSITIVE"`     // re-resolve interval for addresses with a name
+		RefreshNegative   time.Duration    `yaml:"refreshNegative" envconfig:"ENSRESOLVER_REFRESH_NEGATIVE"`     // re-resolve interval for addresses without a name
+		BatchSize         int              `yaml:"batchSize" envconfig:"ENSRESOLVER_BATCH_SIZE"`
+		QueueSize         int              `yaml:"queueSize" envconfig:"ENSRESOLVER_QUEUE_SIZE"`
+		CacheSize         int              `yaml:"cacheSize" envconfig:"ENSRESOLVER_CACHE_SIZE"`
+	} `yaml:"ensResolver"`
 }
 
 type EndpointConfig struct {

--- a/types/models/address.go
+++ b/types/models/address.go
@@ -7,6 +7,7 @@ import (
 // AddressPageData is a struct to hold info for the address page
 type AddressPageData struct {
 	Address            []byte `json:"address"`
+	AddressEnsName     string `json:"address_ens_name"` // resolved primary ENS name for this address (empty if none)
 	AccountID          uint64 `json:"account_id"`
 	IsContract         bool   `json:"is_contract"`
 	DataRange          *ElDataRangeInfo
@@ -72,6 +73,8 @@ type AddressPageData struct {
 	BlockFees  []*AddressPageDataBlockFee `json:"block_fees"`
 	BfPageSize uint64                     `json:"bf_page_size"`
 	BfPager    *PagerData                 `json:"bf_pager"`
+
+	EnsNameData
 }
 
 // AddressPageDataTokenBalance represents a token balance in the sidebar

--- a/types/models/blocks_filtered.go
+++ b/types/models/blocks_filtered.go
@@ -65,6 +65,8 @@ type BlocksFilteredPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type BlocksFilteredPageDataBlock struct {

--- a/types/models/builder_deposits.go
+++ b/types/models/builder_deposits.go
@@ -52,6 +52,8 @@ type BuilderDepositsPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type BuilderDepositsPageDataDeposit struct {

--- a/types/models/builder_exits.go
+++ b/types/models/builder_exits.go
@@ -32,6 +32,8 @@ type BuilderExitsPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type BuilderExitsPageDataExit struct {

--- a/types/models/builders.go
+++ b/types/models/builders.go
@@ -28,6 +28,8 @@ type BuildersPageData struct {
 	FilteredPageLink string                     `json:"filtered_page_link"`
 
 	UrlParams map[string]string `json:"url_params"`
+
+	EnsNameData
 }
 
 type BuildersPageDataStatusOption struct {
@@ -96,6 +98,8 @@ type BuilderPageData struct {
 	WithdrawalCount           uint64                       `json:"withdrawal_count"`
 	AdditionalWithdrawalCount uint64                       `json:"additional_withdrawal_count"`
 	HasMoreBlocks             bool                         `json:"has_more_blocks"`
+
+	EnsNameData
 }
 
 // BuilderPageDataBlock represents a block/payload built by this builder

--- a/types/models/common.go
+++ b/types/models/common.go
@@ -36,10 +36,10 @@ func (d *EnsNameData) SetEnsNames(names map[string]string) {
 // (not pre-marshaled) so html/template JSON-encodes it exactly once in the script
 // context — pre-marshaling to a string would get double-encoded there.
 func (d *EnsNameData) EnsNamesForJS() map[string]string {
-	names := make(map[string]string, len(d.EnsNames))
 	if d == nil {
-		return names
+		return map[string]string{}
 	}
+	names := make(map[string]string, len(d.EnsNames))
 	for _, mapping := range d.EnsNames {
 		names[strings.ToLower(mapping.Address)] = mapping.Name
 	}

--- a/types/models/common.go
+++ b/types/models/common.go
@@ -1,5 +1,7 @@
 package models
 
+import "strings"
+
 type UrlParam struct {
 	Key   string
 	Value string
@@ -8,4 +10,50 @@ type UrlParam struct {
 type KeyValue struct {
 	Key   string `json:"k"`
 	Value string `json:"v"`
+}
+
+// EnsNameMapping maps a lowercase 0x-hex execution address to its primary ENS name.
+// A slice of these is embedded in page models (SSZ-cacheable, unlike a map) and
+// rendered client-side to swap displayed addresses for their name.
+type EnsNameMapping struct {
+	Address string `json:"a"`
+	Name    string `json:"n"`
+}
+
+// EnsNameData is embedded in page models that display execution addresses. It carries
+// the resolved primary ENS names and exposes them to the layout without reflection.
+type EnsNameData struct {
+	EnsNames []EnsNameMapping `json:"ens_names,omitempty"`
+}
+
+// SetEnsNames stores resolved names (address -> name) in cacheable slice form.
+func (d *EnsNameData) SetEnsNames(names map[string]string) {
+	d.EnsNames = EnsNamesFromMap(names)
+}
+
+// EnsNamesForJS returns the carried names as an address->name map for embedding in a
+// page's ens-names <script type="application/json"> block. It is returned as a Go value
+// (not pre-marshaled) so html/template JSON-encodes it exactly once in the script
+// context — pre-marshaling to a string would get double-encoded there.
+func (d *EnsNameData) EnsNamesForJS() map[string]string {
+	names := make(map[string]string, len(d.EnsNames))
+	if d == nil {
+		return names
+	}
+	for _, mapping := range d.EnsNames {
+		names[strings.ToLower(mapping.Address)] = mapping.Name
+	}
+	return names
+}
+
+// EnsNamesFromMap converts a resolver result map into the cacheable slice form.
+func EnsNamesFromMap(names map[string]string) []EnsNameMapping {
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]EnsNameMapping, 0, len(names))
+	for addr, name := range names {
+		out = append(out, EnsNameMapping{Address: strings.ToLower(addr), Name: name})
+	}
+	return out
 }

--- a/types/models/consolidations.go
+++ b/types/models/consolidations.go
@@ -17,6 +17,8 @@ type ConsolidationsPageData struct {
 	QueuedConsolidations        []*ConsolidationsPageDataQueuedConsolidation `json:"queued_consolidations"`
 	QueuedTabCount              uint64                                       `json:"queued_tab_count"`
 	TabView                     string                                       `json:"tab_view"`
+
+	EnsNameData
 }
 
 type ConsolidationsPageDataRecentConsolidation struct {

--- a/types/models/deposits.go
+++ b/types/models/deposits.go
@@ -22,6 +22,8 @@ type DepositsPageData struct {
 	QueuedDepositCount     uint64                              `json:"queued_deposit_count"`
 	IsElectraActive        bool                                `json:"is_electra_active"`
 	TabView                string                              `json:"tab_view"`
+
+	EnsNameData
 }
 
 type DepositsPageDataInitiatedDeposit struct {

--- a/types/models/el_consolidations.go
+++ b/types/models/el_consolidations.go
@@ -37,6 +37,8 @@ type ElConsolidationsPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type ElConsolidationsPageDataConsolidation struct {

--- a/types/models/el_withdrawals.go
+++ b/types/models/el_withdrawals.go
@@ -36,6 +36,8 @@ type ElWithdrawalsPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type ElWithdrawalsPageDataWithdrawal struct {

--- a/types/models/exits.go
+++ b/types/models/exits.go
@@ -23,6 +23,8 @@ type ExitsPageData struct {
 
 	RecentExitRequests     []*ExitsPageDataRecentExitRequest `json:"recent_exit_requests"`
 	RecentExitRequestCount uint64                            `json:"recent_exit_request_count"`
+
+	EnsNameData
 }
 
 type ExitsPageDataRecentExit struct {

--- a/types/models/included_deposits.go
+++ b/types/models/included_deposits.go
@@ -36,6 +36,8 @@ type IncludedDepositsPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type IncludedDepositsPageDataDeposit struct {

--- a/types/models/initiated_deposits.go
+++ b/types/models/initiated_deposits.go
@@ -33,6 +33,8 @@ type InitiatedDepositsPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type InitiatedDepositsPageDataDeposit struct {

--- a/types/models/mev_blocks.go
+++ b/types/models/mev_blocks.go
@@ -34,6 +34,8 @@ type MevBlocksPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams map[string]string `json:"url_params"`
+
+	EnsNameData
 }
 
 type MevBlocksPageDataBlock struct {

--- a/types/models/queued_deposits.go
+++ b/types/models/queued_deposits.go
@@ -33,6 +33,8 @@ type QueuedDepositsPageData struct {
 	LastPageLink     string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type QueuedDepositsPageDataDeposit struct {

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -25,6 +25,8 @@ type SlotPageData struct {
 	TracoorUrl             string                  `json:"tracoor_url"`
 	SystemContracts        []*types.SystemContract `json:"system_contracts"`
 	TransactionDetails     []*SlotPageTransaction  `json:"transaction_details"`
+
+	EnsNameData
 }
 
 // SlotPageSlotBlock represents a block entry for the slot (for multi-block display)

--- a/types/models/token.go
+++ b/types/models/token.go
@@ -24,4 +24,6 @@ type TokenPageData struct {
 	DisplayMethod bool   `json:"display_method"`
 	DisplayAmount bool   `json:"display_amount"`
 	DisplayStatus bool   `json:"display_status"`
+
+	EnsNameData
 }

--- a/types/models/tokens.go
+++ b/types/models/tokens.go
@@ -12,6 +12,8 @@ type TokensPageData struct {
 	LastItem   uint64 `json:"last_item"`
 
 	Pager *PagerData `json:"pager"`
+
+	EnsNameData
 }
 
 // TokensPageDataToken is a single row of the tokens list.

--- a/types/models/transaction.go
+++ b/types/models/transaction.go
@@ -166,6 +166,8 @@ type TransactionPageData struct {
 	// State changes tab (prestateTracer diffMode)
 	StateChanges             []*TransactionPageDataStateChangeAccount `json:"state_changes"`
 	StateChangesNotAvailable bool                                     `json:"state_changes_not_available"`
+
+	EnsNameData
 }
 
 // TransactionAccessListEntry is one address+storage-keys pair from an EIP-2930 access list.

--- a/types/models/transactions.go
+++ b/types/models/transactions.go
@@ -30,6 +30,8 @@ type TransactionsPageData struct {
 	DisplayGasUsed bool   `json:"display_gas_used"`
 	DisplayType    bool   `json:"display_type"`
 	DisplayNonce   bool   `json:"display_nonce"`
+
+	EnsNameData
 }
 
 // TransactionsFilter holds the current filter values as strings so the filter

--- a/types/models/transfers.go
+++ b/types/models/transfers.go
@@ -45,6 +45,8 @@ type TransfersPageData struct {
 	DisplayToken     bool   `json:"display_token"`
 	DisplayStatus    bool   `json:"display_status"`
 	DisplayTokenType bool   `json:"display_token_type"`
+
+	EnsNameData
 }
 
 // TransfersFilter holds the current transfer filter values as strings so the

--- a/types/models/validator.go
+++ b/types/models/validator.go
@@ -77,6 +77,8 @@ type ValidatorPageData struct {
 	Withdrawals                         []*ValidatorPageDataBeaconWithdrawal `json:"withdrawals"`
 	WithdrawalCount                     uint64                               `json:"withdrawal_count"`
 	AdditionalWithdrawalCount           uint64                               `json:"additional_withdrawal_count"`
+
+	EnsNameData
 }
 
 type ValidatorPageDataBlock struct {

--- a/types/models/validators.go
+++ b/types/models/validators.go
@@ -31,6 +31,8 @@ type ValidatorsPageData struct {
 	FilteredPageLink string                         `json:"filtered_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 type ValidatorsPageDataStatusOption struct {

--- a/types/models/validators_withdrawal_dashboard.go
+++ b/types/models/validators_withdrawal_dashboard.go
@@ -34,6 +34,8 @@ type ValidatorsWithdrawalDashboardPageData struct {
 	ActivityLink   string `json:"activity_link"`
 
 	Validators []*ValidatorsWithdrawalDashboardValidator `json:"validators"`
+
+	EnsNameData
 }
 
 type ValidatorsWithdrawalDashboardValidator struct {

--- a/types/models/withdrawals.go
+++ b/types/models/withdrawals.go
@@ -23,6 +23,8 @@ type WithdrawalsPageData struct {
 
 	BeaconWithdrawals     []*WithdrawalsPageDataBeaconWithdrawal `json:"beacon_withdrawals"`
 	BeaconWithdrawalCount uint64                                 `json:"beacon_withdrawal_count"`
+
+	EnsNameData
 }
 
 type WithdrawalsPageDataRecentWithdrawal struct {

--- a/types/models/withdrawals_list.go
+++ b/types/models/withdrawals_list.go
@@ -35,6 +35,8 @@ type WithdrawalsListPageData struct {
 	LastPageLink  string `json:"last_page_link"`
 
 	UrlParams []UrlParam `json:"url_params"`
+
+	EnsNameData
 }
 
 // WithdrawalsListPageDataWithdrawal represents a single withdrawal entry.

--- a/utils/format.go
+++ b/utils/format.go
@@ -510,6 +510,13 @@ func FormatEthBlockHashLink(blockHash []byte) template.HTML {
 	return template.HTML(caption)
 }
 
+// ensAddrHook returns the class + data-address attributes used by the client-side ENS
+// name swap (static/js/explorer.js). The address is emitted lowercased so JS lookups
+// against the page's ENS map are case-insensitive; href/clipboard stay raw hex.
+func ensAddrHook(fullAddr string) string {
+	return fmt.Sprintf(`class="ens-addr" data-address="%s"`, strings.ToLower(fullAddr))
+}
+
 func FormatEthAddressLink(address []byte) template.HTML {
 	if len(address) == 0 {
 		return template.HTML("")
@@ -521,20 +528,20 @@ func FormatEthAddressLink(address []byte) template.HTML {
 
 	// Use local link when execution indexer is enabled
 	if Config.ExecutionIndexer.Enabled {
-		return template.HTML(fmt.Sprintf(`<a href="/address/%s" data-bs-toggle="tooltip" title="%s">%s</a>`,
-			fullAddr, fullAddr, shortAddr))
+		return template.HTML(fmt.Sprintf(`<a %s href="/address/%s" data-bs-toggle="tooltip" title="%s">%s</a>`,
+			ensAddrHook(fullAddr), fullAddr, fullAddr, shortAddr))
 	}
 
 	// Fall back to external explorer link
 	if Config.Frontend.EthExplorerLink != "" {
 		link, err := url.JoinPath(Config.Frontend.EthExplorerLink, "address", fullAddr)
 		if err == nil {
-			return template.HTML(fmt.Sprintf(`<a href="%v" data-bs-toggle="tooltip" title="%s">%v</a>`,
-				link, fullAddr, shortAddr))
+			return template.HTML(fmt.Sprintf(`<a %s href="%v" data-bs-toggle="tooltip" title="%s">%v</a>`,
+				ensAddrHook(fullAddr), link, fullAddr, shortAddr))
 		}
 	}
 
-	return template.HTML(fmt.Sprintf(`<span data-bs-toggle="tooltip" title="%s">%s</span>`, fullAddr, shortAddr))
+	return template.HTML(fmt.Sprintf(`<span %s data-bs-toggle="tooltip" title="%s">%s</span>`, ensAddrHook(fullAddr), fullAddr, shortAddr))
 }
 
 func FormatEthTransactionLink(hash []byte, width uint64) template.HTML {
@@ -625,20 +632,20 @@ func FormatEthAddressShortLink(address []byte, isContract bool, byteCount ...int
 
 	// Use local link when execution indexer is enabled
 	if Config.ExecutionIndexer.Enabled {
-		result += fmt.Sprintf(`<a href="/address/%s" data-bs-toggle="tooltip" title="%s">%s</a>`,
-			fullAddr, fullAddr, shortAddr)
+		result += fmt.Sprintf(`<a %s href="/address/%s" data-bs-toggle="tooltip" title="%s">%s</a>`,
+			ensAddrHook(fullAddr), fullAddr, fullAddr, shortAddr)
 	} else if Config.Frontend.EthExplorerLink != "" {
 		// Fall back to external explorer link
 		link, err := url.JoinPath(Config.Frontend.EthExplorerLink, "address", fullAddr)
 		if err == nil {
-			result += fmt.Sprintf(`<a href="%v" data-bs-toggle="tooltip" title="%s">%v</a>`,
-				link, fullAddr, shortAddr)
+			result += fmt.Sprintf(`<a %s href="%v" data-bs-toggle="tooltip" title="%s">%v</a>`,
+				ensAddrHook(fullAddr), link, fullAddr, shortAddr)
 		} else {
-			result += fmt.Sprintf(`<span data-bs-toggle="tooltip" title="%s">%s</span>`, fullAddr, shortAddr)
+			result += fmt.Sprintf(`<span %s data-bs-toggle="tooltip" title="%s">%s</span>`, ensAddrHook(fullAddr), fullAddr, shortAddr)
 		}
 	} else {
 		// No link available
-		result += fmt.Sprintf(`<span data-bs-toggle="tooltip" title="%s">%s</span>`, fullAddr, shortAddr)
+		result += fmt.Sprintf(`<span %s data-bs-toggle="tooltip" title="%s">%s</span>`, ensAddrHook(fullAddr), fullAddr, shortAddr)
 	}
 
 	return template.HTML(result)
@@ -790,14 +797,14 @@ func FormatEthAddressFullLink(address []byte) template.HTML {
 
 	// Use local link when execution indexer is enabled
 	if Config.ExecutionIndexer.Enabled {
-		return template.HTML(fmt.Sprintf(`<a href="/address/%s">%s</a>`, fullAddr, fullAddr))
+		return template.HTML(fmt.Sprintf(`<a %s href="/address/%s">%s</a>`, ensAddrHook(fullAddr), fullAddr, fullAddr))
 	}
 
 	// Fall back to external explorer link
 	if Config.Frontend.EthExplorerLink != "" {
 		link, err := url.JoinPath(Config.Frontend.EthExplorerLink, "address", fullAddr)
 		if err == nil {
-			return template.HTML(fmt.Sprintf(`<a href="%v">%v</a>`, link, fullAddr))
+			return template.HTML(fmt.Sprintf(`<a %s href="%v">%v</a>`, ensAddrHook(fullAddr), link, fullAddr))
 		}
 	}
 
@@ -835,22 +842,22 @@ func FormatContractCreationLink(fromAddr []byte, nonce uint64) template.HTML {
 
 	// Use local link when execution indexer is enabled
 	if Config.ExecutionIndexer.Enabled {
-		return template.HTML(fmt.Sprintf(`%s<a href="/address/%s" data-bs-toggle="tooltip" title="%s">%s</a>`,
-			icon, fullAddr, fullAddr, shortAddr))
+		return template.HTML(fmt.Sprintf(`%s<a %s href="/address/%s" data-bs-toggle="tooltip" title="%s">%s</a>`,
+			icon, ensAddrHook(fullAddr), fullAddr, fullAddr, shortAddr))
 	}
 
 	// Fall back to external explorer link
 	if Config.Frontend.EthExplorerLink != "" {
 		link, err := url.JoinPath(Config.Frontend.EthExplorerLink, "address", fullAddr)
 		if err == nil {
-			return template.HTML(fmt.Sprintf(`%s<a href="%v" data-bs-toggle="tooltip" title="%s">%v</a>`,
-				icon, link, fullAddr, shortAddr))
+			return template.HTML(fmt.Sprintf(`%s<a %s href="%v" data-bs-toggle="tooltip" title="%s">%v</a>`,
+				icon, ensAddrHook(fullAddr), link, fullAddr, shortAddr))
 		}
 	}
 
 	// No link available
-	return template.HTML(fmt.Sprintf(`%s<span data-bs-toggle="tooltip" title="%s">%s</span>`,
-		icon, fullAddr, shortAddr))
+	return template.HTML(fmt.Sprintf(`%s<span %s data-bs-toggle="tooltip" title="%s">%s</span>`,
+		icon, ensAddrHook(fullAddr), fullAddr, shortAddr))
 }
 
 func FormatValidator(index uint64, name string) template.HTML {

--- a/utils/templateFucs.go
+++ b/utils/templateFucs.go
@@ -87,25 +87,26 @@ func GetTemplateFuncs() template.FuncMap {
 	}
 
 	customFuncs := template.FuncMap{
-		"includeHTML": IncludeHTML,
-		"includeJSON": IncludeJSON,
-		"html":        func(x string) template.HTML { return template.HTML(x) },
-		"float64":     toFloat64,
-		"bigIntCmp":   func(i *big.Int, j int) int { return i.Cmp(big.NewInt(int64(j))) },
-		"mod":         func(i, j int) bool { return i%j == 0 },
-		"sub":         func(i, j int) int { return i - j },
-		"subUI64":     func(i, j uint64) uint64 { return i - j },
-		"add":         func(i, j int) int { return i + j },
-		"addI64":      func(i, j int64) int64 { return i + j },
-		"addUI64":     func(i, j uint64) uint64 { return i + j },
-		"addFloat64":  func(i, j float64) float64 { return i + j },
-		"mul":         func(i, j float64) float64 { return i * j },
-		"div":         func(i, j float64) float64 { return i / j },
-		"divInt":      func(i, j int) float64 { return float64(i) / float64(j) },
-		"nef":         func(i, j float64) bool { return i != j },
-		"gtf":         func(i, j float64) bool { return i > j },
-		"ltf":         func(i, j float64) bool { return i < j },
-		"inlist":      checkInList,
+		"includeHTML":  IncludeHTML,
+		"includeJSON":  IncludeJSON,
+		"ensNamesJson": EnsNamesJSON,
+		"html":         func(x string) template.HTML { return template.HTML(x) },
+		"float64":      toFloat64,
+		"bigIntCmp":    func(i *big.Int, j int) int { return i.Cmp(big.NewInt(int64(j))) },
+		"mod":          func(i, j int) bool { return i%j == 0 },
+		"sub":          func(i, j int) int { return i - j },
+		"subUI64":      func(i, j uint64) uint64 { return i - j },
+		"add":          func(i, j int) int { return i + j },
+		"addI64":       func(i, j int64) int64 { return i + j },
+		"addUI64":      func(i, j uint64) uint64 { return i + j },
+		"addFloat64":   func(i, j float64) float64 { return i + j },
+		"mul":          func(i, j float64) float64 { return i * j },
+		"div":          func(i, j float64) float64 { return i / j },
+		"divInt":       func(i, j int) float64 { return float64(i) / float64(j) },
+		"nef":          func(i, j float64) bool { return i != j },
+		"gtf":          func(i, j float64) bool { return i > j },
+		"ltf":          func(i, j float64) bool { return i < j },
+		"inlist":       checkInList,
 		"round": func(i float64, n int) float64 {
 			return math.Round(i*math.Pow10(n)) / math.Pow10(n)
 		},
@@ -229,6 +230,22 @@ func IncludeJSON(obj any, escapeHTML bool) template.HTML {
 		s = html.EscapeString(s)
 	}
 	return template.HTML(s)
+}
+
+// ensNamesProvider is implemented by page models that embed models.EnsNameData.
+type ensNamesProvider interface {
+	EnsNamesForJS() map[string]string
+}
+
+// EnsNamesJSON returns a page model's embedded ENS names as an address->name map for the
+// client-side address swap. It returns the Go map (not a pre-marshaled string) so
+// html/template JSON-encodes it exactly once inside the <script> block — returning a
+// marshaled string there would be double-encoded. Empty map for models without names.
+func EnsNamesJSON(data any) map[string]string {
+	if provider, ok := data.(ensNamesProvider); ok {
+		return provider.EnsNamesForJS()
+	}
+	return map[string]string{}
 }
 
 func GraffitiToString(graffiti []byte) string {


### PR DESCRIPTION
# ENS name resolution for execution addresses

Adds an **optional** background service that resolves execution addresses to their
primary ENS name and displays the name in place of (or alongside) the raw hex across the
explorer. Disabled by default; enabled via a new `ensResolver` config block.

## Motivation

Dora renders execution addresses as raw `0x…` hex everywhere. When an operator points the
resolver at a chain that has ENS deployed (mainnet, or a devnet with its own registry),
addresses are shown as human-readable names — with the full address still available on
hover and via copy.

## How it works

Resolution is **batched, asynchronous, and persisted**, and it is driven entirely by the
**handlers** (never lazily from templates):

1. Each page handler collects the execution addresses it will show and calls
   `EnsResolver.ResolveNames(ctx, addrs)` **once** per page build. This reads an in-memory
   LRU, issues a **single** batched DB query for cache misses, and enqueues any
   unresolved/stale addresses onto a capped queue.
2. A background worker drains the queue in batches and resolves names via **reverse
   resolution with forward-verification** (anti-spoofing), batched through **Multicall3**
   when it is deployed (individual `eth_call`s otherwise). Results — positive **and**
   negative — are written to the `ens_names` table and the LRU.
3. The resolved names for a page are stored on the page model and emitted once as a JSON
   block; **client-side JS** swaps the displayed address text for the name, keeping the
   link target, copy value and address-highlight intact, and capping the width so long
   names can't break layouts.

Names are **re-queued after a configurable threshold** (separate intervals for found vs.
not-found results), compared against the stored resolve time.

### Registries & chain support

- Multiple `registryAddresses` may be configured; each is **bytecode-probed** on the
  target chain at startup and skipped if not deployed. Usable registries are tried in
  **config order**, and the first verified name wins.
- Multicall3 is likewise bytecode-probed; if absent, the resolver falls back to
  individual calls.
- Resolver RPC endpoints are optional — with none configured it falls back to an
  available client from Dora's existing execution pool.

## Configuration

```yaml
ensResolver:
  enabled: false            # enable ENS name resolution & display
  endpoints: []             # optional dedicated EL RPCs; empty -> use the main EL pool
  registryAddresses:        # tried in order, first verified name wins; probed for bytecode
    - "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"   # ENS registry (mainnet)
  multicallAddress: "0xcA11bde05977b3631167028862bE2a173976CA11"  # Multicall3 (probed)
  refreshPositive: 24h      # re-resolve interval for addresses that have a name
  refreshNegative: 6h       # re-resolve interval for addresses without a name
  batchSize: 100            # addresses resolved per worker batch
  queueSize: 50000          # capped in-memory queue of pending addresses
  cacheSize: 50000          # in-memory LRU name cache size
```

All fields support env overrides (`ENSRESOLVER_*`). Defaults are applied when the service
starts. The devnet harness (`.hack/devnet/run.sh`) enables the resolver against the
devnet's own EL pool with a devnet registry.

## Database

New `ens_names` table (paired sqlite + pgsql goose migrations), keyed by the **raw
20-byte address**, storing positive **and** negative results plus the resolve time:

| column          | type        | notes                                  |
|-----------------|-------------|----------------------------------------|
| `address`       | BLOB/BYTEA  | primary key (raw 20 bytes)             |
| `name`          | TEXT        | empty string = persisted negative      |
| `resolved_time` | INT/BIGINT  | unix seconds; drives refresh staleness |

Batch accessors in `db/ens_names.go` (`GetEnsNamesByAddresses`, `InsertEnsNames`) follow
the existing sqlx / `EngineQuery` patterns.

## Display details

- **Shared address funcs** (`utils/format.go`): the link/label renderers get a
  `class="ens-addr" data-address="<lowercase addr>"` hook. `href`, `data-clipboard-text`
  and the tooltip address stay raw hex, so links, copy and address-highlight are unchanged.
- **Client swap** (`static/js/explorer.js`): `applyEnsNames()` merges every `.ens-names`
  JSON block in the DOM, swaps matching `.ens-addr` nodes to the (ellipsis-capped) name,
  and sets a `name + address` tooltip. It runs in `initControls`, so it re-applies after
  lazy content loads, and is idempotent.
- **Lazy tabs**: every `lazyPage` fragment emits its own `.ens-names` block, and the JS
  merges all blocks — so lazily-loaded tab content resolves correctly too.
- **Tx-detail callouts**: the client-rendered origin/target addresses are resolved
  server-side and swapped via an exposed `applyEnsToNode` helper.
- **Address page header**: the page's own address is rendered in full (not a swappable
  link), so its name is surfaced explicitly — shown as a pill in the header and as a
  dedicated **ENS Name** row in the details card when resolved.
- **`/debug/cache`**: a new **ENS Resolver** tab shows queue size, LRU cache usage,
  refresh intervals, probe state, and the working (bytecode-verified) registries.

### SSZ / cache note

The frontend cache serializes page models via dynssz. ENS names are stored on each model
as a slice (`[]EnsNameMapping` embedded via `EnsNameData`), **not a map**, so SSZ-cacheable
models stay SSZ-cacheable. The names are emitted by returning the Go map value (not a
pre-marshaled string) into the `<script type="application/json">` block, so html/template
JSON-encodes it exactly once (avoids the double-encoding pitfall).

## Files

- **New**: `services/ensresolver.go`, `services/ensresolver_ens.go`, `db/ens_names.go`,
  `db/schema/{sqlite,pgsql}/20260704000000_ens-names.sql`.
- **Config/wiring**: `types/config.go`, `config/default.config.yml`,
  `services/chainservice.go`, `.hack/devnet/run.sh`.
- **Model plumbing**: `types/models/common.go` (`EnsNameData`), `dbtypes/dbtypes.go`, plus
  an embedded field on ~25 page models and their handlers.
- **Display**: `utils/format.go`, `utils/templateFucs.go`, `templates/_layout/layout.html`,
  `templates/_shared/txDetailsModal.html`, the `lazyPage` fragments,
  `static/js/explorer.js`, `static/css/layout.css`.
- **Debug**: `handlers/debug_cache.go`, `templates/debug_cache/debug_cache.html`.

## Testing

- `go build ./...`, `go vet ./...`, and `gofmt` are clean.
- Verified (temporary check) that embedding `EnsNameData` does **not** demote
  SSZ-compatible page models to JSON caching.
- Verified via a standalone html/template repro that the JSON block is single-encoded.
- Not yet exercised end-to-end against a live RPC (enable → observe a known name resolve,
  refresh, and DB rows) — recommended before merge.
