### PR TITLE
change builder withdrawal prefix from 0x03 to 0xB0

### DIFF
--- a/db/deposits.go
+++ b/db/deposits.go
@@ -169,7 +169,7 @@ func GetDepositsFiltered(ctx context.Context, offset uint64, limit uint32, canon
 		}
 
 		if len(txFilter.WithdrawalAddress) > 0 {
-			// 0x01 = ETH1, 0x02 = compounding, 0x03 = builder deposit
+			// 0x01 = ETH1, 0x02 = compounding, 0xB0 = builder deposit
 			wdcreds1 := make([]byte, 32)
 			wdcreds1[0] = 0x01
 			copy(wdcreds1[12:], txFilter.WithdrawalAddress)
@@ -177,7 +177,7 @@ func GetDepositsFiltered(ctx context.Context, offset uint64, limit uint32, canon
 			wdcreds2[0] = 0x02
 			copy(wdcreds2[12:], txFilter.WithdrawalAddress)
 			wdcreds3 := make([]byte, 32)
-			wdcreds3[0] = 0x03
+			wdcreds3[0] = 0xB0
 			copy(wdcreds3[12:], txFilter.WithdrawalAddress)
 			args = append(args, wdcreds1, wdcreds2, wdcreds3)
 			fmt.Fprintf(&sql, " %v (deposits.withdrawalcredentials = $%v OR deposits.withdrawalcredentials = $%v OR deposits.withdrawalcredentials = $%v)", filterOp, len(args)-2, len(args)-1, len(args))

--- a/handlers/api/deposits_included_v1.go
+++ b/handlers/api/deposits_included_v1.go
@@ -176,7 +176,7 @@ func APIDepositsIncludedV1(w http.ResponseWriter, r *http.Request) {
 		seen := map[uint8]bool{}
 		for _, v := range credVals {
 			t, err := strconv.ParseUint(v, 10, 8)
-			if err != nil || t > 3 || seen[uint8(t)] {
+			if err != nil || (t > 2 && t != 0xB0) || seen[uint8(t)] {
 				continue
 			}
 			seen[uint8(t)] = true

--- a/handlers/deposits.go
+++ b/handlers/deposits.go
@@ -160,8 +160,8 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 		// load initiated deposits
 		dbDepositTxs := db.GetDepositTxs(ctx, 0, 20)
 		for _, depositTx := range dbDepositTxs {
-			// Check if this is a builder deposit (0x03 withdrawal credentials)
-			isBuilder := len(depositTx.WithdrawalCredentials) > 0 && depositTx.WithdrawalCredentials[0] == 0x03
+			// Check if this is a builder deposit (0xB0 withdrawal credentials)
+			isBuilder := len(depositTx.WithdrawalCredentials) > 0 && depositTx.WithdrawalCredentials[0] == 0xB0
 
 			depositTxData := &models.DepositsPageDataInitiatedDeposit{
 				Index:                 depositTx.Index,
@@ -251,9 +251,9 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 
 		dbDeposits, _ := services.GlobalBeaconService.GetDepositRequestsByFilter(ctx, depositFilter, 0, uint32(20))
 		for _, deposit := range dbDeposits {
-			// Check if this is a builder deposit (0x03 withdrawal credentials)
+			// Check if this is a builder deposit (0xB0 withdrawal credentials)
 			wdCreds := deposit.WithdrawalCredentials()
-			isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
+			isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0xB0
 
 			depositData := &models.DepositsPageDataIncludedDeposit{
 				PublicKey:             deposit.PublicKey(),
@@ -376,9 +376,9 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 			}
 
 			for _, queueEntry := range queuedDeposits.Queue[:limit] {
-				// Check if this is a builder deposit (0x03 withdrawal credentials)
+				// Check if this is a builder deposit (0xB0 withdrawal credentials)
 				wdCreds := queueEntry.PendingDeposit.WithdrawalCredentials[:]
-				isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
+				isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0xB0
 
 				// EpochEstimate is the churn-based epoch for normal deposits and the
 				// validator's withdrawable epoch for postponed ones; 0 means unknown.

--- a/handlers/included_deposits.go
+++ b/handlers/included_deposits.go
@@ -87,7 +87,7 @@ func IncludedDeposits(w http.ResponseWriter, r *http.Request) {
 			seen := map[uint8]bool{}
 			for _, v := range vals {
 				t, err := strconv.ParseUint(v, 10, 8)
-				if err != nil || t > 3 || seen[uint8(t)] {
+				if err != nil || (t > 2 && t != 0xB0) || seen[uint8(t)] {
 					continue
 				}
 				seen[uint8(t)] = true
@@ -222,7 +222,7 @@ func buildFilteredIncludedDepositsPageData(ctx context.Context, pageIdx uint64, 
 
 	for _, deposit := range dbDeposits {
 		wdCreds := deposit.WithdrawalCredentials()
-		isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
+		isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0xB0
 
 		depositData := &models.IncludedDepositsPageDataDeposit{
 			PublicKey:             deposit.PublicKey(),

--- a/handlers/initiated_deposits.go
+++ b/handlers/initiated_deposits.go
@@ -182,7 +182,7 @@ func buildFilteredInitiatedDepositsPageData(ctx context.Context, pageIdx uint64,
 	}
 
 	for _, depositTx := range dbDepositTxs {
-		isBuilder := len(depositTx.WithdrawalCredentials) > 0 && depositTx.WithdrawalCredentials[0] == 0x03
+		isBuilder := len(depositTx.WithdrawalCredentials) > 0 && depositTx.WithdrawalCredentials[0] == 0xB0
 
 		depositTxData := &models.InitiatedDepositsPageDataDeposit{
 			Index:                 depositTx.Index,

--- a/handlers/queued_deposits.go
+++ b/handlers/queued_deposits.go
@@ -213,7 +213,7 @@ func buildQueuedDepositsPageData(ctx context.Context, pageIdx uint64, pageSize u
 		queueEntry := filteredQueue[i]
 
 		wdCreds := queueEntry.PendingDeposit.WithdrawalCredentials[:]
-		isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0x03
+		isBuilder := len(wdCreds) > 0 && wdCreds[0] == 0xB0
 
 		// EpochEstimate is the churn-based epoch for normal deposits and the validator's
 		// withdrawable epoch for postponed ones; 0 means unknown.

--- a/handlers/validators.go
+++ b/handlers/validators.go
@@ -74,7 +74,7 @@ func Validators(w http.ResponseWriter, r *http.Request) {
 			seen := map[uint8]bool{}
 			for _, v := range vals {
 				t, err := strconv.ParseUint(v, 10, 8)
-				if err != nil || t > 3 || seen[uint8(t)] {
+				if err != nil || (t > 2 && t != 0xB0) || seen[uint8(t)] {
 					continue
 				}
 				seen[uint8(t)] = true

--- a/indexer/beacon/pendingvalidators.go
+++ b/indexer/beacon/pendingvalidators.go
@@ -131,9 +131,9 @@ func IsProjectedValidator(v *phase0.Validator) bool {
 }
 
 // isBuilderWithdrawalCredential reports whether the credentials use the Gloas
-// builder prefix (0x03).
+// builder prefix (0xB0).
 func isBuilderWithdrawalCredential(wc []byte) bool {
-	return len(wc) > 0 && wc[0] == 0x03
+	return len(wc) > 0 && wc[0] == 0xB0
 }
 
 // depositProcessingEstimator estimates the epoch at which each pending deposit is
@@ -164,7 +164,7 @@ func newDepositProcessingEstimator(currentEpoch phase0.Epoch, depositBalanceToCo
 }
 
 // next returns the estimated processing epoch for a deposit of the given amount and
-// advances the estimator. onboarded is true when the deposit is a builder (0x03) that
+// advances the estimator. onboarded is true when the deposit is a builder (0xB0) that
 // reaches the Gloas fork unprocessed: at the fork such deposits are onboarded as
 // builders (onboard_builders_from_pending_deposits), removed from the queue, and never
 // become validators — so they consume no further deposit churn, which lets the normal

--- a/indexer/beacon/pendingvalidators_test.go
+++ b/indexer/beacon/pendingvalidators_test.go
@@ -119,7 +119,7 @@ func TestProjectOrderingAndGating(t *testing.T) {
 }
 
 // TestProjectGloasBuilderFilter verifies that, when a Gloas fork is scheduled, new
-// 0x03 (builder) deposits whose estimated processing epoch is at or after the fork
+// 0xB0 (builder) deposits whose estimated processing epoch is at or after the fork
 // are dropped (they are onboarded as builders at the fork), while those processed
 // before the fork — and all non-builder deposits — still project.
 func TestProjectGloasBuilderFilter(t *testing.T) {
@@ -127,7 +127,7 @@ func TestProjectGloasBuilderFilter(t *testing.T) {
 	const amount = phase0.Gwei(32_000_000_000)
 
 	builderWc := make([]byte, 32)
-	builderWc[0] = 0x03
+	builderWc[0] = 0xB0
 	execWc := make([]byte, 32)
 	execWc[0] = 0x01
 

--- a/indexer/beacon/statetransition/fork.go
+++ b/indexer/beacon/statetransition/fork.go
@@ -12,11 +12,11 @@ import (
 	"github.com/ethpandaops/dora/indexer/beacon/depositsig"
 )
 
-// builderWithdrawalPrefix is BUILDER_WITHDRAWAL_PREFIX (Gloas/EIP-8282): the 0x03
+// builderWithdrawalPrefix is BUILDER_WITHDRAWAL_PREFIX (Gloas/EIP-8282): the 0xB0
 // withdrawal-credential prefix that marks a deposit as a builder deposit.
-const builderWithdrawalPrefix byte = 0x03
+const builderWithdrawalPrefix byte = 0xB0
 
-// isBuilderWithdrawalCredential reports whether the credentials use the builder prefix (0x03).
+// isBuilderWithdrawalCredential reports whether the credentials use the builder prefix (0xB0).
 func isBuilderWithdrawalCredential(wc []byte) bool {
 	return len(wc) > 0 && wc[0] == builderWithdrawalPrefix
 }

--- a/indexer/beacon/statetransition/operations.go
+++ b/indexer/beacon/statetransition/operations.go
@@ -92,7 +92,7 @@ func applyExecutionRequests(s *stateAccessor, requests *all.ExecutionRequests) {
 // The request is appended to the pending_deposits queue. Gloas (EIP-8282)
 // removed the builder branch entirely: builder deposits now arrive via the
 // dedicated builder deposit contract (processBuilderDepositRequest), so a
-// 0x03-credential deposit via the regular deposit contract is queued as an
+// 0xB0-credential deposit via the regular deposit contract is queued as an
 // ordinary validator deposit like any other.
 //
 // https://github.com/ethereum/consensus-specs/pull/5359

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -696,7 +696,7 @@ func (dbw *dbWriter) persistBlockDeposits(tx *sqlx.Tx, block *Block, depositInde
 // reconcileOnboardedBuilderDeposits keeps the upgrade_to_gloas onboarded builder deposit copies in
 // sync with their source validator deposits. The copies are written once at the fork boundary with
 // the then-unfinalized fork id and are not re-persisted per block, so when a source deposit (a
-// pre-gloas builder 0x03 deposit) is persisted canonically its matching copy is moved onto the same
+// pre-gloas builder 0xB0 deposit) is persisted canonically its matching copy is moved onto the same
 // fork id; otherwise the copy keeps its unfinalized fork id and later shows up as orphaned. It only
 // runs once the fork has activated (i.e. the copy exists).
 func (dbw *dbWriter) reconcileOnboardedBuilderDeposits(tx *sqlx.Tx, deposits []*dbtypes.Deposit, forkId ForkKey) error {
@@ -708,9 +708,9 @@ func (dbw *dbWriter) reconcileOnboardedBuilderDeposits(tx *sqlx.Tx, deposits []*
 
 	onboardingSlot := uint64(chainState.EpochToSlot(phase0.Epoch(*gloasForkEpoch)))
 	for _, deposit := range deposits {
-		// only pre-gloas builder (0x03) deposits are onboarded into builder_deposits by the fork
+		// only pre-gloas builder (0xB0) deposits are onboarded into builder_deposits by the fork
 		// transition, so only those have a copy to reconcile.
-		if deposit.CredType != 0x03 || uint64(chainState.EpochOfSlot(phase0.Slot(deposit.SlotNumber))) >= *gloasForkEpoch {
+		if deposit.CredType != 0xB0 || uint64(chainState.EpochOfSlot(phase0.Slot(deposit.SlotNumber))) >= *gloasForkEpoch {
 			continue
 		}
 

--- a/services/chainservice_builder_onboarding.go
+++ b/services/chainservice_builder_onboarding.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ethpandaops/dora/dbtypes"
 )
 
-// builderWithdrawalCredType is BUILDER_WITHDRAWAL_PREFIX (Gloas/EIP-8282): the 0x03 withdrawal
+// builderWithdrawalCredType is BUILDER_WITHDRAWAL_PREFIX (Gloas/EIP-8282): the 0xB0 withdrawal
 // credential prefix that marks a deposit as a builder deposit, onboarded as a builder at the Gloas
 // fork transition (onboard_builders_from_pending_deposits).
-const builderWithdrawalCredType uint8 = 0x03
+const builderWithdrawalCredType uint8 = 0xB0
 
-// isBuilderCredential reports whether the withdrawal credentials use the builder prefix (0x03).
+// isBuilderCredential reports whether the withdrawal credentials use the builder prefix (0xB0).
 func isBuilderCredential(wc []byte) bool {
 	return len(wc) > 0 && wc[0] == builderWithdrawalCredType
 }
@@ -25,7 +25,7 @@ func isBuilderCredential(wc []byte) bool {
 // far above any realistic count of pre-fork builder deposits; hitting it sets Truncated.
 const projectionFetchCap = 10000
 
-// ProjectedBuilderDeposit is one builder-credential (0x03) deposit on chain together with its
+// ProjectedBuilderDeposit is one builder-credential (0xB0) deposit on chain together with its
 // projected fate at the upcoming Gloas fork transition. When none of the fate flags is set the
 // deposit is projected to be onboarded as a builder (Result distinguishes new vs top-up).
 type ProjectedBuilderDeposit struct {
@@ -96,7 +96,7 @@ type BuilderOnboardingProjection struct {
 // not scheduled (no finite fork epoch) or the chain head/queue cannot be resolved. It is meant for
 // the builder deposits page before the fork, where the real builder_deposits table is still empty.
 //
-// It enumerates every 0x03-credential deposit and classifies each: deposits already applied or that
+// It enumerates every 0xB0-credential deposit and classifies each: deposits already applied or that
 // the churn queue would process before the fork become regular validators ("too early"); the rest
 // register builders (or top up earlier ones), drop on an invalid proof-of-possession, or stay as
 // validator deposits when they share a pubkey with a validator — mirroring
@@ -162,7 +162,7 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 	}
 	tailEstimate := indexedQueue.EstimateAppendedDepositEpoch(depositAmount)
 
-	// Primary source: every builder-credential (0x03) deposit on chain (cache + DB merge). The
+	// Primary source: every builder-credential (0xB0) deposit on chain (cache + DB merge). The
 	// credential-type filter lives on the tx filter (both the cache and DB paths apply it there).
 	depositFilter := &dbtypes.DepositFilter{
 		WithOrphaned: 1,

--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -308,8 +308,8 @@ func (bs *ChainService) GetDepositOperationsByFilter(ctx context.Context, filter
 
 			if len(txFilter.WithdrawalAddress) > 0 {
 				wdcreds := depositWithTx.WithdrawalCredentials
-				// 0x01 = ETH1, 0x02 = compounding, 0x03 = builder deposit
-				if wdcreds[0] != 0x01 && wdcreds[0] != 0x02 && wdcreds[0] != 0x03 {
+				// 0x01 = ETH1, 0x02 = compounding, 0xB0 = builder deposit
+				if wdcreds[0] != 0x01 && wdcreds[0] != 0x02 && wdcreds[0] != 0xB0 {
 					continue
 				}
 
@@ -792,7 +792,7 @@ func isSyntheticPendingDeposit(deposit *electra.PendingDeposit) bool {
 //
 // Post-Gloas (EIP-8282) builder deposits arrive via the dedicated builder deposit contract
 // and never appear in the regular deposit stream, so every included regular deposit (any
-// credential type, including 0x03) enters the pending_deposits queue and is a valid anchor;
+// credential type, including 0xB0) enters the pending_deposits queue and is a valid anchor;
 // the EL deposit index sequence stays contiguous with the queue.
 func (bs *ChainService) getRecentIncludedDeposits(ctx context.Context, headRoot phase0.Root) *dbtypes.Deposit {
 	headBlock := bs.beaconIndexer.GetBlockByRoot(headRoot)

--- a/services/chainservice_deposits_test.go
+++ b/services/chainservice_deposits_test.go
@@ -121,7 +121,7 @@ func TestResolveQueueDepositIndexes(t *testing.T) {
 			wantPostponed: []bool{false, false, false},
 		},
 		{
-			name:          "0x03 (builder-cred) regular deposit is indexed contiguously like any validator deposit",
+			name:          "0xB0 (builder-cred) regular deposit is indexed contiguously like any validator deposit",
 			queue:         []*electra.PendingDeposit{regularDeposit(10, 1), regularDeposit(11, 2)},
 			anchor:        anchorAt(8, 11),
 			wantIndexes:   []*uint64{u64p(7), u64p(8)},

--- a/templates/builder_deposits/builder_deposits.html
+++ b/templates/builder_deposits/builder_deposits.html
@@ -24,7 +24,7 @@
           <p class="mb-2">
             Gloas activates at epoch <strong>{{ .GloasForkEpoch }}</strong>
             (<span data-timer="{{ .GloasForkTime.Unix }}" data-bs-toggle="tooltip" data-bs-title="{{ .GloasForkTime }}">{{ formatRecentTimeShort .GloasForkTime }}</span>).
-            Builder deposits are not recorded on-chain yet &mdash; the entries below are the actual <strong>0x03-credential deposits</strong>,
+            Builder deposits are not recorded on-chain yet &mdash; the entries below are the actual <strong>0xB0-credential deposits</strong>,
             each annotated with its <strong>projected</strong> fate at the fork (based on the deposit churn limit and pending queue), and may change as deposits are submitted or processed.
             {{ if .ProjectionTruncated }}<span class="text-muted">(showing the first {{ len .Deposits }}; older deposits omitted)</span>{{ end }}
           </p>

--- a/templates/included_deposits/included_deposits.html
+++ b/templates/included_deposits/included_deposits.html
@@ -121,7 +121,7 @@
                       <option value="0" {{ if index .FilterCredTypes 0 }}selected{{ end }}>0x00 (BLS)</option>
                       <option value="1" {{ if index .FilterCredTypes 1 }}selected{{ end }}>0x01 (Execution)</option>
                       <option value="2" {{ if index .FilterCredTypes 2 }}selected{{ end }}>0x02 (Compounding)</option>
-                      <option value="3" {{ if index .FilterCredTypes 3 }}selected{{ end }}>0x03 (Builder)</option>
+                      <option value="176" {{ if index .FilterCredTypes 176 }}selected{{ end }}>0xB0 (Builder)</option>
                     </select>
                   </div>
                 </div>

--- a/templates/validators/validators.html
+++ b/templates/validators/validators.html
@@ -81,7 +81,7 @@
                       <option value="0" {{ if index .FilterCredTypes 0 }}selected{{ end }}>0x00 (BLS)</option>
                       <option value="1" {{ if index .FilterCredTypes 1 }}selected{{ end }}>0x01 (Execution)</option>
                       <option value="2" {{ if index .FilterCredTypes 2 }}selected{{ end }}>0x02 (Compounding)</option>
-                      <option value="3" {{ if index .FilterCredTypes 3 }}selected{{ end }}>0x03 (Builder)</option>
+                      <option value="176" {{ if index .FilterCredTypes 176 }}selected{{ end }}>0xB0 (Builder)</option>
                     </select>
                   </div>
                 </div>

--- a/ui-package/src/components/SubmitBuilderDepositsForm/BuilderDepositsTable.tsx
+++ b/ui-package/src/components/SubmitBuilderDepositsForm/BuilderDepositsTable.tsx
@@ -178,7 +178,7 @@ const BuilderDepositsTable = (props: IBuilderDepositsTableProps): React.ReactEle
     signingDomain.set(forkDataRoot.slice(0, 28), 4);
 
     return json.map((deposit: IDeposit) => {
-      const credsOk = deposit.withdrawal_credentials.replace(/^0x/, "").substring(0, 2).toLowerCase() === "03";
+      const credsOk = deposit.withdrawal_credentials.replace(/^0x/, "").substring(0, 2).toLowerCase() === "b0";
       deposit.validity = props.deposits ? credsOk : (credsOk && verifyDeposit(deposit, signingDomain));
       return deposit;
     });

--- a/ui-package/src/components/SubmitBuilderDepositsForm/SubmitBuilderDepositsForm.tsx
+++ b/ui-package/src/components/SubmitBuilderDepositsForm/SubmitBuilderDepositsForm.tsx
@@ -21,7 +21,7 @@ const SubmitBuilderDepositsForm = (props: ISubmitBuilderDepositsFormProps): Reac
       <div className="row">
         <div className="col-12">
           <h3>Submit builder deposits</h3>
-          <p>This tool submits builder deposits to the builder deposit contract. Builder deposits carry a 0x03 withdrawal credential and a proof-of-possession signed under the dedicated builder-deposit domain.</p>
+          <p>This tool submits builder deposits to the builder deposit contract. Builder deposits carry a 0xB0 withdrawal credential and a proof-of-possession signed under the dedicated builder-deposit domain.</p>
           <div className="alert alert-warning">
             <b>Don't provide your keystore or mnemonic to us or any other website.</b> The generator below is for devnet testing only.
           </div>
@@ -62,7 +62,7 @@ const SubmitBuilderDepositsForm = (props: ISubmitBuilderDepositsFormProps): Reac
               Generate
             </button>
           </div>
-          <p className="text-secondary-emphasis mt-2">The deposit data file is a JSON array of builder deposits (pubkey, 0x03 withdrawal_credentials, amount, signature).</p>
+          <p className="text-secondary-emphasis mt-2">The deposit data file is a JSON array of builder deposits (pubkey, 0xB0 withdrawal_credentials, amount, signature).</p>
         </div>
 
         {(file || generatedDeposits) && isConnected && (

--- a/ui-package/src/components/SubmitDepositsForm/DepositGenerator.ts
+++ b/ui-package/src/components/SubmitDepositsForm/DepositGenerator.ts
@@ -30,7 +30,7 @@ const SigningData = new ContainerType({
   domain: new ByteVectorType(32),
 });
 
-export type CredentialType = '00' | '01' | '02' | '03';
+export type CredentialType = '00' | '01' | '02' | 'b0';
 
 // DepositDomainType selects the signing domain: regular validator deposits use
 // DOMAIN_DEPOSIT (0x03000000); builder deposits use DOMAIN_BUILDER_DEPOSIT (0x0E000000).
@@ -70,10 +70,10 @@ export function validateMnemonicWords(mnemonic: string): boolean {
 
 /**
  * Build withdrawal credentials from type and ETH address
- * @param credType - '01' for execution, '02' for compounding, '03' for builder
+ * @param credType - '01' for execution, '02' for compounding, 'b0' for builder
  * @param address - 20-byte ETH address (0x prefixed)
  */
-export function buildWithdrawalCredentialsFromAddress(credType: '01' | '02' | '03', address: string): string {
+export function buildWithdrawalCredentialsFromAddress(credType: '01' | '02' | 'b0', address: string): string {
   const cleanAddress = address.startsWith('0x') ? address.slice(2) : address;
   if (cleanAddress.length !== 40) {
     throw new Error("Invalid address length");
@@ -117,9 +117,9 @@ export async function buildWithdrawalCredentials(
     return buildBLSWithdrawalCredentials(withdrawalPubkey);
   } else {
     if (!config.address) {
-      throw new Error("Address required for 0x01/0x02/0x03 credentials");
+      throw new Error("Address required for 0x01/0x02/0xB0 credentials");
     }
-    return buildWithdrawalCredentialsFromAddress(config.type as '01' | '02' | '03', config.address);
+    return buildWithdrawalCredentialsFromAddress(config.type as '01' | '02' | 'b0', config.address);
   }
 }
 

--- a/ui-package/src/components/SubmitDepositsForm/DepositGeneratorModal.tsx
+++ b/ui-package/src/components/SubmitDepositsForm/DepositGeneratorModal.tsx
@@ -21,7 +21,7 @@ interface IDepositGeneratorModalProps {
   onClose: () => void;
   onGenerate: (deposits: IDeposit[]) => void;
   // Builder mode (Gloas/EIP-8282): sign under DOMAIN_BUILDER_DEPOSIT and lock the
-  // withdrawal credential to the 0x03 builder prefix.
+  // withdrawal credential to the 0xB0 builder prefix.
   domainType?: DepositDomainType;
   lockBuilderCredentials?: boolean;
 }
@@ -35,8 +35,8 @@ interface IValidatorOverrideState {
   useCustomAmount: boolean;
   // Credential override fields
   credentialInputMode: CredentialInputMode;
-  credentialType: CredentialType; // '00', '01', '02', '03'
-  withdrawalAddress: string; // For 0x01/0x02/0x03
+  credentialType: CredentialType; // '00', '01', '02', 'b0'
+  withdrawalAddress: string; // For 0x01/0x02/0xB0
   rawCredentials: string; // For raw mode
   useCustomCredentials: boolean;
 }
@@ -56,7 +56,7 @@ const DepositGeneratorModal: React.FC<IDepositGeneratorModalProps> = (props) => 
   const [validatorCount, setValidatorCount] = useState(1);
   const [amountEth, setAmountEth] = useState('32');
   const [credentialInputMode, setCredentialInputMode] = useState<CredentialInputMode>('type');
-  const [credentialType, setCredentialType] = useState<CredentialType>(lockBuilderCredentials ? '03' : '01');
+  const [credentialType, setCredentialType] = useState<CredentialType>(lockBuilderCredentials ? 'b0' : '01');
   const [withdrawalAddress, setWithdrawalAddress] = useState(defaultWithdrawalAddress || '');
   const [rawCredentials, setRawCredentials] = useState('');
 
@@ -407,13 +407,13 @@ const DepositGeneratorModal: React.FC<IDepositGeneratorModalProps> = (props) => 
                         onChange={(e) => setCredentialType(e.target.value as CredentialType)}
                       >
                         {lockBuilderCredentials ? (
-                          <option value="03">0x03 - Builder</option>
+                          <option value="b0">0xB0 - Builder</option>
                         ) : (
                           <>
                             <option value="00">0x00 - BLS (derived)</option>
                             <option value="01">0x01 - Execution</option>
                             <option value="02">0x02 - Compounding</option>
-                            <option value="03">0x03 - Builder</option>
+                            <option value="b0">0xB0 - Builder</option>
                           </>
                         )}
                       </select>
@@ -547,9 +547,9 @@ const DepositGeneratorModal: React.FC<IDepositGeneratorModalProps> = (props) => 
                                       <option value="00">0x00</option>
                                       <option value="01">0x01</option>
                                       <option value="02">0x02</option>
-                                      <option value="03">0x03</option>
+                                      <option value="b0">0xB0</option>
                                     </select>
-                                    {/* Address input (only for 0x01/0x02/0x03) */}
+                                    {/* Address input (only for 0x01/0x02/0xB0) */}
                                     {override.credentialType !== '00' && (
                                       <input
                                         type="text"

--- a/ui-package/src/components/SubmitDepositsForm/GatingContract.ts
+++ b/ui-package/src/components/SubmitDepositsForm/GatingContract.ts
@@ -139,7 +139,7 @@ export const DEPOSIT_TYPES = {
   BLS: 0x00,
   EXECUTION: 0x01,
   COMPOUNDING: 0x02,
-  EPBS: 0x03,
+  EPBS: 0xb0,
   TOPUP: 0xffff
 } as const;
 
@@ -148,7 +148,7 @@ export const DEPOSIT_TYPE_LABELS: Record<number, string> = {
   [DEPOSIT_TYPES.BLS]: "BLS Withdrawal (0x00)",
   [DEPOSIT_TYPES.EXECUTION]: "Execution Withdrawal (0x01)",
   [DEPOSIT_TYPES.COMPOUNDING]: "Compounding (0x02)",
-  [DEPOSIT_TYPES.EPBS]: "ePBS Builder (0x03)",
+  [DEPOSIT_TYPES.EPBS]: "ePBS Builder (0xB0)",
   [DEPOSIT_TYPES.TOPUP]: "Topup Deposits"
 };
 
@@ -157,7 +157,7 @@ export const PREFIX_TO_DEPOSIT_TYPE: Record<string, number> = {
   "00": DEPOSIT_TYPES.BLS,
   "01": DEPOSIT_TYPES.EXECUTION,
   "02": DEPOSIT_TYPES.COMPOUNDING,
-  "03": DEPOSIT_TYPES.EPBS
+  "b0": DEPOSIT_TYPES.EPBS
 };
 
 // Deposit gate config interface

--- a/utils/format.go
+++ b/utils/format.go
@@ -1071,7 +1071,7 @@ func formatWithdrawalHash(hash []byte) template.HTML {
 		colorClass = "text-success"
 	} else if hash[0] == 0x02 {
 		colorClass = "text-info"
-	} else if hash[0] == 0x03 {
+	} else if hash[0] == 0xB0 {
 		colorClass = "text-primary"
 	} else {
 		colorClass = "text-warning"
@@ -1085,8 +1085,8 @@ func FormatWithdawalCredentials(hash []byte) template.HTML {
 		return "INVALID CREDENTIALS"
 	}
 
-	// For 0x01, 0x02 or 0x03 credentials, link to the address
-	if hash[0] == 0x01 || hash[0] == 0x02 || hash[0] == 0x03 {
+	// For 0x01, 0x02 or 0xB0 credentials, link to the address
+	if hash[0] == 0x01 || hash[0] == 0x02 || hash[0] == 0xB0 {
 		addr := fmt.Sprintf("0x%x", hash[12:])
 
 		// Use local link when execution indexer is enabled


### PR DESCRIPTION
`BUILDER_WITHDRAWAL_PREFIX` changed from `0x03` to `0xB0` in ethereum/consensus-specs#5416 (lands in v1.7.0-alpha.12, targeted by glamsterdam-devnet-7).

This updates every place dora classifies builder credentials by prefix:
- `indexer/beacon/statetransition/fork.go` + `services/chainservice_builder_onboarding.go` constants (fork-transition builder onboarding simulation and projection)
- pending-deposit classification (`indexer/beacon/pendingvalidators.go`) and deposit handlers (`queued/included/initiated/deposits`)
- withdrawal-address deposit filter (`db/deposits.go`, `services/chainservice_deposits.go`) and credentials formatting (`utils/format.go`)
- cred-type filter parsing now accepts `0,1,2,176` (`0xB0`); validators/included_deposits filter dropdowns updated
- ui-package deposit generator: credential type `03` → `b0`, gating contract deposit type `EPBS` `0x03` → `0xb0`, builder deposit-data validation checks `0xB0`

The deposit-domain constant `0x03000000` (`DOMAIN_DEPOSIT`) and the EIP-8282 deposit request type `0x03` are different namespaces and are untouched.

`go build ./...`, `go test` on touched packages, and `tsc --noEmit` (no new errors vs base) all pass.