### PR TITLE
Fix EIP-8282 builder contract resolution from eth_config

### DIFF
--- a/clients/execution/chainstate.go
+++ b/clients/execution/chainstate.go
@@ -16,8 +16,8 @@ import (
 var DefaultSystemContractAddresses = map[string]common.Address{
 	rpc.ConsolidationRequestContract:  common.HexToAddress("0x0000BBdDc7CE488642fb579F8B00f3a590007251"),
 	rpc.WithdrawalRequestContract:     common.HexToAddress("0x00000961Ef480Eb55e80D19ad83579A64c007002"),
-	rpc.BuilderDepositRequestContract: common.HexToAddress("0x0000884d2AA32eAa155F59A2f24eFa73D9008282"),
-	rpc.BuilderExitRequestContract:    common.HexToAddress("0x000014574A74c805590AFF9499fc7A690f008282"),
+	rpc.BuilderDepositRequestContract: common.HexToAddress("0x0000bFF46984e3725691FA540a8C7589300D8282"),
+	rpc.BuilderExitRequestContract:    common.HexToAddress("0x000064D678505ad48F8cCb093BC65613800E8282"),
 	rpc.BeaconRootsContract:           common.HexToAddress("0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02"),
 	rpc.HistoryStorageContract:        common.HexToAddress("0x0000F90827F1C53a10cb7A02335B175320002935"),
 }

--- a/clients/execution/rpc/ethconfig.go
+++ b/clients/execution/rpc/ethconfig.go
@@ -11,8 +11,8 @@ const (
 	DepositContract               = "DEPOSIT_CONTRACT_ADDRESS"
 	ConsolidationRequestContract  = "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS"
 	WithdrawalRequestContract     = "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS"
-	BuilderDepositRequestContract = "BUILDER_DEPOSIT_REQUEST_PREDEPLOY_ADDRESS"
-	BuilderExitRequestContract    = "BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS"
+	BuilderDepositRequestContract = "BUILDER_DEPOSIT_CONTRACT_ADDRESS"
+	BuilderExitRequestContract    = "BUILDER_EXIT_CONTRACT_ADDRESS"
 	BeaconRootsContract           = "BEACON_ROOTS_ADDRESS"
 	HistoryStorageContract        = "HISTORY_STORAGE_ADDRESS"
 )

--- a/indexer/execution/system_contracts/builder_deposit_indexer.go
+++ b/indexer/execution/system_contracts/builder_deposit_indexer.go
@@ -51,11 +51,13 @@ func NewBuilderDepositIndexer(indexer *execution.IndexerCtx) *BuilderDepositInde
 		indexer,
 		indexer.Logger.WithField("contract-indexer", "builder_deposits"),
 		&contractIndexerOptions[dbtypes.BuilderDepositTx]{
-			stateKey:        "indexer.builderdepositindexer",
-			batchSize:       batchSize,
-			contractAddress: bi.indexerCtx.GetSystemContractAddress(rpc.BuilderDepositRequestContract),
-			deployBlock:     uint64(utils.Config.ExecutionApi.GloasDeployBlock),
-			dequeueRate:     specs.MaxBuilderDepositRequestsPerPayload,
+			stateKey:  "indexer.builderdepositindexer",
+			batchSize: batchSize,
+			contractAddress: func() common.Address {
+				return bi.indexerCtx.GetSystemContractAddress(rpc.BuilderDepositRequestContract)
+			},
+			deployBlock: uint64(utils.Config.ExecutionApi.GloasDeployBlock),
+			dequeueRate: specs.MaxBuilderDepositRequestsPerPayload,
 
 			processFinalTx:  bi.processFinalTx,
 			processRecentTx: bi.processRecentTx,

--- a/indexer/execution/system_contracts/builder_exit_indexer.go
+++ b/indexer/execution/system_contracts/builder_exit_indexer.go
@@ -50,11 +50,13 @@ func NewBuilderExitIndexer(indexer *execution.IndexerCtx) *BuilderExitIndexer {
 		indexer,
 		indexer.Logger.WithField("contract-indexer", "builder_exits"),
 		&contractIndexerOptions[dbtypes.BuilderExitTx]{
-			stateKey:        "indexer.builderexitindexer",
-			batchSize:       batchSize,
-			contractAddress: bi.indexerCtx.GetSystemContractAddress(rpc.BuilderExitRequestContract),
-			deployBlock:     uint64(utils.Config.ExecutionApi.GloasDeployBlock),
-			dequeueRate:     specs.MaxBuilderExitRequestsPerPayload,
+			stateKey:  "indexer.builderexitindexer",
+			batchSize: batchSize,
+			contractAddress: func() common.Address {
+				return bi.indexerCtx.GetSystemContractAddress(rpc.BuilderExitRequestContract)
+			},
+			deployBlock: uint64(utils.Config.ExecutionApi.GloasDeployBlock),
+			dequeueRate: specs.MaxBuilderExitRequestsPerPayload,
 
 			processFinalTx:  bi.processFinalTx,
 			processRecentTx: bi.processRecentTx,

--- a/indexer/execution/system_contracts/consolidation_indexer.go
+++ b/indexer/execution/system_contracts/consolidation_indexer.go
@@ -51,11 +51,13 @@ func NewConsolidationIndexer(indexer *execution.IndexerCtx) *ConsolidationIndexe
 		indexer,
 		indexer.Logger.WithField("contract-indexer", "consolidations"),
 		&contractIndexerOptions[dbtypes.ConsolidationRequestTx]{
-			stateKey:        "indexer.consolidationindexer",
-			batchSize:       batchSize,
-			contractAddress: ci.indexerCtx.GetSystemContractAddress(rpc.ConsolidationRequestContract),
-			deployBlock:     uint64(utils.Config.ExecutionApi.ElectraDeployBlock),
-			dequeueRate:     specs.MaxConsolidationRequestsPerPayload,
+			stateKey:  "indexer.consolidationindexer",
+			batchSize: batchSize,
+			contractAddress: func() common.Address {
+				return ci.indexerCtx.GetSystemContractAddress(rpc.ConsolidationRequestContract)
+			},
+			deployBlock: uint64(utils.Config.ExecutionApi.ElectraDeployBlock),
+			dequeueRate: specs.MaxConsolidationRequestsPerPayload,
 
 			processFinalTx:  ci.processFinalTx,
 			processRecentTx: ci.processRecentTx,

--- a/indexer/execution/system_contracts/contract_indexer.go
+++ b/indexer/execution/system_contracts/contract_indexer.go
@@ -31,11 +31,11 @@ type contractIndexer[TxType any] struct {
 
 // contractIndexerOptions defines the configuration for the contract indexer
 type contractIndexerOptions[TxType any] struct {
-	stateKey        string         // key to identify the indexer state in the database
-	batchSize       int            // number of logs to fetch per request
-	contractAddress common.Address // address of the contract to index
-	deployBlock     uint64         // block number from where to start crawling logs
-	dequeueRate     uint64         // number of logs to dequeue per block, 0 for no queue
+	stateKey        string                // key to identify the indexer state in the database
+	batchSize       int                   // number of logs to fetch per request
+	contractAddress func() common.Address // resolves the address of the contract to index (re-evaluated per scan, as client configs may arrive after startup)
+	deployBlock     uint64                // block number from where to start crawling logs
+	dequeueRate     uint64                // number of logs to dequeue per block, 0 for no queue
 
 	// processFinalTx processes a finalized transaction log
 	processFinalTx func(log *types.Log, tx *types.Transaction, header *types.Header, txFrom common.Address, dequeueBlock uint64, parentTxs []*TxType) (*TxType, error)
@@ -227,7 +227,7 @@ func (ci *contractIndexer[TxType]) processFinalizedBlocks(finalizedBlockNumber u
 			FromBlock: big.NewInt(0).SetUint64(ci.state.FinalBlock + 1),
 			ToBlock:   big.NewInt(0).SetUint64(toBlock),
 			Addresses: []common.Address{
-				ci.options.contractAddress,
+				ci.options.contractAddress(),
 			},
 			// Match any topic. A nil Topics serializes to "topics": null, which some
 			// execution clients (e.g. ethrex) reject as a missing parameter; a non-nil
@@ -462,7 +462,7 @@ func (ci *contractIndexer[TxType]) processRecentBlocksForFork(headFork *exectx.F
 				FromBlock: big.NewInt(0).SetUint64(startBlockNumber),
 				ToBlock:   big.NewInt(0).SetUint64(toBlock),
 				Addresses: []common.Address{
-					ci.options.contractAddress,
+					ci.options.contractAddress(),
 				},
 				// Match any topic. A nil Topics serializes to "topics": null, which some
 				// execution clients (e.g. ethrex) reject as a missing parameter; a non-nil

--- a/indexer/execution/system_contracts/deposit_indexer.go
+++ b/indexer/execution/system_contracts/deposit_indexer.go
@@ -70,11 +70,13 @@ func NewDepositIndexer(indexer *execution.IndexerCtx) *DepositIndexer {
 		indexer,
 		ds.logger.WithField("routine", "crawler"),
 		&contractIndexerOptions[dbtypes.DepositTx]{
-			stateKey:        "indexer.depositstate",
-			batchSize:       batchSize,
-			contractAddress: common.Address(specs.DepositContractAddress),
-			deployBlock:     uint64(utils.Config.ExecutionApi.DepositDeployBlock),
-			dequeueRate:     0,
+			stateKey:  "indexer.depositstate",
+			batchSize: batchSize,
+			contractAddress: func() common.Address {
+				return common.Address(specs.DepositContractAddress)
+			},
+			deployBlock: uint64(utils.Config.ExecutionApi.DepositDeployBlock),
+			dequeueRate: 0,
 
 			processFinalTx:  ds.processFinalTx,
 			processRecentTx: ds.processRecentTx,

--- a/indexer/execution/system_contracts/withdrawal_indexer.go
+++ b/indexer/execution/system_contracts/withdrawal_indexer.go
@@ -52,11 +52,13 @@ func NewWithdrawalIndexer(indexer *execution.IndexerCtx) *WithdrawalIndexer {
 		indexer,
 		indexer.Logger.WithField("contract-indexer", "withdrawals"),
 		&contractIndexerOptions[dbtypes.WithdrawalRequestTx]{
-			stateKey:        "indexer.withdrawalindexer",
-			batchSize:       batchSize,
-			contractAddress: wi.indexerCtx.GetSystemContractAddress(rpc.WithdrawalRequestContract),
-			deployBlock:     uint64(utils.Config.ExecutionApi.ElectraDeployBlock),
-			dequeueRate:     specs.MaxWithdrawalRequestsPerPayload,
+			stateKey:  "indexer.withdrawalindexer",
+			batchSize: batchSize,
+			contractAddress: func() common.Address {
+				return wi.indexerCtx.GetSystemContractAddress(rpc.WithdrawalRequestContract)
+			},
+			deployBlock: uint64(utils.Config.ExecutionApi.ElectraDeployBlock),
+			dequeueRate: specs.MaxWithdrawalRequestsPerPayload,
 
 			processFinalTx:  wi.processFinalTx,
 			processRecentTx: wi.processRecentTx,


### PR DESCRIPTION
# Fix EIP-8282 builder contract resolution from eth_config

## Problem

Builder deposit/exit transactions were not being indexed (empty `builder_deposit_request_txs` / `builder_exit_request_txs` tables, empty tx hashes on `/builders/deposits`), even though the EL clients supply the correct contract addresses via `eth_config`.

Two issues caused this:

1. **Wrong `systemContracts` lookup keys**: dora looked up the builder contracts under `BUILDER_DEPOSIT_REQUEST_PREDEPLOY_ADDRESS` / `BUILDER_EXIT_REQUEST_PREDEPLOY_ADDRESS`, but EL clients report them as `BUILDER_DEPOSIT_CONTRACT_ADDRESS` / `BUILDER_EXIT_CONTRACT_ADDRESS`. The lookup never matched, so dora always fell back to the hardcoded default addresses — which were outdated EIP-8282 draft addresses. The contract indexers scanned a contract with no logs and found nothing.

2. **Contract address captured once at startup**: the system contract indexers resolved the contract address a single time at construction and baked it into the indexer options. If the indexers started before any client delivered its `eth_config` (a startup race), or the address changed at a fork boundary, the indexer kept scanning the stale address forever.

## Changes

- `clients/execution/rpc/ethconfig.go`: rename the builder contract `systemContracts` keys to `BUILDER_DEPOSIT_CONTRACT_ADDRESS` / `BUILDER_EXIT_CONTRACT_ADDRESS`, matching what EL clients report.
- `clients/execution/chainstate.go`: update `DefaultSystemContractAddresses` to the current EIP-8282 addresses (`0x0000bFF46984e3725691FA540a8C7589300D8282` for deposits, `0x000064D678505ad48F8cCb093BC65613800E8282` for exits).
- `indexer/execution/system_contracts/contract_indexer.go`: `contractIndexerOptions.contractAddress` is now a `func() common.Address` resolver, evaluated on every log scan (finalized and recent), so late-arriving client configs and fork-boundary address changes are picked up.
- All five system contract indexers (builder deposit, builder exit, withdrawal, consolidation, deposit) pass resolver closures accordingly.

## Deployment note

On instances that already ran with the wrong address, the contract indexer state has advanced past the affected blocks. To backfill missed builder deposits/exits, reset the `indexer.builderdepositindexer`, `indexer.builderdepositmatcher`, `indexer.builderexitindexer` and `indexer.builderexitmatcher` rows in `explorer_state` so the indexers re-crawl from the Gloas deploy block.
