### PR TITLE
Implement validator name filter for deposit queries

### DIFF
--- a/db/deposit_txs.go
+++ b/db/deposit_txs.go
@@ -193,6 +193,13 @@ func GetDepositTxsFiltered(ctx context.Context, offset uint64, limit uint32, can
 		FROM deposit_txs
 	`)
 
+	if filter.ValidatorName != "" {
+		fmt.Fprint(&sql, `
+		LEFT JOIN validators ON validators.pubkey = deposit_txs.publickey
+		LEFT JOIN validator_names ON validator_names."index" = validators.validator_index
+	`)
+	}
+
 	filterOp := "WHERE"
 	if filter.MinIndex > 0 {
 		args = append(args, filter.MinIndex)
@@ -248,6 +255,14 @@ func GetDepositTxsFiltered(ctx context.Context, offset uint64, limit uint32, can
 	if filter.MaxAmount > 0 {
 		args = append(args, filter.MaxAmount*utils.GWEI.Uint64())
 		fmt.Fprintf(&sql, " %v amount <= $%v", filterOp, len(args))
+		filterOp = "AND"
+	}
+	if filter.ValidatorName != "" {
+		args = append(args, "%"+filter.ValidatorName+"%")
+		fmt.Fprintf(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
+			dbtypes.DBEnginePgsql:  " %v validator_names.name ilike $%v",
+			dbtypes.DBEngineSqlite: " %v validator_names.name LIKE $%v",
+		}), filterOp, len(args))
 		filterOp = "AND"
 	}
 

--- a/db/deposits.go
+++ b/db/deposits.go
@@ -129,6 +129,13 @@ func GetDepositsFiltered(ctx context.Context, offset uint64, limit uint32, canon
 		`)
 	}
 
+	if filter.ValidatorName != "" {
+		fmt.Fprint(&sql, `
+			LEFT JOIN validators ON validators.pubkey = deposits.publickey
+			LEFT JOIN validator_names ON validator_names."index" = validators.validator_index
+		`)
+	}
+
 	filterOp := "WHERE"
 	if filter.MinIndex > 0 {
 		args = append(args, filter.MinIndex)
@@ -153,6 +160,14 @@ func GetDepositsFiltered(ctx context.Context, offset uint64, limit uint32, canon
 	if filter.MaxAmount > 0 {
 		args = append(args, filter.MaxAmount*utils.GWEI.Uint64())
 		fmt.Fprintf(&sql, " %v deposits.amount <= $%v", filterOp, len(args))
+		filterOp = "AND"
+	}
+	if filter.ValidatorName != "" {
+		args = append(args, "%"+filter.ValidatorName+"%")
+		fmt.Fprintf(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
+			dbtypes.DBEnginePgsql:  " %v validator_names.name ilike $%v",
+			dbtypes.DBEngineSqlite: " %v validator_names.name LIKE $%v",
+		}), filterOp, len(args))
 		filterOp = "AND"
 	}
 

--- a/db/deposits_test.go
+++ b/db/deposits_test.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/jmoiron/sqlx"
+)
+
+// TestGetDepositsFilteredByValidatorName checks the validator name filter, which
+// resolves names through the validators table (deposits are keyed by pubkey).
+func TestGetDepositsFilteredByValidatorName(t *testing.T) {
+	newTestDB(t)
+
+	pubkey1 := append([]byte{0x01}, make([]byte, 47)...)
+	pubkey2 := append([]byte{0x02}, make([]byte, 47)...)
+	pubkeyUnknown := append([]byte{0x03}, make([]byte, 47)...)
+	creds := make([]byte, 32)
+
+	err := RunDBTransaction(func(tx *sqlx.Tx) error {
+		for i, pubkey := range [][]byte{pubkey1, pubkey2} {
+			if err := InsertValidator(context.Background(), tx, &dbtypes.Validator{
+				ValidatorIndex: uint64(i), Pubkey: pubkey, WithdrawalCredentials: creds,
+			}); err != nil {
+				return err
+			}
+		}
+		if err := InsertValidatorNames(context.Background(), tx, []*dbtypes.ValidatorName{
+			{Index: 0, Name: "lighthouse-geth-1"},
+			{Index: 1, Name: "prysm-besu-2"},
+		}); err != nil {
+			return err
+		}
+
+		for i, pubkey := range [][]byte{pubkey1, pubkey2, pubkeyUnknown} {
+			depositIndex := uint64(i)
+			if err := InsertDeposits(context.Background(), tx, []*dbtypes.Deposit{{
+				Index: &depositIndex, SlotNumber: uint64(100 + i), SlotIndex: 0,
+				SlotRoot: []byte{byte(i)}, PublicKey: pubkey, WithdrawalCredentials: creds,
+				Amount: 32000000000,
+			}}); err != nil {
+				return err
+			}
+			if err := InsertDepositTxs(context.Background(), tx, []*dbtypes.DepositTx{{
+				Index: depositIndex, BlockNumber: uint64(10 + i), BlockRoot: []byte{byte(i)},
+				PublicKey: pubkey, WithdrawalCredentials: creds, Amount: 32000000000,
+				Signature: []byte{}, TxHash: []byte{byte(i)}, TxSender: []byte{}, TxTarget: []byte{},
+				ValidSignature: 1,
+			}}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		vname     string
+		wantCount int
+	}{
+		{"matches single validator", "lighthouse-geth-1", 1},
+		{"substring match", "prysm", 1},
+		{"no match", "unknown-node", 0},
+		{"no filter returns all", "", 3},
+	}
+
+	for _, c := range cases {
+		t.Run("deposits: "+c.name, func(t *testing.T) {
+			deposits, _, err := GetDepositsFiltered(context.Background(), 0, 100, []uint64{0},
+				&dbtypes.DepositFilter{ValidatorName: c.vname, WithOrphaned: 1}, nil)
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			if len(deposits) != c.wantCount {
+				t.Errorf("got %v deposits, want %v", len(deposits), c.wantCount)
+			}
+		})
+		t.Run("deposit_txs: "+c.name, func(t *testing.T) {
+			txs, _, err := GetDepositTxsFiltered(context.Background(), 0, 100, []uint64{0},
+				&dbtypes.DepositTxFilter{ValidatorName: c.vname, WithOrphaned: 1, WithValid: 1})
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			if len(txs) != c.wantCount {
+				t.Errorf("got %v deposit txs, want %v", len(txs), c.wantCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The validator name filter (`f.vname`) on [included_deposits](https://dora.glamsterdam-devnet-7.ethpandaops.io/validators/included_deposits) and initiated_deposits has no effect (spotted by @pk910 while reviewing #796): the handlers pass it into `DepositFilter`/`DepositTxFilter`, and the in-memory unfinalized path applies it, but neither `GetDepositsFiltered` nor `GetDepositTxsFiltered` ever consumed the field — finalized rows were never filtered.

## How

Deposits are keyed by pubkey rather than validator index, so the name resolves through the validators table (`publickey → validators.pubkey → validator_names."index"`), using the same `LEFT JOIN … ILIKE` shape as the other event queries. `validators.pubkey` is indexed. Deposits for pubkeys that never became a validator have no name and never match a name filter — consistent with the pages showing no name for them.

Joins are only added when the filter is set, so unfiltered queries are unchanged.

## Testing

sqlite integration test covering both queries: exact match, substring match, no match, unfiltered, and the unknown-pubkey case.

Note: independent of #796 — this fixes the *current-name* filter mechanism. Time-aware name stamping for the deposits family remains a #796 follow-up.