### PR TITLE
Hot-add endpoints from endpointsUrl without restart

### DIFF
--- a/clients/consensus/pool.go
+++ b/clients/consensus/pool.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"math/rand/v2"
@@ -15,6 +16,7 @@ import (
 type Pool struct {
 	ctx           context.Context
 	logger        logrus.FieldLogger
+	clientsMutex  sync.RWMutex
 	clientCounter uint16
 	clients       []*Client
 	chainState    *ChainState
@@ -46,6 +48,9 @@ func (pool *Pool) GetChainState() *ChainState {
 }
 
 func (pool *Pool) AddEndpoint(endpoint *ClientConfig) (*Client, error) {
+	pool.clientsMutex.Lock()
+	defer pool.clientsMutex.Unlock()
+
 	clientIdx := pool.clientCounter
 	pool.clientCounter++
 
@@ -60,13 +65,19 @@ func (pool *Pool) AddEndpoint(endpoint *ClientConfig) (*Client, error) {
 }
 
 func (pool *Pool) GetAllEndpoints() []*Client {
-	return pool.clients
+	pool.clientsMutex.RLock()
+	defer pool.clientsMutex.RUnlock()
+
+	clients := make([]*Client, len(pool.clients))
+	copy(clients, pool.clients)
+
+	return clients
 }
 
 func (pool *Pool) GetReadyEndpoint(clientType ClientType) *Client {
 	readyClients := []*Client{}
 
-	for _, client := range pool.clients {
+	for _, client := range pool.GetAllEndpoints() {
 		if !client.isOnline {
 			continue
 		}

--- a/clients/execution/pool.go
+++ b/clients/execution/pool.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"math/rand/v2"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -11,6 +12,7 @@ import (
 type Pool struct {
 	ctx           context.Context
 	logger        logrus.FieldLogger
+	clientsMutex  sync.RWMutex
 	clientCounter uint16
 	clients       []*Client
 	chainState    *ChainState
@@ -30,6 +32,9 @@ func (pool *Pool) GetChainState() *ChainState {
 }
 
 func (pool *Pool) AddEndpoint(endpoint *ClientConfig) (*Client, error) {
+	pool.clientsMutex.Lock()
+	defer pool.clientsMutex.Unlock()
+
 	clientIdx := pool.clientCounter
 	pool.clientCounter++
 	client, err := pool.newPoolClient(clientIdx, endpoint)
@@ -44,13 +49,19 @@ func (pool *Pool) AddEndpoint(endpoint *ClientConfig) (*Client, error) {
 }
 
 func (pool *Pool) GetAllEndpoints() []*Client {
-	return pool.clients
+	pool.clientsMutex.RLock()
+	defer pool.clientsMutex.RUnlock()
+
+	clients := make([]*Client, len(pool.clients))
+	copy(clients, pool.clients)
+
+	return clients
 }
 
 func (pool *Pool) GetReadyEndpoints(clientType ClientType) []*Client {
 	readyClients := []*Client{}
 
-	for _, client := range pool.clients {
+	for _, client := range pool.GetAllEndpoints() {
 		if !client.isOnline {
 			continue
 		}

--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -78,6 +78,12 @@ beaconapi:
     - name: "local"
       url: "http://127.0.0.1:5052"
 
+  # alternatively, load the endpoints list from a URL or file path (yaml list of endpoint objects).
+  # the source is re-fetched periodically and new endpoints are hot-added at runtime;
+  # changed or removed endpoints still require a restart.
+  #endpointsUrl: ""
+  #endpointsReloadInterval: 1h # 0 = default (1h), negative = disable reloading
+
   # local cache for page models
   localCacheSize: 100 # 100MB
 
@@ -90,7 +96,13 @@ executionapi:
   endpoints:
     - name: "local"
       url: "http://127.0.0.1:8545"
-  
+
+  # alternatively, load the endpoints list from a URL or file path (yaml list of endpoint objects).
+  # the source is re-fetched periodically and new endpoints are hot-added at runtime;
+  # changed or removed endpoints still require a restart.
+  #endpointsUrl: ""
+  #endpointsReloadInterval: 1h # 0 = default (1h), negative = disable reloading
+
   logBatchSize: 1000
   depositDeployBlock: 0 # el block number from where to crawl the deposit contract (should be <=, but close to the deposit contract deployment block)
   electraDeployBlock: 0 # el block number from where to crawl the electra system contracts (should be <=, but close to electra fork activation block)

--- a/indexer/beacon/client.go
+++ b/indexer/beacon/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -27,7 +28,7 @@ type Client struct {
 	index    uint16
 	client   *consensus.Client
 	logger   logrus.FieldLogger
-	indexing bool
+	indexing atomic.Bool
 
 	priority       int
 	archive        bool
@@ -44,11 +45,10 @@ type Client struct {
 // newClient creates a new indexer client for a given consensus pool client.
 func newClient(index uint16, client *consensus.Client, priority int, archive bool, skipValidators bool, indexer *Indexer, logger logrus.FieldLogger) *Client {
 	return &Client{
-		indexer:  indexer,
-		index:    index,
-		client:   client,
-		logger:   logger,
-		indexing: false,
+		indexer: indexer,
+		index:   index,
+		client:  client,
+		logger:  logger,
 
 		priority:       priority,
 		archive:        archive,
@@ -75,11 +75,9 @@ func (c *Client) GetIndex() uint16 {
 // startIndexing starts the indexing process for this client.
 // attaches block & head event handlers and starts the event processing subroutine.
 func (c *Client) startIndexing() {
-	if c.indexing {
+	if !c.indexing.CompareAndSwap(false, true) {
 		return
 	}
-
-	c.indexing = true
 
 	// single ordered subscription for block & head events to preserve SSE ordering
 	c.streamSubscription = c.client.SubscribeStreamEvent(100, true)

--- a/indexer/beacon/indexer.go
+++ b/indexer/beacon/indexer.go
@@ -55,6 +55,7 @@ type Indexer struct {
 	inclusionListCache *inclusionListCache
 
 	// indexer state
+	clientsMutex          sync.RWMutex
 	clients               []*Client
 	dbWriter              *dbWriter
 	running               bool
@@ -224,21 +225,33 @@ func (indexer *Indexer) awaitBackfillComplete(ctx context.Context, timeout time.
 }
 
 // AddClient adds a new consensus pool client to the indexer.
+// Clients added while the indexer is already running start indexing immediately.
 func (indexer *Indexer) AddClient(index uint16, client *consensus.Client, priority int, archive bool, skipValidators bool) *Client {
 	logger := indexer.logger.WithField("client", client.GetName())
 	indexerClient := newClient(index, client, priority, archive, skipValidators, indexer, logger)
+
+	indexer.clientsMutex.Lock()
 	indexer.clients = append(indexer.clients, indexerClient)
+	running := indexer.running
+	indexer.clientsMutex.Unlock()
+
+	if running {
+		indexerClient.startIndexing()
+	}
 
 	return indexerClient
 }
 
 // StartIndexer starts the indexing process.
 func (indexer *Indexer) StartIndexer() {
+	indexer.clientsMutex.Lock()
 	if indexer.running {
+		indexer.clientsMutex.Unlock()
 		return
 	}
 
 	indexer.running = true
+	indexer.clientsMutex.Unlock()
 	chainState := indexer.consensusPool.GetChainState()
 
 	// initialize dynamic SSZ encoder
@@ -450,7 +463,7 @@ func (indexer *Indexer) StartIndexer() {
 	indexer.blockBidCache.loadFromDB(chainState.CurrentSlot())
 
 	// start indexing for all clients
-	for _, client := range indexer.clients {
+	for _, client := range indexer.GetAllClients() {
 		client.startIndexing()
 	}
 

--- a/indexer/beacon/indexer_getter.go
+++ b/indexer/beacon/indexer_getter.go
@@ -25,6 +25,9 @@ func (indexer *Indexer) GetDynSSZ() *dynssz.DynSsz {
 
 // GetAllClients returns a slice of all clients in the indexer.
 func (indexer *Indexer) GetAllClients() []*Client {
+	indexer.clientsMutex.RLock()
+	defer indexer.clientsMutex.RUnlock()
+
 	clients := make([]*Client, len(indexer.clients))
 	copy(clients, indexer.clients)
 	return clients
@@ -36,7 +39,7 @@ func (indexer *Indexer) GetReadyClientsByCheckpoint(finalizedEpoch phase0.Epoch,
 
 	finalizedSlot := indexer.consensusPool.GetChainState().EpochToSlot(finalizedEpoch)
 
-	for _, client := range indexer.clients {
+	for _, client := range indexer.GetAllClients() {
 		if client.client.GetStatus() != consensus.ClientStatusOnline {
 			continue
 		}
@@ -83,7 +86,7 @@ func (indexer *Indexer) GetReadyClientsByCheckpoint(finalizedEpoch phase0.Epoch,
 func (indexer *Indexer) GetReadyClientsByBlockRoot(blockRoot phase0.Root, preferArchive bool) []*Client {
 	clients := make([]*Client, 0)
 
-	for _, client := range indexer.clients {
+	for _, client := range indexer.GetAllClients() {
 		if client.client.GetStatus() != consensus.ClientStatusOnline {
 			continue
 		}

--- a/indexer/beacon/synchronizer.go
+++ b/indexer/beacon/synchronizer.go
@@ -213,7 +213,7 @@ func (s *synchronizer) getSyncClients(epoch phase0.Epoch) []*Client {
 	archiveClients := make([]*Client, 0)
 	normalClients := make([]*Client, 0)
 
-	for _, client := range s.indexer.clients {
+	for _, client := range s.indexer.GetAllClients() {
 		if client.client.GetStatus() != consensus.ClientStatusOnline {
 			continue
 		}

--- a/indexer/execution/indexerctx.go
+++ b/indexer/execution/indexerctx.go
@@ -5,6 +5,7 @@ import (
 	"math/rand/v2"
 	"slices"
 	"sort"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethpandaops/dora/clients/consensus"
@@ -16,13 +17,14 @@ import (
 
 // IndexerCtx is the context for the execution indexer
 type IndexerCtx struct {
-	Ctx              context.Context
-	Logger           logrus.FieldLogger
-	BeaconIndexer    *beacon.Indexer
-	ExecutionPool    *execution.Pool
-	ConsensusPool    *consensus.Pool
-	ChainState       *consensus.ChainState
-	executionClients map[*execution.Client]*indexerElClientInfo
+	Ctx                   context.Context
+	Logger                logrus.FieldLogger
+	BeaconIndexer         *beacon.Indexer
+	ExecutionPool         *execution.Pool
+	ConsensusPool         *consensus.Pool
+	ChainState            *consensus.ChainState
+	executionClientsMutex sync.RWMutex
+	executionClients      map[*execution.Client]*indexerElClientInfo
 }
 
 // indexerElClientInfo holds information about a client and its priority
@@ -46,6 +48,9 @@ func NewIndexerCtx(ctx context.Context, logger logrus.FieldLogger, executionPool
 
 // AddClientInfo adds client info to the indexer context
 func (ictx *IndexerCtx) AddClientInfo(client *execution.Client, priority int, archive bool) {
+	ictx.executionClientsMutex.Lock()
+	defer ictx.executionClientsMutex.Unlock()
+
 	ictx.executionClients[client] = &indexerElClientInfo{
 		priority: priority,
 		archive:  archive,
@@ -92,8 +97,20 @@ func (ictx *IndexerCtx) GetClientsOnFork(forkId beacon.ForkKey, clientType execu
 // SortClients sorts clients by priority, but randomizes the order for equal priority.
 // Returns true if clientA should come before clientB.
 func (ictx *IndexerCtx) SortClients(clientA *execution.Client, clientB *execution.Client, preferArchive bool) bool {
+	ictx.executionClientsMutex.RLock()
 	clientAInfo := ictx.executionClients[clientA]
 	clientBInfo := ictx.executionClients[clientB]
+	ictx.executionClientsMutex.RUnlock()
+
+	// hot-added clients may briefly be visible in the pool before their info is registered
+	defaultInfo := &indexerElClientInfo{}
+	if clientAInfo == nil {
+		clientAInfo = defaultInfo
+	}
+
+	if clientBInfo == nil {
+		clientBInfo = defaultInfo
+	}
 
 	if preferArchive && clientAInfo.archive != clientBInfo.archive {
 		return clientAInfo.archive

--- a/services/chainservice.go
+++ b/services/chainservice.go
@@ -37,6 +37,7 @@ type ChainService struct {
 	logger                logrus.FieldLogger
 	consensusPool         *consensus.Pool
 	executionPool         *execution.Pool
+	executionIndexerCtx   *execindexer.IndexerCtx
 	beaconIndexer         *beacon.Indexer
 	validatorNames        *ValidatorNames
 	buildoorInventory     *BuildoorInventory
@@ -159,6 +160,82 @@ func applyAuthGroupToEndpoint(endpoint *types.EndpointConfig) (*types.EndpointCo
 	return &endpointCopy, nil
 }
 
+// addConsensusClient wires a beacon endpoint into the consensus pool and beacon indexer.
+// Safe to call while the service is running - hot-added clients start indexing immediately.
+func (cs *ChainService) addConsensusClient(endpoint *types.EndpointConfig) error {
+	processedEndpoint, err := applyAuthGroupToEndpoint(endpoint)
+	if err != nil {
+		return fmt.Errorf("could not apply authGroup: %w", err)
+	}
+
+	endpointConfig := &consensus.ClientConfig{
+		URL:        processedEndpoint.Url,
+		Name:       processedEndpoint.Name,
+		Headers:    processedEndpoint.Headers,
+		DisableSSZ: utils.Config.KillSwitch.DisableSSZRequests,
+	}
+
+	if processedEndpoint.Ssh != nil {
+		endpointConfig.SshConfig = &sshtunnel.SshConfig{
+			Host:     processedEndpoint.Ssh.Host,
+			Port:     processedEndpoint.Ssh.Port,
+			User:     processedEndpoint.Ssh.User,
+			Password: processedEndpoint.Ssh.Password,
+			Keyfile:  processedEndpoint.Ssh.Keyfile,
+		}
+	}
+
+	client, err := cs.consensusPool.AddEndpoint(endpointConfig)
+	if err != nil {
+		return fmt.Errorf("could not add to pool: %w", err)
+	}
+
+	cs.beaconIndexer.AddClient(client.GetIndex(), client, processedEndpoint.Priority, processedEndpoint.Archive, processedEndpoint.SkipValidators)
+
+	return nil
+}
+
+// addExecutionClient wires an execution endpoint into the execution pool and indexer context.
+// Safe to call while the service is running.
+func (cs *ChainService) addExecutionClient(endpoint *types.EndpointConfig) error {
+	processedEndpoint, err := applyAuthGroupToEndpoint(endpoint)
+	if err != nil {
+		return fmt.Errorf("could not apply authGroup: %w", err)
+	}
+
+	endpointConfig := &execution.ClientConfig{
+		URL:     processedEndpoint.Url,
+		Name:    processedEndpoint.Name,
+		Headers: processedEndpoint.Headers,
+	}
+
+	if processedEndpoint.Ssh != nil {
+		endpointConfig.SshConfig = &sshtunnel.SshConfig{
+			Host:     processedEndpoint.Ssh.Host,
+			Port:     processedEndpoint.Ssh.Port,
+			User:     processedEndpoint.Ssh.User,
+			Password: processedEndpoint.Ssh.Password,
+			Keyfile:  processedEndpoint.Ssh.Keyfile,
+		}
+	}
+
+	client, err := cs.executionPool.AddEndpoint(endpointConfig)
+	if err != nil {
+		return fmt.Errorf("could not add to pool: %w", err)
+	}
+
+	cs.executionIndexerCtx.AddClientInfo(client, processedEndpoint.Priority, processedEndpoint.Archive)
+
+	// Add snooper client if configured
+	if processedEndpoint.EngineSnooperUrl != "" {
+		if err := cs.snooperManager.AddClient(client, processedEndpoint.EngineSnooperUrl); err != nil {
+			cs.logger.WithError(err).Errorf("could not add snooper client for '%v'", processedEndpoint.Name)
+		}
+	}
+
+	return nil
+}
+
 // StartService is used to start the beaconchain service
 func (cs *ChainService) StartService() error {
 	if cs.started {
@@ -167,6 +244,7 @@ func (cs *ChainService) StartService() error {
 	cs.started = true
 
 	executionIndexerCtx := execindexer.NewIndexerCtx(cs.ctx, cs.logger.WithField("service", "el-indexer"), cs.executionPool, cs.consensusPool, cs.beaconIndexer)
+	cs.executionIndexerCtx = executionIndexerCtx
 
 	// load genesis config if configured
 	if utils.Config.ExecutionApi.GenesisConfig != "" {
@@ -180,38 +258,10 @@ func (cs *ChainService) StartService() error {
 	}
 
 	// add consensus clients
-	for index, endpoint := range utils.Config.BeaconApi.Endpoints {
-		// Apply authGroup settings if configured
-		processedEndpoint, err := applyAuthGroupToEndpoint(&endpoint)
-		if err != nil {
-			cs.logger.Errorf("could not apply authGroup to beacon client '%v': %v", endpoint.Name, err)
-			continue
+	for _, endpoint := range utils.Config.BeaconApi.Endpoints {
+		if err := cs.addConsensusClient(&endpoint); err != nil {
+			cs.logger.Errorf("could not add beacon client '%v': %v", endpoint.Name, err)
 		}
-
-		endpointConfig := &consensus.ClientConfig{
-			URL:        processedEndpoint.Url,
-			Name:       processedEndpoint.Name,
-			Headers:    processedEndpoint.Headers,
-			DisableSSZ: utils.Config.KillSwitch.DisableSSZRequests,
-		}
-
-		if processedEndpoint.Ssh != nil {
-			endpointConfig.SshConfig = &sshtunnel.SshConfig{
-				Host:     processedEndpoint.Ssh.Host,
-				Port:     processedEndpoint.Ssh.Port,
-				User:     processedEndpoint.Ssh.User,
-				Password: processedEndpoint.Ssh.Password,
-				Keyfile:  processedEndpoint.Ssh.Keyfile,
-			}
-		}
-
-		client, err := cs.consensusPool.AddEndpoint(endpointConfig)
-		if err != nil {
-			cs.logger.Errorf("could not add beacon client '%v' to pool: %v", processedEndpoint.Name, err)
-			continue
-		}
-
-		cs.beaconIndexer.AddClient(uint16(index), client, processedEndpoint.Priority, processedEndpoint.Archive, processedEndpoint.SkipValidators)
 	}
 
 	if len(cs.consensusPool.GetAllEndpoints()) == 0 {
@@ -220,42 +270,8 @@ func (cs *ChainService) StartService() error {
 
 	// add execution clients
 	for _, endpoint := range utils.Config.ExecutionApi.Endpoints {
-		// Apply authGroup settings if configured
-		processedEndpoint, err := applyAuthGroupToEndpoint(&endpoint)
-		if err != nil {
-			cs.logger.Errorf("could not apply authGroup to execution client '%v': %v", endpoint.Name, err)
-			continue
-		}
-
-		endpointConfig := &execution.ClientConfig{
-			URL:     processedEndpoint.Url,
-			Name:    processedEndpoint.Name,
-			Headers: processedEndpoint.Headers,
-		}
-
-		if processedEndpoint.Ssh != nil {
-			endpointConfig.SshConfig = &sshtunnel.SshConfig{
-				Host:     processedEndpoint.Ssh.Host,
-				Port:     processedEndpoint.Ssh.Port,
-				User:     processedEndpoint.Ssh.User,
-				Password: processedEndpoint.Ssh.Password,
-				Keyfile:  processedEndpoint.Ssh.Keyfile,
-			}
-		}
-
-		client, err := cs.executionPool.AddEndpoint(endpointConfig)
-		if err != nil {
-			cs.logger.Errorf("could not add execution client '%v' to pool: %v", processedEndpoint.Name, err)
-			continue
-		}
-
-		executionIndexerCtx.AddClientInfo(client, processedEndpoint.Priority, processedEndpoint.Archive)
-
-		// Add snooper client if configured
-		if processedEndpoint.EngineSnooperUrl != "" {
-			if err := cs.snooperManager.AddClient(client, processedEndpoint.EngineSnooperUrl); err != nil {
-				cs.logger.WithError(err).Errorf("could not add snooper client for '%v'", processedEndpoint.Name)
-			}
+		if err := cs.addExecutionClient(&endpoint); err != nil {
+			cs.logger.Errorf("could not add execution client '%v': %v", endpoint.Name, err)
 		}
 	}
 
@@ -395,6 +411,9 @@ func (cs *ChainService) StartService() error {
 	if utils.Config.EnsResolver.Enabled {
 		cs.ensResolver.StartUpdater()
 	}
+
+	// start watching endpointsUrl sources for new endpoints
+	cs.startEndpointsReloader()
 
 	return nil
 }

--- a/services/endpointsreloader.go
+++ b/services/endpointsreloader.go
@@ -1,0 +1,153 @@
+package services
+
+import (
+	"context"
+	"net/url"
+	"reflect"
+	"time"
+
+	"github.com/ethpandaops/dora/types"
+	"github.com/ethpandaops/dora/utils"
+	"github.com/sirupsen/logrus"
+)
+
+const defaultEndpointsReloadInterval = time.Hour
+
+// endpointsReloader periodically re-fetches an endpointsUrl source and hot-adds
+// endpoints that appear there, so new nodes show up without a restart.
+// Changed or removed endpoints only log a warning - applying those needs a restart.
+type endpointsReloader struct {
+	logger    logrus.FieldLogger
+	kind      string
+	sourceURL string
+	interval  time.Duration
+	addClient func(*types.EndpointConfig) error
+
+	known         map[string]types.EndpointConfig
+	removedWarned map[string]bool
+}
+
+func (cs *ChainService) startEndpointsReloader() {
+	if sourceURL := utils.Config.BeaconApi.EndpointsURL; sourceURL != "" {
+		if interval := endpointsReloadInterval(utils.Config.BeaconApi.EndpointsReloadInterval); interval > 0 {
+			reloader := newEndpointsReloader(cs.logger, "beacon", sourceURL, interval, utils.Config.BeaconApi.Endpoints, cs.addConsensusClient)
+			go reloader.run(cs.ctx)
+		}
+	}
+
+	if sourceURL := utils.Config.ExecutionApi.EndpointsURL; sourceURL != "" {
+		if interval := endpointsReloadInterval(utils.Config.ExecutionApi.EndpointsReloadInterval); interval > 0 {
+			reloader := newEndpointsReloader(cs.logger, "execution", sourceURL, interval, utils.Config.ExecutionApi.Endpoints, cs.addExecutionClient)
+			go reloader.run(cs.ctx)
+		}
+	}
+}
+
+func newEndpointsReloader(logger logrus.FieldLogger, kind string, sourceURL string, interval time.Duration, initial []types.EndpointConfig, addClient func(*types.EndpointConfig) error) *endpointsReloader {
+	// endpoints already wired (or attempted) at startup
+	known := make(map[string]types.EndpointConfig, len(initial))
+	for _, endpoint := range initial {
+		known[endpointName(&endpoint)] = endpoint
+	}
+
+	return &endpointsReloader{
+		logger:        logger.WithField("service", kind+"-endpoints-reloader"),
+		kind:          kind,
+		sourceURL:     sourceURL,
+		interval:      interval,
+		addClient:     addClient,
+		known:         known,
+		removedWarned: map[string]bool{},
+	}
+}
+
+// endpointsReloadInterval resolves the configured interval (0 = default, negative = disabled).
+func endpointsReloadInterval(configured time.Duration) time.Duration {
+	if configured == 0 {
+		return defaultEndpointsReloadInterval
+	}
+
+	if configured < 0 {
+		return 0
+	}
+
+	return configured
+}
+
+// endpointName mirrors the name defaulting applied on initial config load.
+func endpointName(endpoint *types.EndpointConfig) string {
+	if endpoint.Name != "" {
+		return endpoint.Name
+	}
+
+	if urlObj, err := url.Parse(endpoint.Url); err == nil {
+		return urlObj.Hostname()
+	}
+
+	return endpoint.Url
+}
+
+func (r *endpointsReloader) run(ctx context.Context) {
+	r.logger.Infof("watching %v for new endpoints (interval: %v)", r.sourceURL, r.interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(r.interval):
+		}
+
+		endpoints, err := utils.LoadEndpointsFromURL(r.sourceURL)
+		if err != nil {
+			r.logger.WithError(err).Errorf("failed to reload endpoints from %v", r.sourceURL)
+			continue
+		}
+
+		r.reconcile(endpoints)
+	}
+}
+
+// reconcile diffs the fetched endpoints against the known set and hot-adds new ones.
+func (r *endpointsReloader) reconcile(endpoints []types.EndpointConfig) {
+	if len(endpoints) == 0 {
+		r.logger.Warnf("endpoint source %v returned no endpoints, ignoring", r.sourceURL)
+		return
+	}
+
+	seen := make(map[string]bool, len(endpoints))
+
+	for _, endpoint := range endpoints {
+		name := endpointName(&endpoint)
+		seen[name] = true
+
+		if knownEndpoint, ok := r.known[name]; ok {
+			if r.removedWarned[name] {
+				delete(r.removedWarned, name)
+				r.logger.Infof("endpoint '%v' re-appeared in %v, client is still active", name, r.sourceURL)
+			}
+
+			if !reflect.DeepEqual(knownEndpoint, endpoint) {
+				r.logger.Warnf("endpoint '%v' changed in %v, applying the change requires a restart", name, r.sourceURL)
+				r.known[name] = endpoint
+			}
+
+			continue
+		}
+
+		if err := r.addClient(&endpoint); err != nil {
+			r.logger.WithError(err).Errorf("failed to add new %v endpoint '%v'", r.kind, name)
+			continue
+		}
+
+		r.known[name] = endpoint
+		r.logger.Infof("added new %v endpoint '%v' (%v)", r.kind, name, endpoint.Url)
+	}
+
+	// clients are never torn down at runtime, so removals only get a warning
+	for name := range r.known {
+		if !seen[name] && !r.removedWarned[name] {
+			r.logger.Warnf("endpoint '%v' removed from %v, client stays active until restart", name, r.sourceURL)
+			r.removedWarned[name] = true
+		}
+	}
+}

--- a/services/endpointsreloader_test.go
+++ b/services/endpointsreloader_test.go
@@ -1,0 +1,157 @@
+package services
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/dora/types"
+	"github.com/sirupsen/logrus"
+)
+
+func newTestReloader(initial []types.EndpointConfig, addClient func(*types.EndpointConfig) error) *endpointsReloader {
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	return newEndpointsReloader(logger, "beacon", "http://test/endpoints.yaml", time.Minute, initial, addClient)
+}
+
+func TestReconcileAddsNewEndpoints(t *testing.T) {
+	added := []string{}
+	reloader := newTestReloader(
+		[]types.EndpointConfig{{Name: "node-1", Url: "http://node-1"}},
+		func(endpoint *types.EndpointConfig) error {
+			added = append(added, endpoint.Name)
+			return nil
+		},
+	)
+
+	fetched := []types.EndpointConfig{
+		{Name: "node-1", Url: "http://node-1"},
+		{Name: "node-2", Url: "http://node-2"},
+	}
+
+	reloader.reconcile(fetched)
+
+	if len(added) != 1 || added[0] != "node-2" {
+		t.Fatalf("expected only node-2 to be added, got %v", added)
+	}
+
+	// second reconcile with the same list must not re-add
+	reloader.reconcile(fetched)
+
+	if len(added) != 1 {
+		t.Fatalf("expected no further adds on unchanged list, got %v", added)
+	}
+}
+
+func TestReconcileRetriesFailedAdds(t *testing.T) {
+	attempts := 0
+	reloader := newTestReloader(nil, func(endpoint *types.EndpointConfig) error {
+		attempts++
+		if attempts == 1 {
+			return fmt.Errorf("transient failure")
+		}
+		return nil
+	})
+
+	fetched := []types.EndpointConfig{{Name: "node-1", Url: "http://node-1"}}
+
+	reloader.reconcile(fetched)
+	reloader.reconcile(fetched)
+	reloader.reconcile(fetched)
+
+	if attempts != 2 {
+		t.Fatalf("expected failed add to be retried once then succeed, got %v attempts", attempts)
+	}
+}
+
+func TestReconcileChangedEndpointIsNotReadded(t *testing.T) {
+	added := 0
+	reloader := newTestReloader(
+		[]types.EndpointConfig{{Name: "node-1", Url: "http://node-1"}},
+		func(endpoint *types.EndpointConfig) error {
+			added++
+			return nil
+		},
+	)
+
+	reloader.reconcile([]types.EndpointConfig{{Name: "node-1", Url: "http://node-1-changed"}})
+
+	if added != 0 {
+		t.Fatalf("changed endpoint must not be re-added, got %v adds", added)
+	}
+
+	if reloader.known["node-1"].Url != "http://node-1-changed" {
+		t.Fatalf("changed endpoint config should be recorded to avoid repeated warnings")
+	}
+}
+
+func TestReconcileRemovalAndReappearance(t *testing.T) {
+	added := 0
+	reloader := newTestReloader(
+		[]types.EndpointConfig{
+			{Name: "node-1", Url: "http://node-1"},
+			{Name: "node-2", Url: "http://node-2"},
+		},
+		func(endpoint *types.EndpointConfig) error {
+			added++
+			return nil
+		},
+	)
+
+	// node-2 disappears from the source
+	reloader.reconcile([]types.EndpointConfig{{Name: "node-1", Url: "http://node-1"}})
+
+	if !reloader.removedWarned["node-2"] {
+		t.Fatalf("expected removal warning state for node-2")
+	}
+
+	// node-2 re-appears - its client was never torn down, so it must not be re-added
+	reloader.reconcile([]types.EndpointConfig{
+		{Name: "node-1", Url: "http://node-1"},
+		{Name: "node-2", Url: "http://node-2"},
+	})
+
+	if added != 0 {
+		t.Fatalf("re-appearing endpoint must not be re-added, got %v adds", added)
+	}
+
+	if reloader.removedWarned["node-2"] {
+		t.Fatalf("removal warning state should be cleared on re-appearance")
+	}
+}
+
+func TestReconcileIgnoresEmptyList(t *testing.T) {
+	reloader := newTestReloader(
+		[]types.EndpointConfig{{Name: "node-1", Url: "http://node-1"}},
+		func(endpoint *types.EndpointConfig) error { return nil },
+	)
+
+	reloader.reconcile([]types.EndpointConfig{})
+
+	if reloader.removedWarned["node-1"] {
+		t.Fatalf("an empty endpoint list must be ignored, not treated as mass removal")
+	}
+}
+
+func TestEndpointNameDefaultsToHostname(t *testing.T) {
+	name := endpointName(&types.EndpointConfig{Url: "https://bn-node-1.example.com:5052"})
+	if name != "bn-node-1.example.com" {
+		t.Fatalf("expected hostname default, got %v", name)
+	}
+}
+
+func TestEndpointsReloadInterval(t *testing.T) {
+	if endpointsReloadInterval(0) != defaultEndpointsReloadInterval {
+		t.Fatalf("zero should resolve to the default interval")
+	}
+
+	if endpointsReloadInterval(-1) != 0 {
+		t.Fatalf("negative should disable the reloader")
+	}
+
+	if endpointsReloadInterval(time.Hour) != time.Hour {
+		t.Fatalf("positive values should be used as-is")
+	}
+}

--- a/types/config.go
+++ b/types/config.go
@@ -102,7 +102,9 @@ type Config struct {
 		Endpoint     string           `yaml:"endpoint" envconfig:"BEACONAPI_ENDPOINT"`
 		Endpoints    []EndpointConfig `yaml:"endpoints"`
 		EndpointsURL string           `yaml:"endpointsUrl" envconfig:"BEACONAPI_ENDPOINTS_URL"`
-		ClientIndex  *int             `yaml:"clientIndex" envconfig:"BEACONAPI_CLIENT_INDEX"`
+		// interval to re-fetch endpointsUrl and hot-add new endpoints (0 = default 1h, negative = disabled)
+		EndpointsReloadInterval time.Duration `yaml:"endpointsReloadInterval" envconfig:"BEACONAPI_ENDPOINTS_RELOAD_INTERVAL"`
+		ClientIndex             *int          `yaml:"clientIndex" envconfig:"BEACONAPI_CLIENT_INDEX"`
 
 		LocalCacheSize       int    `yaml:"localCacheSize" envconfig:"BEACONAPI_LOCAL_CACHE_SIZE"`
 		SkipFinalAssignments bool   `yaml:"skipFinalAssignments" envconfig:"BEACONAPI_SKIP_FINAL_ASSIGNMENTS"`
@@ -115,6 +117,8 @@ type Config struct {
 		Endpoint     string           `yaml:"endpoint" envconfig:"EXECUTIONAPI_ENDPOINT"`
 		Endpoints    []EndpointConfig `yaml:"endpoints"`
 		EndpointsURL string           `yaml:"endpointsUrl" envconfig:"EXECUTIONAPI_ENDPOINTS_URL"`
+		// interval to re-fetch endpointsUrl and hot-add new endpoints (0 = default 1h, negative = disabled)
+		EndpointsReloadInterval time.Duration `yaml:"endpointsReloadInterval" envconfig:"EXECUTIONAPI_ENDPOINTS_RELOAD_INTERVAL"`
 
 		LogBatchSize       int    `yaml:"logBatchSize" envconfig:"EXECUTIONAPI_LOG_BATCH_SIZE"`
 		DepositDeployBlock int    `yaml:"depositDeployBlock" envconfig:"EXECUTIONAPI_DEPOSIT_DEPLOY_BLOCK"` // el block number from where to crawl the deposit system contract (should be <=, but close to deposit contract deployment)

--- a/utils/config.go
+++ b/utils/config.go
@@ -29,7 +29,7 @@ func ReadConfig(cfg *types.Config, path string) error {
 
 	// Load beacon endpoints from URL if specified
 	if cfg.BeaconApi.EndpointsURL != "" && len(cfg.BeaconApi.Endpoints) == 0 {
-		endpoints, err := loadEndpointsFromUrl(cfg.BeaconApi.EndpointsURL)
+		endpoints, err := LoadEndpointsFromURL(cfg.BeaconApi.EndpointsURL)
 		if err != nil {
 			return fmt.Errorf("failed to load beacon endpoints from URL: %w", err)
 		}
@@ -68,7 +68,7 @@ func ReadConfig(cfg *types.Config, path string) error {
 
 	// Load execution endpoints from URL if specified
 	if cfg.ExecutionApi.EndpointsURL != "" && len(cfg.ExecutionApi.Endpoints) == 0 {
-		endpoints, err := loadEndpointsFromUrl(cfg.ExecutionApi.EndpointsURL)
+		endpoints, err := LoadEndpointsFromURL(cfg.ExecutionApi.EndpointsURL)
 		if err != nil {
 			return fmt.Errorf("failed to load execution endpoints from URL: %w", err)
 		}
@@ -121,8 +121,8 @@ func readConfigEnv(cfg *types.Config) error {
 	return envconfig.Process("", cfg)
 }
 
-// loadEndpointsFromUrl loads endpoint configurations from a URL or file path
-func loadEndpointsFromUrl(endpointsURL string) ([]types.EndpointConfig, error) {
+// LoadEndpointsFromURL loads endpoint configurations from a URL or file path
+func LoadEndpointsFromURL(endpointsURL string) ([]types.EndpointConfig, error) {
 	var data []byte
 	var err error
 


### PR DESCRIPTION
## Problem

When endpoints are loaded via `beaconapi.endpointsUrl` / `executionapi.endpointsUrl`, dora fetches the source **once at startup**. Adding nodes to a devnet means the endpoints file changes on GitHub, but the running dora never sees them — it needs a restart, and everything downstream of the client API (e.g. cartographoor → ethpandaops.io instances tab) stays stale. This bit us on glamsterdam-devnet-7: 15 new nodes were live for hours while dora kept showing the old 20.

## Change

Re-fetch the `endpointsUrl` source periodically and **hot-add** new endpoints at runtime:

- New setting `endpointsReloadInterval` under both `beaconapi` and `executionapi` — `0` = default (1h), negative = disable. Only active when `endpointsUrl` is set.
- Per-endpoint wiring extracted from `StartService` into `addConsensusClient` / `addExecutionClient`, shared by startup and the reloader (authGroups, ssh tunnels and engine snoopers all work for hot-added endpoints).
- Beacon indexer clients added while the indexer is running start indexing immediately; the indexer client id now uses the pool-assigned index so hot-added clients stay unique.
- Concurrency: the pool client slices, beacon indexer client list and execution client info map were add-once-at-startup — they now have proper locking (`GetAllEndpoints`/`GetAllClients` return snapshots, `startIndexing` is CAS-idempotent, `SortClients` tolerates the brief pool-visible-but-unregistered window).
- **Changed or removed endpoints are not applied** — the running client stays active and a warning is logged once (client teardown has no code path today). A re-appearing endpoint is recognized as still-wired, so a flapping source can't create duplicate clients. An empty fetch result is ignored rather than treated as mass removal.

## Testing

- Unit tests for the reconcile logic (add / retry-on-failure / changed / removed+re-appeared / empty list); full suite + `go vet` green, services package passes with `-race`.
- Live smoke test against glamsterdam-devnet-7 endpoints with a file-based `endpointsUrl` at 15s interval: appending an endpoint produced `added new beacon endpoint 'lighthouse-besu-1'` within one tick and the client showed up **online** in `/api/v1/clients/consensus`; removal logged the stays-active warning; re-adding it did not create a duplicate.