### PR TITLE
Show all slot bids with parent tuple classification on slot details page

### DIFF
--- a/db/block_bids.go
+++ b/db/block_bids.go
@@ -64,24 +64,25 @@ func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 	return nil
 }
 
-func GetBidsForBlockRoot(ctx context.Context, blockRoot []byte, slot uint64) []*dbtypes.BlockBid {
+// GetBidsForSlot returns all bids for a slot regardless of their parent root,
+// so bids targeting other forks or deeper ancestors (reorg bids) are included.
+func GetBidsForSlot(ctx context.Context, slot uint64) []*dbtypes.BlockBid {
 	var sql strings.Builder
 	args := []any{
-		blockRoot,
 		slot,
 	}
 	fmt.Fprint(&sql, `
 	SELECT
 		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment
 	FROM block_bids
-	WHERE parent_root = $1 AND slot = $2
+	WHERE slot = $1
 	ORDER BY value DESC
 	`)
 
 	bids := []*dbtypes.BlockBid{}
 	err := ReaderDb.SelectContext(ctx, &bids, sql.String(), args...)
 	if err != nil {
-		logger.Errorf("Error while fetching bids for block root: %v", err)
+		logger.Errorf("Error while fetching bids for slot: %v", err)
 		return nil
 	}
 	return bids

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1256,7 +1256,7 @@ const docTemplate = `{
         },
         "/v1/slot/{slotOrHash}/bids": {
             "get": {
-                "description": "Returns the execution payload bids submitted for a slot's parent root (ePBS, gloas+).",
+                "description": "Returns all execution payload bids submitted for a slot (ePBS, gloas+), including bids targeting other forks or deeper ancestors (reorg bids). Each bid is classified against the slot's actual block parent chain.",
                 "produces": [
                     "application/json"
                 ],
@@ -4225,6 +4225,18 @@ const docTemplate = `{
                 "builder_name": {
                     "type": "string"
                 },
+                "candidate_key": {
+                    "description": "CandidateKey is the buildoor-style candidate identifier (parent_full, parent_empty,\ngrandparent_full, grandparent_empty, ancestor-N_full/-empty); empty for orphaned-fork\nand unknown-parent bids.",
+                    "type": "string"
+                },
+                "el_parent_slot": {
+                    "description": "ElParentSlot is the slot whose payload block hash matches the bid's parent hash,\ni.e. the EL head the bid builds on (omitted if not resolvable).",
+                    "type": "integer"
+                },
+                "el_parent_unrevealed": {
+                    "description": "ElParentUnrevealed: the bid's parent hash matches a committed payload hash that was\nnever revealed - such a bid can never become valid.",
+                    "type": "boolean"
+                },
                 "el_payment": {
                     "type": "integer"
                 },
@@ -4240,11 +4252,26 @@ const docTemplate = `{
                 "is_winning": {
                     "type": "boolean"
                 },
+                "parent_class": {
+                    "description": "Bid target classification relative to the slot's actual block parent chain.\nParentClass: \"parent\" (targets the block's actual beacon parent), \"reorg\" (targets a\ndeeper ancestor, orphaning ReorgDepth blocks), \"orphaned\" (targets a block outside\nthe block's chain), \"unknown\" (parent root not resolvable).",
+                    "type": "string"
+                },
+                "parent_full": {
+                    "description": "ParentFull: the bid builds on the targeted block's own payload (full) rather than an\nearlier payload (empty).",
+                    "type": "boolean"
+                },
                 "parent_hash": {
                     "type": "string"
                 },
                 "parent_root": {
                     "type": "string"
+                },
+                "parent_slot": {
+                    "description": "ParentSlot is the slot of the targeted beacon parent block (0 if unknown).",
+                    "type": "integer"
+                },
+                "reorg_depth": {
+                    "type": "integer"
                 },
                 "slot": {
                     "type": "integer"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1253,7 +1253,7 @@
         },
         "/v1/slot/{slotOrHash}/bids": {
             "get": {
-                "description": "Returns the execution payload bids submitted for a slot's parent root (ePBS, gloas+).",
+                "description": "Returns all execution payload bids submitted for a slot (ePBS, gloas+), including bids targeting other forks or deeper ancestors (reorg bids). Each bid is classified against the slot's actual block parent chain.",
                 "produces": [
                     "application/json"
                 ],
@@ -4222,6 +4222,18 @@
                 "builder_name": {
                     "type": "string"
                 },
+                "candidate_key": {
+                    "description": "CandidateKey is the buildoor-style candidate identifier (parent_full, parent_empty,\ngrandparent_full, grandparent_empty, ancestor-N_full/-empty); empty for orphaned-fork\nand unknown-parent bids.",
+                    "type": "string"
+                },
+                "el_parent_slot": {
+                    "description": "ElParentSlot is the slot whose payload block hash matches the bid's parent hash,\ni.e. the EL head the bid builds on (omitted if not resolvable).",
+                    "type": "integer"
+                },
+                "el_parent_unrevealed": {
+                    "description": "ElParentUnrevealed: the bid's parent hash matches a committed payload hash that was\nnever revealed - such a bid can never become valid.",
+                    "type": "boolean"
+                },
                 "el_payment": {
                     "type": "integer"
                 },
@@ -4237,11 +4249,26 @@
                 "is_winning": {
                     "type": "boolean"
                 },
+                "parent_class": {
+                    "description": "Bid target classification relative to the slot's actual block parent chain.\nParentClass: \"parent\" (targets the block's actual beacon parent), \"reorg\" (targets a\ndeeper ancestor, orphaning ReorgDepth blocks), \"orphaned\" (targets a block outside\nthe block's chain), \"unknown\" (parent root not resolvable).",
+                    "type": "string"
+                },
+                "parent_full": {
+                    "description": "ParentFull: the bid builds on the targeted block's own payload (full) rather than an\nearlier payload (empty).",
+                    "type": "boolean"
+                },
                 "parent_hash": {
                     "type": "string"
                 },
                 "parent_root": {
                     "type": "string"
+                },
+                "parent_slot": {
+                    "description": "ParentSlot is the slot of the targeted beacon parent block (0 if unknown).",
+                    "type": "integer"
+                },
+                "reorg_depth": {
+                    "type": "integer"
                 },
                 "slot": {
                     "type": "integer"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1141,6 +1141,22 @@ definitions:
         type: integer
       builder_name:
         type: string
+      candidate_key:
+        description: |-
+          CandidateKey is the buildoor-style candidate identifier (parent_full, parent_empty,
+          grandparent_full, grandparent_empty, ancestor-N_full/-empty); empty for orphaned-fork
+          and unknown-parent bids.
+        type: string
+      el_parent_slot:
+        description: |-
+          ElParentSlot is the slot whose payload block hash matches the bid's parent hash,
+          i.e. the EL head the bid builds on (omitted if not resolvable).
+        type: integer
+      el_parent_unrevealed:
+        description: |-
+          ElParentUnrevealed: the bid's parent hash matches a committed payload hash that was
+          never revealed - such a bid can never become valid.
+        type: boolean
       el_payment:
         type: integer
       fee_recipient:
@@ -1151,10 +1167,28 @@ definitions:
         type: boolean
       is_winning:
         type: boolean
+      parent_class:
+        description: |-
+          Bid target classification relative to the slot's actual block parent chain.
+          ParentClass: "parent" (targets the block's actual beacon parent), "reorg" (targets a
+          deeper ancestor, orphaning ReorgDepth blocks), "orphaned" (targets a block outside
+          the block's chain), "unknown" (parent root not resolvable).
+        type: string
+      parent_full:
+        description: |-
+          ParentFull: the bid builds on the targeted block's own payload (full) rather than an
+          earlier payload (empty).
+        type: boolean
       parent_hash:
         type: string
       parent_root:
         type: string
+      parent_slot:
+        description: ParentSlot is the slot of the targeted beacon parent block (0
+          if unknown).
+        type: integer
+      reorg_depth:
+        type: integer
       slot:
         type: integer
       total_value:
@@ -2839,8 +2873,9 @@ paths:
       - Slot
   /v1/slot/{slotOrHash}/bids:
     get:
-      description: Returns the execution payload bids submitted for a slot's parent
-        root (ePBS, gloas+).
+      description: Returns all execution payload bids submitted for a slot (ePBS,
+        gloas+), including bids targeting other forks or deeper ancestors (reorg bids).
+        Each bid is classified against the slot's actual block parent chain.
       operationId: getSlotBids
       parameters:
       - description: Slot number or block root (0x-prefixed hex)

--- a/handlers/api/slot_bids_v1.go
+++ b/handlers/api/slot_bids_v1.go
@@ -93,7 +93,12 @@ func APISlotBidsV1(w http.ResponseWriter, r *http.Request) {
 
 	apiBids := make([]*APISlotBid, 0, len(bids))
 	for _, bid := range bids {
-		isWinning := len(dbSlot.EthBlockHash) > 0 && bytes.Equal(bid.BlockHash, dbSlot.EthBlockHash)
+		// The winner is the exact bid committed in the block: several builders may bid the
+		// same block hash, so the builder index and parent root must match too.
+		isWinning := len(dbSlot.EthBlockHash) > 0 &&
+			bytes.Equal(bid.BlockHash, dbSlot.EthBlockHash) &&
+			bid.BuilderIndex == dbSlot.BuilderIndex &&
+			bytes.Equal(bid.ParentRoot, dbSlot.ParentRoot)
 
 		// Dora's bid indexer casts the on-chain uint64 BuilderIndex to int64 and
 		// uses -1 (== MaxUint64 reinterpreted) as a "self-built" sentinel. Surface

--- a/handlers/api/slot_bids_v1.go
+++ b/handlers/api/slot_bids_v1.go
@@ -42,11 +42,33 @@ type APISlotBid struct {
 	ElPayment    uint64 `json:"el_payment"`
 	TotalValue   uint64 `json:"total_value"`
 	IsWinning    bool   `json:"is_winning"`
+
+	// Bid target classification relative to the slot's actual block parent chain.
+	// ParentClass: "parent" (targets the block's actual beacon parent), "reorg" (targets a
+	// deeper ancestor, orphaning ReorgDepth blocks), "orphaned" (targets a block outside
+	// the block's chain), "unknown" (parent root not resolvable).
+	ParentClass string `json:"parent_class"`
+	// ParentFull: the bid builds on the targeted block's own payload (full) rather than an
+	// earlier payload (empty).
+	ParentFull bool   `json:"parent_full"`
+	ReorgDepth uint64 `json:"reorg_depth,omitempty"`
+	// ParentSlot is the slot of the targeted beacon parent block (0 if unknown).
+	ParentSlot uint64 `json:"parent_slot,omitempty"`
+	// ElParentSlot is the slot whose payload block hash matches the bid's parent hash,
+	// i.e. the EL head the bid builds on (omitted if not resolvable).
+	ElParentSlot *uint64 `json:"el_parent_slot,omitempty"`
+	// ElParentUnrevealed: the bid's parent hash matches a committed payload hash that was
+	// never revealed - such a bid can never become valid.
+	ElParentUnrevealed bool `json:"el_parent_unrevealed,omitempty"`
+	// CandidateKey is the buildoor-style candidate identifier (parent_full, parent_empty,
+	// grandparent_full, grandparent_empty, ancestor-N_full/-empty); empty for orphaned-fork
+	// and unknown-parent bids.
+	CandidateKey string `json:"candidate_key,omitempty"`
 }
 
 // APISlotBidsV1 returns all execution payload bids submitted for a slot (ePBS, EIP-7732)
 // @Summary Get execution payload bids for a slot
-// @Description Returns the execution payload bids submitted for a slot's parent root (ePBS, gloas+).
+// @Description Returns all execution payload bids submitted for a slot (ePBS, gloas+), including bids targeting other forks or deeper ancestors (reorg bids). Each bid is classified against the slot's actual block parent chain.
 // @Tags Slot
 // @Produce json
 // @Param slotOrHash path string true "Slot number or block root (0x-prefixed hex)"
@@ -65,10 +87,9 @@ func APISlotBidsV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	indexer := services.GlobalBeaconService.GetBeaconIndexer()
 	var parentRoot phase0.Root
 	copy(parentRoot[:], dbSlot.ParentRoot)
-	bids := indexer.GetBlockBids(parentRoot, phase0.Slot(dbSlot.Slot))
+	bids := services.GlobalBeaconService.GetSlotBidsClassified(r.Context(), phase0.Slot(dbSlot.Slot), parentRoot)
 
 	apiBids := make([]*APISlotBid, 0, len(bids))
 	for _, bid := range bids {
@@ -84,24 +105,43 @@ func APISlotBidsV1(w http.ResponseWriter, r *http.Request) {
 			builderName = services.GlobalBeaconService.GetValidatorName(builderIndexU | services.BuilderIndexFlag)
 		}
 
-		apiBids = append(apiBids, &APISlotBid{
-			ParentRoot:   fmt.Sprintf("0x%x", bid.ParentRoot),
-			ParentHash:   fmt.Sprintf("0x%x", bid.ParentHash),
-			BlockHash:    fmt.Sprintf("0x%x", bid.BlockHash),
-			FeeRecipient: fmt.Sprintf("0x%x", bid.FeeRecipient),
-			GasLimit:     bid.GasLimit,
-			BuilderIndex: builderIndexU,
-			BuilderName:  builderName,
-			IsSelfBuilt:  isSelfBuilt,
-			Slot:         bid.Slot,
-			Value:        bid.Value,
-			ElPayment:    bid.ElPayment,
-			TotalValue:   bid.Value + bid.ElPayment,
-			IsWinning:    isWinning,
-		})
+		apiBid := &APISlotBid{
+			ParentRoot:         fmt.Sprintf("0x%x", bid.ParentRoot),
+			ParentHash:         fmt.Sprintf("0x%x", bid.ParentHash),
+			BlockHash:          fmt.Sprintf("0x%x", bid.BlockHash),
+			FeeRecipient:       fmt.Sprintf("0x%x", bid.FeeRecipient),
+			GasLimit:           bid.GasLimit,
+			BuilderIndex:       builderIndexU,
+			BuilderName:        builderName,
+			IsSelfBuilt:        isSelfBuilt,
+			Slot:               bid.Slot,
+			Value:              bid.Value,
+			ElPayment:          bid.ElPayment,
+			TotalValue:         bid.Value + bid.ElPayment,
+			IsWinning:          isWinning,
+			ParentClass:        bid.ParentClass.String(),
+			ParentFull:         bid.ParentFull,
+			ReorgDepth:         bid.ReorgDepth,
+			ParentSlot:         bid.ParentSlot,
+			ElParentUnrevealed: bid.ElParentUnrevealed,
+			CandidateKey:       bidCandidateKey(bid),
+		}
+		if bid.ElParentKnown {
+			elParentSlot := bid.ElParentSlot
+			apiBid.ElParentSlot = &elParentSlot
+		}
+
+		apiBids = append(apiBids, apiBid)
 	}
 
+	// Bids for the block's actual parent root first, then bids targeting other parents
+	// (reorg/fork bids); within each group sorted by total value descending.
 	sort.SliceStable(apiBids, func(i, j int) bool {
+		iParent := apiBids[i].ParentClass == "parent"
+		jParent := apiBids[j].ParentClass == "parent"
+		if iParent != jParent {
+			return iParent
+		}
 		return apiBids[i].TotalValue > apiBids[j].TotalValue
 	})
 
@@ -119,4 +159,27 @@ func APISlotBidsV1(w http.ResponseWriter, r *http.Request) {
 		logrus.WithError(err).Error("failed to encode slot bids response")
 		http.Error(w, `{"status": "ERROR: failed to encode response"}`, http.StatusInternalServerError)
 	}
+}
+
+// bidCandidateKey maps a classified bid onto the candidate keys used by build tooling
+// (parent_full, parent_empty, grandparent_full, grandparent_empty, ancestor-N_full/-empty).
+func bidCandidateKey(bid *services.ClassifiedBlockBid) string {
+	var position string
+	switch bid.ParentClass {
+	case services.BidParentClassParent:
+		position = "parent"
+	case services.BidParentClassReorg:
+		if bid.ReorgDepth == 1 {
+			position = "grandparent"
+		} else {
+			position = fmt.Sprintf("ancestor-%v", bid.ReorgDepth+1)
+		}
+	default:
+		return ""
+	}
+
+	if bid.ParentFull {
+		return position + "_full"
+	}
+	return position + "_empty"
 }

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1123,7 +1124,7 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 
 	// Load execution payload bids for ePBS (gloas+) blocks
 	if blockData.Block.Version >= spec.DataVersionGloas {
-		getSlotPageBids(pageData, blockData.Header.Message.Slot)
+		getSlotPageBids(ctx, pageData, blockData.Header.Message.Slot)
 		getSlotPagePtcVotes(pageData, blockData, blockData.Header.Message.Slot)
 	}
 
@@ -1510,16 +1511,18 @@ func getSlotPageExecutionProofs(pageData *models.SlotPageBlockData, blockRoot ph
 	pageData.ExecutionProofsCount = uint64(len(pageData.ExecutionProofs))
 }
 
-func getSlotPageBids(pageData *models.SlotPageBlockData, blockSlot phase0.Slot) {
-	beaconIndexer := services.GlobalBeaconService.GetBeaconIndexer()
-	bids := beaconIndexer.GetBlockBids(phase0.Root(pageData.ParentRoot), blockSlot)
+func getSlotPageBids(ctx context.Context, pageData *models.SlotPageBlockData, blockSlot phase0.Slot) {
+	bids := services.GlobalBeaconService.GetSlotBidsClassified(ctx, blockSlot, phase0.Root(pageData.ParentRoot))
 
 	pageData.Bids = make([]*models.SlotPageBid, 0, len(bids))
 
-	// Get the winning block hash for comparison
+	// Get the winning block hash for comparison. For blocks with a missed payload there is
+	// no execution data, but the committed bid (payload header) still identifies the winner.
 	var winningBlockHash []byte
 	if pageData.ExecutionData != nil {
 		winningBlockHash = pageData.ExecutionData.BlockHash
+	} else if pageData.PayloadHeader != nil {
+		winningBlockHash = pageData.PayloadHeader.BlockHash
 	}
 
 	for _, bid := range bids {
@@ -1537,33 +1540,79 @@ func getSlotPageBids(pageData *models.SlotPageBlockData, blockSlot phase0.Slot) 
 			Value:        bid.Value,
 			ElPayment:    bid.ElPayment,
 			TotalValue:   bid.Value + bid.ElPayment,
+			IsWinning:    winningBlockHash != nil && bytes.Equal(bid.BlockHash, winningBlockHash),
+			ParentSlot:   bid.ParentSlot,
+			ParentKnown:  bid.ParentKnown,
+			IsParentBid:  bid.ParentClass == services.BidParentClassParent,
 		}
-
-		// Check if this is the winning bid
-		if winningBlockHash != nil && len(bid.BlockHash) == len(winningBlockHash) {
-			isWinning := true
-			for i := range bid.BlockHash {
-				if bid.BlockHash[i] != winningBlockHash[i] {
-					isWinning = false
-					break
-				}
-			}
-			bidData.IsWinning = isWinning
-		}
+		bidData.ClassLabel, bidData.ClassColor, bidData.ClassTitle = describeBidClass(bid)
 
 		pageData.Bids = append(pageData.Bids, bidData)
 	}
 
-	// Sort by total value (value + el_payment) descending
-	for i := 0; i < len(pageData.Bids)-1; i++ {
-		for j := i + 1; j < len(pageData.Bids); j++ {
-			if pageData.Bids[j].TotalValue > pageData.Bids[i].TotalValue {
-				pageData.Bids[i], pageData.Bids[j] = pageData.Bids[j], pageData.Bids[i]
+	// Bids for the block's actual parent root first, then bids targeting other parents
+	// (reorg/fork bids); within each group sorted by total value (value + el_payment) descending.
+	sort.SliceStable(pageData.Bids, func(i, j int) bool {
+		if pageData.Bids[i].IsParentBid != pageData.Bids[j].IsParentBid {
+			return pageData.Bids[i].IsParentBid
+		}
+		return pageData.Bids[i].TotalValue > pageData.Bids[j].TotalValue
+	})
+
+	pageData.BidsCount = uint64(len(pageData.Bids))
+}
+
+// describeBidClass derives the display label, badge color and tooltip for a classified bid.
+func describeBidClass(bid *services.ClassifiedBlockBid) (label, color, title string) {
+	fullness := "empty"
+	if bid.ParentFull {
+		fullness = "full"
+	}
+
+	switch bid.ParentClass {
+	case services.BidParentClassParent:
+		label = fmt.Sprintf("parent (%s)", fullness)
+		if bid.ParentFull {
+			color = "success"
+			title = fmt.Sprintf("Builds on the block's actual parent (slot %v) and its payload", bid.ParentSlot)
+		} else {
+			color = "warning"
+			title = fmt.Sprintf("Builds on the block's actual parent (slot %v), treating its payload as withheld", bid.ParentSlot)
+		}
+	case services.BidParentClassReorg:
+		if bid.ReorgDepth == 1 {
+			label = fmt.Sprintf("grandparent (%s)", fullness)
+		} else {
+			label = fmt.Sprintf("reorg -%v (%s)", bid.ReorgDepth+1, fullness)
+		}
+		if bid.ParentFull {
+			color = "purple"
+		} else {
+			color = "secondary"
+		}
+		title = fmt.Sprintf("Reorg bid: builds on the ancestor at slot %v, orphaning %v block(s)", bid.ParentSlot, bid.ReorgDepth)
+	case services.BidParentClassOrphaned:
+		label = fmt.Sprintf("orphaned fork (%s)", fullness)
+		color = "dark"
+		title = fmt.Sprintf("Builds on a block at slot %v that is not part of this block's chain", bid.ParentSlot)
+	default:
+		label = "unknown parent"
+		color = "danger"
+		title = "The bid's parent block root does not match any known block in the preceding slots"
+	}
+
+	if !bid.ParentFull && bid.ParentClass != services.BidParentClassUnknown {
+		if bid.ElParentKnown {
+			title += fmt.Sprintf("; EL head: payload of slot %v", bid.ElParentSlot)
+			if bid.ElParentUnrevealed {
+				title += " (never revealed - invalid parent hash)"
 			}
+		} else {
+			title += "; EL head: unknown payload"
 		}
 	}
 
-	pageData.BidsCount = uint64(len(pageData.Bids))
+	return label, color, title
 }
 
 // getSlotPagePtcVotes extracts PTC (Payload Timeliness Committee) votes from a Gloas block.

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -1516,13 +1516,17 @@ func getSlotPageBids(ctx context.Context, pageData *models.SlotPageBlockData, bl
 
 	pageData.Bids = make([]*models.SlotPageBid, 0, len(bids))
 
-	// Get the winning block hash for comparison. For blocks with a missed payload there is
-	// no execution data, but the committed bid (payload header) still identifies the winner.
-	var winningBlockHash []byte
-	if pageData.ExecutionData != nil {
-		winningBlockHash = pageData.ExecutionData.BlockHash
-	} else if pageData.PayloadHeader != nil {
-		winningBlockHash = pageData.PayloadHeader.BlockHash
+	// The winner is the exact bid committed in the block (payload header): several builders
+	// may bid the same block hash, so the builder index and parent tuple must match too.
+	winningBid := pageData.PayloadHeader
+	isWinningBid := func(bid *services.ClassifiedBlockBid) bool {
+		if winningBid == nil {
+			return false
+		}
+		return uint64(bid.BuilderIndex) == winningBid.BuilderIndex &&
+			bytes.Equal(bid.BlockHash, winningBid.BlockHash) &&
+			bytes.Equal(bid.ParentRoot, winningBid.ParentBlockRoot) &&
+			bytes.Equal(bid.ParentHash, winningBid.ParentBlockHash)
 	}
 
 	for _, bid := range bids {
@@ -1540,7 +1544,7 @@ func getSlotPageBids(ctx context.Context, pageData *models.SlotPageBlockData, bl
 			Value:        bid.Value,
 			ElPayment:    bid.ElPayment,
 			TotalValue:   bid.Value + bid.ElPayment,
-			IsWinning:    winningBlockHash != nil && bytes.Equal(bid.BlockHash, winningBlockHash),
+			IsWinning:    isWinningBid(bid),
 			ParentSlot:   bid.ParentSlot,
 			ParentKnown:  bid.ParentKnown,
 			IsParentBid:  bid.ParentClass == services.BidParentClassParent,

--- a/indexer/beacon/bidcache.go
+++ b/indexer/beacon/bidcache.go
@@ -117,16 +117,15 @@ func (cache *blockBidCache) AddBid(bid *dbtypes.BlockBid) bool {
 	return true
 }
 
-// GetBidsForBlockRoot returns all bids for a given parent block root and slot.
-// Filtering by slot is required because orphaned/skipped predecessor slots share
-// the same parent root as the canonical block that ends up replacing them.
-func (cache *blockBidCache) GetBidsForBlockRoot(blockRoot phase0.Root, slot phase0.Slot) []*dbtypes.BlockBid {
+// GetBidsForSlot returns all cached bids for a slot regardless of their parent root,
+// so bids targeting other forks or deeper ancestors (reorg bids) are included.
+func (cache *blockBidCache) GetBidsForSlot(slot phase0.Slot) []*dbtypes.BlockBid {
 	cache.cacheMutex.RLock()
 	defer cache.cacheMutex.RUnlock()
 
 	result := make([]*dbtypes.BlockBid, 0)
-	for key, bid := range cache.bids {
-		if key.ParentRoot == blockRoot && phase0.Slot(bid.Slot) == slot {
+	for _, bid := range cache.bids {
+		if phase0.Slot(bid.Slot) == slot {
 			result = append(result, bid)
 		}
 	}

--- a/indexer/beacon/indexer_getter.go
+++ b/indexer/beacon/indexer_getter.go
@@ -537,19 +537,35 @@ func (indexer *Indexer) GetInclusionListsBySlot(slot phase0.Slot) []*v1.SignedIn
 	return indexer.inclusionListCache.getInclusionListsBySlot(slot)
 }
 
-// GetBlockBids returns the execution payload bids for a given parent block root and slot.
-// It first checks the in-memory cache, then falls back to the database.
-// Filtering by slot is required because orphaned/skipped predecessor slots share
-// the same parent root as the canonical block that ends up replacing them.
-func (indexer *Indexer) GetBlockBids(parentBlockRoot phase0.Root, slot phase0.Slot) []*dbtypes.BlockBid {
-	// First check the in-memory cache
-	bids := indexer.blockBidCache.GetBidsForBlockRoot(parentBlockRoot, slot)
-	if len(bids) > 0 {
-		return bids
+// GetBlockBidsForSlot returns all execution payload bids for a slot regardless of their
+// parent root, so bids targeting other forks or deeper ancestors (reorg bids) are included.
+// Cache and DB results are merged since a slot's bids can be spread across both around a flush.
+func (indexer *Indexer) GetBlockBidsForSlot(slot phase0.Slot) []*dbtypes.BlockBid {
+	bids := indexer.blockBidCache.GetBidsForSlot(slot)
+
+	seenBids := make(map[bidCacheKey]bool, len(bids))
+	for _, bid := range bids {
+		seenBids[bidCacheKey{
+			ParentRoot:   phase0.Root(bid.ParentRoot),
+			ParentHash:   phase0.Hash32(bid.ParentHash),
+			BlockHash:    phase0.Hash32(bid.BlockHash),
+			BuilderIndex: bid.BuilderIndex,
+		}] = true
 	}
 
-	// Fall back to database
-	return db.GetBidsForBlockRoot(indexer.ctx, parentBlockRoot[:], uint64(slot))
+	for _, bid := range db.GetBidsForSlot(indexer.ctx, uint64(slot)) {
+		key := bidCacheKey{
+			ParentRoot:   phase0.Root(bid.ParentRoot),
+			ParentHash:   phase0.Hash32(bid.ParentHash),
+			BlockHash:    phase0.Hash32(bid.BlockHash),
+			BuilderIndex: bid.BuilderIndex,
+		}
+		if !seenBids[key] {
+			bids = append(bids, bid)
+		}
+	}
+
+	return bids
 }
 
 // GetCachedBidsByBuilderIndex returns the not-yet-flushed (recent) bids for a builder index within

--- a/services/chainservice_bids.go
+++ b/services/chainservice_bids.go
@@ -1,0 +1,170 @@
+package services
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+
+	"github.com/ethpandaops/dora/dbtypes"
+)
+
+// BidParentClass classifies which chain position an execution payload bid targets,
+// relative to the parent chain of a reference block (usually the block that was
+// actually proposed in the bid's slot).
+type BidParentClass uint8
+
+const (
+	// BidParentClassUnknown means the bid's parent root could not be resolved to a known block.
+	BidParentClassUnknown BidParentClass = iota
+	// BidParentClassParent means the bid targets the reference block's beacon parent.
+	BidParentClassParent
+	// BidParentClassReorg means the bid targets a deeper ancestor of the reference block,
+	// i.e. it proposes to orphan the block(s) between that ancestor and the reference block.
+	BidParentClassReorg
+	// BidParentClassOrphaned means the bid targets a known block outside the reference
+	// block's parent chain (a competing fork that ended up orphaned).
+	BidParentClassOrphaned
+)
+
+// String returns the wire/display identifier of the bid parent class.
+func (c BidParentClass) String() string {
+	switch c {
+	case BidParentClassParent:
+		return "parent"
+	case BidParentClassReorg:
+		return "reorg"
+	case BidParentClassOrphaned:
+		return "orphaned"
+	default:
+		return "unknown"
+	}
+}
+
+// bidClassifyWindow is the number of slots preceding the bid slot that are inspected
+// to resolve bid parent roots and parent payload hashes.
+const bidClassifyWindow = 16
+
+// ClassifiedBlockBid is a BlockBid annotated with the chain position its parent tuple
+// (parent_block_root, parent_block_hash) targets.
+type ClassifiedBlockBid struct {
+	*dbtypes.BlockBid
+	ParentClass BidParentClass
+	// ReorgDepth is the number of blocks on the reference chain the bid would orphan
+	// (0 for parent bids, 1 for grandparent/"reorg n-1" bids, ...).
+	ReorgDepth uint64
+	// ParentSlot is the slot of the targeted beacon parent block (valid if ParentKnown).
+	ParentSlot  uint64
+	ParentKnown bool
+	// ParentFull indicates the bid builds on the targeted block's own payload (full parent).
+	// False means it builds on an earlier payload, i.e. it treats the target's payload as
+	// withheld/empty.
+	ParentFull bool
+	// ElParentSlot is the slot of the block whose payload block hash matches the bid's
+	// parent hash, i.e. the EL head the bid builds on (valid if ElParentKnown).
+	ElParentSlot  uint64
+	ElParentKnown bool
+	// ElParentUnrevealed indicates the bid's parent hash matches a committed payload hash
+	// that was never revealed on the reference chain - such a bid can never become valid.
+	ElParentUnrevealed bool
+}
+
+// GetSlotBidsClassified returns all execution payload bids for the given slot (regardless
+// of their parent root) and classifies each bid's parent tuple against the parent chain of
+// the reference block identified by parentRoot (the reference block's parent root).
+// Bids targeting deeper ancestors (reorg bids) or competing forks are included and marked.
+func (bs *ChainService) GetSlotBidsClassified(ctx context.Context, slot phase0.Slot, parentRoot phase0.Root) []*ClassifiedBlockBid {
+	bids := bs.beaconIndexer.GetBlockBidsForSlot(slot)
+	if len(bids) == 0 {
+		return []*ClassifiedBlockBid{}
+	}
+
+	// Load all blocks (canonical + orphaned) in the window preceding the bid slot to
+	// resolve the bids' parent roots and payload hashes against.
+	firstSlot := uint64(0)
+	if uint64(slot) > 0 {
+		firstSlot = uint64(slot) - 1
+	}
+	ctxBlocks := bs.GetDbBlocksForSlots(ctx, firstSlot, bidClassifyWindow, false, true)
+
+	blockByRoot := make(map[phase0.Root]*dbtypes.Slot, len(ctxBlocks))
+	for _, block := range ctxBlocks {
+		if len(block.Root) != 32 {
+			continue
+		}
+		blockByRoot[phase0.Root(block.Root)] = block
+	}
+
+	// Walk the reference block's parent chain; index = reorg depth (0 = parent).
+	ancestors := make([]*dbtypes.Slot, 0, bidClassifyWindow)
+	ancestorDepth := make(map[phase0.Root]int, bidClassifyWindow)
+	ancestorRoot := parentRoot
+	for range bidClassifyWindow {
+		block := blockByRoot[ancestorRoot]
+		if block == nil {
+			break
+		}
+
+		ancestorDepth[ancestorRoot] = len(ancestors)
+		ancestors = append(ancestors, block)
+
+		if len(block.ParentRoot) != 32 {
+			break
+		}
+		ancestorRoot = phase0.Root(block.ParentRoot)
+	}
+
+	classifiedBids := make([]*ClassifiedBlockBid, 0, len(bids))
+	for _, bid := range bids {
+		classifiedBid := &ClassifiedBlockBid{BlockBid: bid}
+
+		// Resolve the targeted beacon parent block.
+		var targetBlock *dbtypes.Slot
+		if len(bid.ParentRoot) == 32 {
+			bidParentRoot := phase0.Root(bid.ParentRoot)
+			if depth, isAncestor := ancestorDepth[bidParentRoot]; isAncestor {
+				targetBlock = ancestors[depth]
+				if depth == 0 {
+					classifiedBid.ParentClass = BidParentClassParent
+				} else {
+					classifiedBid.ParentClass = BidParentClassReorg
+					classifiedBid.ReorgDepth = uint64(depth)
+				}
+			} else if forkBlock := blockByRoot[bidParentRoot]; forkBlock != nil {
+				targetBlock = forkBlock
+				classifiedBid.ParentClass = BidParentClassOrphaned
+			}
+		}
+
+		if targetBlock != nil {
+			classifiedBid.ParentSlot = targetBlock.Slot
+			classifiedBid.ParentKnown = true
+			classifiedBid.ParentFull = len(targetBlock.EthBlockHash) > 0 &&
+				bytes.Equal(bid.ParentHash, targetBlock.EthBlockHash)
+		}
+
+		// Resolve the EL parent: the reference-chain block whose payload block hash the
+		// bid builds on. For payload-less blocks EthBlockHash holds the committed (never
+		// revealed) bid hash, so a match there flags an invalid parent hash.
+		for _, ancestor := range ancestors {
+			if len(ancestor.EthBlockHash) == 0 || !bytes.Equal(bid.ParentHash, ancestor.EthBlockHash) {
+				continue
+			}
+
+			classifiedBid.ElParentSlot = ancestor.Slot
+			classifiedBid.ElParentKnown = true
+			classifiedBid.ElParentUnrevealed = ancestor.PayloadStatus == dbtypes.PayloadStatusMissing
+			break
+		}
+		if !classifiedBid.ElParentKnown && classifiedBid.ParentFull {
+			// Fork-target bids build on the fork block's own payload.
+			classifiedBid.ElParentSlot = targetBlock.Slot
+			classifiedBid.ElParentKnown = true
+			classifiedBid.ElParentUnrevealed = targetBlock.PayloadStatus == dbtypes.PayloadStatusMissing
+		}
+
+		classifiedBids = append(classifiedBids, classifiedBid)
+	}
+
+	return classifiedBids
+}

--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -4,7 +4,10 @@
       <thead>
         <tr>
           <th class="border-0">Builder</th>
+          <th class="border-0">Bid Target</th>
           <th class="border-0">Block Hash</th>
+          <th class="border-0">Parent Hash</th>
+          <th class="border-0">Parent Root</th>
           <th class="border-0">Fee Recipient</th>
           <th class="border-0">Gas Limit</th>
           <th class="border-0">Value</th>
@@ -14,7 +17,7 @@
       </thead>
       <tbody>
         {{ range $i, $bid := .Block.Bids }}
-          <tr{{ if $bid.IsWinning }} style="border-left: 3px solid var(--bs-success);"{{ end }}>
+          <tr{{ if or $bid.IsWinning (not $bid.IsParentBid) }} style="{{ if $bid.IsWinning }}border-left: 3px solid var(--bs-success);{{ end }}{{ if not $bid.IsParentBid }}opacity: 0.6;{{ end }}"{{ end }}>
             <td>
               {{ if $bid.IsSelfBuilt }}
                 <span class="builder-label builder-index"><i class="fas fa-hard-hat mr-2"></i> Self-built</span>
@@ -24,9 +27,32 @@
               {{ if $bid.IsWinning }}<span class="badge bg-success ms-1">Winner</span>{{ end }}
             </td>
             <td>
+              {{ if eq $bid.ClassColor "purple" }}
+                <span class="badge text-white" style="background-color: #6f42c1;" data-bs-toggle="tooltip" title="{{ $bid.ClassTitle }}">{{ $bid.ClassLabel }}</span>
+              {{ else }}
+                <span class="badge bg-{{ $bid.ClassColor }}{{ if eq $bid.ClassColor "warning" }} text-dark{{ end }}" data-bs-toggle="tooltip" title="{{ $bid.ClassTitle }}">{{ $bid.ClassLabel }}</span>
+              {{ end }}
+            </td>
+            <td>
               <div class="d-flex align-items-center">
                 <span class="text-monospace text-truncate">0x{{ printf "%x" $bid.BlockHash }}</span>
                 <i class="fa fa-copy text-muted p-1 flex-shrink-0" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $bid.BlockHash }}"></i>
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                <span class="text-monospace text-truncate">0x{{ printf "%x" $bid.ParentHash }}</span>
+                <i class="fa fa-copy text-muted p-1 flex-shrink-0" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $bid.ParentHash }}"></i>
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                {{ if $bid.ParentKnown }}
+                  <a class="text-monospace text-truncate" href="/slot/{{ printf "%x" $bid.ParentRoot }}" data-bs-toggle="tooltip" title="Slot {{ $bid.ParentSlot }}">0x{{ printf "%x" $bid.ParentRoot }}</a>
+                {{ else }}
+                  <span class="text-monospace text-truncate">0x{{ printf "%x" $bid.ParentRoot }}</span>
+                {{ end }}
+                <i class="fa fa-copy text-muted p-1 flex-shrink-0" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $bid.ParentRoot }}"></i>
               </div>
             </td>
             <td>{{ ethAddressLink $bid.FeeRecipient }}</td>

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -391,6 +391,15 @@ type SlotPageBid struct {
 	ElPayment    uint64 `json:"el_payment"`
 	TotalValue   uint64 `json:"total_value"`
 	IsWinning    bool   `json:"is_winning"`
+
+	// Bid target classification: which parent tuple (parent_block_root, parent_block_hash)
+	// the bid builds on, relative to the displayed block's parent chain.
+	ClassLabel  string `json:"class_label"`   // badge text, e.g. "parent (full)", "grandparent (empty)"
+	ClassColor  string `json:"class_color"`   // badge color key: success|warning|purple|secondary|dark|danger
+	ClassTitle  string `json:"class_title"`   // tooltip with target block / EL head details
+	ParentSlot  uint64 `json:"parent_slot"`   // slot of the targeted beacon parent block
+	ParentKnown bool   `json:"parent_known"`  // targeted beacon parent block was resolved (enables linking)
+	IsParentBid bool   `json:"is_parent_bid"` // targets the displayed block's actual parent root (others are listed last, grayed out)
 }
 
 // SlotPageBuilderPayment holds the Gloas builder-payment vote quorum for a slot: the same-slot


### PR DESCRIPTION
## Problem

The bids list on the slot details page (ePBS/Gloas) was hard to read and incomplete:

- Bids were fetched filtered by the block's parent root, so **reorg bids** (targeting the grandparent or a competing fork) were silently dropped from the list.
- The table showed neither the bid's **parent block hash** nor its **parent block root**.
- There was no way to tell whether a bid targets the **full** or **empty** parent payload — parent_empty bids looked identical to parent_full bids.

## Changes

**Data layer**
- New `Indexer.GetBlockBidsForSlot(slot)` returns all bids for a slot regardless of parent root, merging bid cache and DB (deduped by parent-root/parent-hash/block-hash/builder key). The old parent-root-filtered getters became unused and were removed.

**Classification** (`services/chainservice_bids.go`, shared by page + API)
- `GetSlotBidsClassified` walks the displayed block's parent chain (16-slot window, incl. orphaned blocks) and classifies each bid's `(parent_block_root, parent_block_hash)` tuple:
  - `parent (full/empty)` — targets the block's actual beacon parent
  - `grandparent / reorg -N (full/empty)` — targets a deeper ancestor, would orphan N block(s)
  - `orphaned fork` — targets a block outside the displayed block's chain
  - `unknown parent` — parent root not resolvable
- Full vs empty is decided against the target block's committed payload hash (works for missed-payload blocks, which store the committed bid hash).
- For empty bids the actual EL head payload slot is resolved; parent hashes matching a **never-revealed** committed payload hash are flagged as invalid.

**Slot page UI**
- New "Bid Target" badge column (green = parent full, amber = parent empty, purple = grandparent full, gray = grandparent empty, dark = orphaned fork, red = unknown) with tooltips explaining the target.
- New Parent Hash and Parent Root columns; the root links to the target block's slot page when resolved.
- Bids not targeting the block's actual parent root are listed last and slightly grayed out.
- Winner detection now also works for missed-payload blocks (falls back to the committed payload header hash).

<img width="1509" height="832" alt="image" src="https://github.com/user-attachments/assets/0c0d53a3-9bda-4336-96ae-f62ce90990e9" />


**Bids API** (`/v1/slot/{slotOrHash}/bids`, additive)
- Now returns all bids for the slot and adds `parent_class`, `parent_full`, `reorg_depth`, `parent_slot`, `el_parent_slot`, `el_parent_unrevealed`, and a `candidate_key` (`parent_full`, `parent_empty`, `grandparent_full`, ...) matching the candidate keys used by bid testing tooling.