### PR TITLE
fix blob count for gloas blocks with missed payloads

### DIFF
--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -994,6 +994,14 @@ func getSlotPageBlockData(ctx context.Context, blockData *services.CombinedBlock
 	}
 
 	if specs.DenebForkEpoch != nil && uint64(epoch) >= *specs.DenebForkEpoch {
+		// Post-Gloas the blob commitments come from the bid, but the blobs themselves only
+		// propagate alongside the payload - a missed-payload block carries no blobs.
+		// Orphaned payloads were revealed, so their blobs are still shown.
+		if blockData.Block.Version >= spec.DataVersionGloas &&
+			(pageData.PayloadHeader == nil || pageData.PayloadHeader.PayloadStatus == uint16(dbtypes.PayloadStatusMissing)) {
+			blobKzgCommitments = nil
+		}
+
 		pageData.BlobsCount = uint64(len(blobKzgCommitments))
 		pageData.Blobs = make([]*models.SlotPageBlob, pageData.BlobsCount)
 		for i := range blobKzgCommitments {

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/dora/utils"
+	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/jmoiron/sqlx"
@@ -431,7 +432,14 @@ func (block *Block) setBlockIndex(body *all.SignedBeaconBlock, payload *all.Sign
 
 	bbody := body.Message.Body
 	blockIndex.Graffiti = bbody.Graffiti
-	blockIndex.BlobCount = uint64(len(utils.BlockBodyBlobCommitments(bbody)))
+
+	// Post-Gloas the blob commitments come from the bid, but the blobs themselves only
+	// propagate alongside the payload - without a revealed payload the block carries no blobs.
+	if bbody.Version >= spec.DataVersionGloas && payload == nil {
+		blockIndex.BlobCount = 0
+	} else {
+		blockIndex.BlobCount = uint64(len(utils.BlockBodyBlobCommitments(bbody)))
+	}
 
 	if extra, err := getBlockExecutionExtraData(body); err == nil {
 		blockIndex.ExecutionExtraData = extra

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -435,6 +435,14 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 		dbw.indexer.blockBidCache.AddBid(blockBid)
 	}
 
+	// Post-Gloas the blob commitments come from the bid, but the blobs themselves only
+	// propagate alongside the payload - a missed-payload block carries no blobs.
+	// Orphaned payloads were revealed, so their blobs remain counted.
+	blobCount := uint64(len(blobKzgCommitments))
+	if payloadStatus == dbtypes.PayloadStatusMissing {
+		blobCount = 0
+	}
+
 	dbBlock := dbtypes.Slot{
 		Slot:                  uint64(block.header.Message.Slot),
 		Proposer:              uint64(block.header.Message.ProposerIndex),
@@ -451,7 +459,7 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 		AttesterSlashingCount: uint64(len(attesterSlashings)),
 		ProposerSlashingCount: uint64(len(proposerSlashings)),
 		BLSChangeCount:        uint64(len(blsToExecChanges)),
-		BlobCount:             uint64(len(blobKzgCommitments)),
+		BlobCount:             blobCount,
 		RecvDelay:             block.recvDelay,
 		PayloadStatus:         payloadStatus,
 		BlockUid:              block.BlockUID,
@@ -654,12 +662,17 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 			var executionWithdrawals []*capella.Withdrawal
 			var depositRequests []*electra.DepositRequest
 
+			blobCount := uint64(len(blobKzgCommitments))
+
 			if chainState.IsEip7732Enabled(chainState.EpochOfSlot(block.Slot)) {
 				blockPayload := block.GetExecutionPayload(dbw.indexer.ctx)
 				if blockPayload != nil {
 					dbEpoch.PayloadCount++
 					executionTransactions = blockPayload.Message.Payload.Transactions
 					executionWithdrawals = blockPayload.Message.Payload.Withdrawals
+				} else {
+					// bid-committed blobs are discarded when the payload is never revealed
+					blobCount = 0
 				}
 			} else {
 				if body.ExecutionPayload != nil {
@@ -702,7 +715,7 @@ func (dbw *dbWriter) buildDbEpoch(epoch phase0.Epoch, blocks []*Block, epochStat
 			}
 
 			dbEpoch.EthTransactionCount += uint64(len(executionTransactions))
-			dbEpoch.BlobCount += uint64(len(blobKzgCommitments))
+			dbEpoch.BlobCount += blobCount
 			dbEpoch.WithdrawCount += uint64(len(executionWithdrawals))
 
 			withdrawalAmountOverflow := false


### PR DESCRIPTION
## Problem

For Gloas (ePBS) blocks, dora derives the blob count from the blob KZG commitments in the block's execution payload bid. Those commitments only declare intent — the blobs themselves propagate alongside the payload reveal. When the payload is never revealed, the blobs are discarded, yet dora still displayed the bid's commitment count as the block's blob count.

## Changes

Blob counts are now gated on the payload actually being revealed (canonical or orphaned); missed-payload blocks show 0 blobs:

- `buildDbBlock`: zero `BlobCount` when the payload status is missing — covers the `slots` table, cached listings (slots/blocks/validator pages) and the v1 slot APIs
- `buildDbEpoch`: skip blobs of missed-payload blocks in epoch aggregates
- `setBlockIndex`: post-Gloas blocks without a payload get `BlobCount = 0` in the in-memory block index (MEV block listings, blob count filters); the index is rebuilt once the payload envelope arrives
- slot detail page: the blobs tab is empty for blocks whose payload status resolved to missing

Orphaned payloads were revealed and their blobs propagated, so they remain counted — only missed payloads are affected.

Note: already-persisted missed-payload slots keep their old `blob_count`; affected epochs need a re-sync to be corrected.