### PR TITLE
fix: confirm durable writes before advancing state in pruning and system-contract indexers

### DIFF
--- a/indexer/beacon/pruning.go
+++ b/indexer/beacon/pruning.go
@@ -214,7 +214,7 @@ func (indexer *Indexer) processEpochPruning(pruneEpoch phase0.Epoch) (uint64, ui
 	t1 = time.Now()
 
 	// persist data in db
-	db.RunDBTransaction(func(tx *sqlx.Tx) error {
+	err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
 		persistedBlocks := map[phase0.Root]bool{}
 
 		for _, epochData := range epochData {
@@ -272,6 +272,13 @@ func (indexer *Indexer) processEpochPruning(pruneEpoch phase0.Epoch) (uint64, ui
 
 		return nil
 	})
+	if err != nil {
+		// The persist transaction (which durably records the prune checkpoint via
+		// updatePruningState) never committed. Return without advancing lastPrunedEpoch
+		// or evicting anything from cache, so this epoch is retried on the next pruning
+		// cycle instead of silently losing its data.
+		return 0, 0, fmt.Errorf("error persisting pruned epoch %d: %v", pruneEpoch, err)
+	}
 
 	indexer.lastPrunedEpoch = pruneEpoch + 1
 	t2dur := time.Since(t1)

--- a/indexer/beacon/pruning_test.go
+++ b/indexer/beacon/pruning_test.go
@@ -1,0 +1,101 @@
+package beacon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/dora/clients/consensus"
+	"github.com/ethpandaops/dora/db"
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/types"
+	"github.com/ethpandaops/dora/utils"
+)
+
+// TestProcessEpochPruning_FailedWriteDoesNotAdvanceState verifies that a failed pruning
+// persist transaction is surfaced as an error and does not advance lastPrunedEpoch. Before
+// the fix, RunDBTransaction's result was discarded, lastPrunedEpoch advanced
+// unconditionally, and the function always returned a nil error - so a transient write
+// failure silently and permanently lost that epoch's pruned data. Fails without the fix,
+// passes with it.
+func TestProcessEpochPruning_FailedWriteDoesNotAdvanceState(t *testing.T) {
+	utils.Config = &types.Config{}
+
+	cfg := &types.DatabaseConfig{
+		Engine: "sqlite",
+		Sqlite: &types.SqliteDatabaseConfig{File: filepath.Join(t.TempDir(), "test.sqlite")},
+	}
+	db.MustInitDB(cfg)
+	if err := db.ApplyEmbeddedDbSchema(-2); err != nil {
+		t.Fatalf("apply schema: %v", err)
+	}
+	t.Cleanup(db.MustCloseDB)
+
+	// Force updatePruningState's db.SetExplorerState write to fail deterministically -
+	// a stand-in for any transient write failure on the explorer_state table.
+	if _, err := db.ReaderDb.Exec(`DROP TABLE explorer_state`); err != nil {
+		t.Fatalf("drop explorer_state table: %v", err)
+	}
+
+	ctx := context.Background()
+	logger := logrus.StandardLogger()
+	consensusPool := consensus.NewPool(ctx, logger)
+	indexer := NewIndexer(ctx, logger, consensusPool)
+
+	// No blocks were added to the cache, so processEpochPruning(0) has nothing to persist
+	// except the prune-state checkpoint itself - which is exactly the write broken above.
+	_, _, err := indexer.processEpochPruning(0)
+
+	if err == nil {
+		t.Fatalf("expected processEpochPruning to report the failed persist, got nil error")
+	}
+
+	var pruneState dbtypes.IndexerPruneState
+	if _, dbErr := db.GetExplorerState(ctx, "indexer.prunestate", &pruneState); dbErr == nil {
+		t.Fatalf("expected GetExplorerState to fail (nothing should have been durably persisted), but it succeeded with epoch=%v", pruneState.Epoch)
+	}
+
+	if indexer.lastPrunedEpoch != 0 {
+		t.Fatalf("lastPrunedEpoch advanced to %v despite the persist transaction failing - epoch 0 will never be retried", indexer.lastPrunedEpoch)
+	}
+}
+
+// TestProcessEpochPruning_SuccessfulWriteAdvancesState is the mirror-image happy path:
+// a successful persist must still advance lastPrunedEpoch and report no error.
+func TestProcessEpochPruning_SuccessfulWriteAdvancesState(t *testing.T) {
+	utils.Config = &types.Config{}
+
+	cfg := &types.DatabaseConfig{
+		Engine: "sqlite",
+		Sqlite: &types.SqliteDatabaseConfig{File: filepath.Join(t.TempDir(), "test.sqlite")},
+	}
+	db.MustInitDB(cfg)
+	if err := db.ApplyEmbeddedDbSchema(-2); err != nil {
+		t.Fatalf("apply schema: %v", err)
+	}
+	t.Cleanup(db.MustCloseDB)
+
+	ctx := context.Background()
+	logger := logrus.StandardLogger()
+	consensusPool := consensus.NewPool(ctx, logger)
+	indexer := NewIndexer(ctx, logger, consensusPool)
+
+	_, _, err := indexer.processEpochPruning(0)
+	if err != nil {
+		t.Fatalf("unexpected error from processEpochPruning: %v", err)
+	}
+
+	if indexer.lastPrunedEpoch != 1 {
+		t.Fatalf("lastPrunedEpoch = %v, want 1", indexer.lastPrunedEpoch)
+	}
+
+	var pruneState dbtypes.IndexerPruneState
+	if _, dbErr := db.GetExplorerState(ctx, "indexer.prunestate", &pruneState); dbErr != nil {
+		t.Fatalf("expected prune state to be durably persisted, GetExplorerState failed: %v", dbErr)
+	}
+	if pruneState.Epoch != 1 {
+		t.Fatalf("persisted prune state epoch = %v, want 1", pruneState.Epoch)
+	}
+}

--- a/indexer/execution/system_contracts/contract_indexer.go
+++ b/indexer/execution/system_contracts/contract_indexer.go
@@ -89,14 +89,22 @@ func (ci *contractIndexer[_]) loadState() {
 // persistState saves the current contract indexer state to the database
 func (ci *contractIndexer[_]) persistState(tx *sqlx.Tx) error {
 	finalizedBlockNumber := ci.getFinalizedBlockNumber()
+
+	// Removed here but only committed to ci.state once the write below is confirmed -
+	// on failure these are put back so ci.state matches what's actually durable.
+	removedForkStates := map[beacon.ForkKey]*contractIndexerForkState{}
 	for forkId, forkState := range ci.state.ForkStates {
 		if forkState.Block < finalizedBlockNumber {
+			removedForkStates[forkId] = forkState
 			delete(ci.state.ForkStates, forkId)
 		}
 	}
 
 	err := db.SetExplorerState(ci.indexer.Ctx, tx, ci.options.stateKey, ci.state)
 	if err != nil {
+		for forkId, forkState := range removedForkStates {
+			ci.state.ForkStates[forkId] = forkState
+		}
 		return fmt.Errorf("error while updating contract indexer state: %v", err)
 	}
 
@@ -588,7 +596,10 @@ func (ci *contractIndexer[TxType]) processRecentBlocksForFork(headFork *exectx.F
 
 // persistFinalizedRequestTxs persists processed finalized transactions and the indexer state to the database
 func (ci *contractIndexer[TxType]) persistFinalizedRequestTxs(finalBlockNumber, finalQueueLen uint64, requests []*TxType) error {
-	return db.RunDBTransaction(func(tx *sqlx.Tx) error {
+	prevFinalBlock := ci.state.FinalBlock
+	prevFinalQueueLen := ci.state.FinalQueueLen
+
+	err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
 		if len(requests) > 0 {
 			err := ci.options.persistTxs(tx, requests)
 			if err != nil {
@@ -601,11 +612,23 @@ func (ci *contractIndexer[TxType]) persistFinalizedRequestTxs(finalBlockNumber, 
 
 		return ci.persistState(tx)
 	})
+	if err != nil {
+		// The transaction didn't commit, so undo the state advance made inside the
+		// closure above - otherwise the next call starts past this range without it
+		// ever having been durably persisted.
+		ci.state.FinalBlock = prevFinalBlock
+		ci.state.FinalQueueLen = prevFinalQueueLen
+		return err
+	}
+
+	return nil
 }
 
 // persistRecentRequestTxs persists processed recent transactions and the indexer state to the database
 func (ci *contractIndexer[TxType]) persistRecentRequestTxs(forkId beacon.ForkKey, finalBlockNumber, finalQueueLen uint64, requests []*TxType) error {
-	return db.RunDBTransaction(func(tx *sqlx.Tx) error {
+	prevForkState, hadForkState := ci.state.ForkStates[forkId]
+
+	err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
 		if len(requests) > 0 {
 			err := ci.options.persistTxs(tx, requests)
 			if err != nil {
@@ -620,4 +643,17 @@ func (ci *contractIndexer[TxType]) persistRecentRequestTxs(forkId beacon.ForkKey
 
 		return ci.persistState(tx)
 	})
+	if err != nil {
+		// The transaction didn't commit, so undo the state advance made inside the
+		// closure above - otherwise the next call starts past this range without it
+		// ever having been durably persisted.
+		if hadForkState {
+			ci.state.ForkStates[forkId] = prevForkState
+		} else {
+			delete(ci.state.ForkStates, forkId)
+		}
+		return err
+	}
+
+	return nil
 }

--- a/indexer/execution/system_contracts/contract_indexer_durable_write_test.go
+++ b/indexer/execution/system_contracts/contract_indexer_durable_write_test.go
@@ -1,0 +1,207 @@
+package system_contracts
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/dora/clients/consensus"
+	"github.com/ethpandaops/dora/clients/execution"
+	"github.com/ethpandaops/dora/db"
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/indexer/beacon"
+	exectx "github.com/ethpandaops/dora/indexer/execution"
+	"github.com/ethpandaops/dora/types"
+	"github.com/ethpandaops/dora/utils"
+)
+
+type durableWriteTestTx struct{}
+
+func newDurableWriteTestIndexer(t *testing.T) *contractIndexer[durableWriteTestTx] {
+	t.Helper()
+
+	utils.Config = &types.Config{}
+
+	cfg := &types.DatabaseConfig{
+		Engine: "sqlite",
+		Sqlite: &types.SqliteDatabaseConfig{File: filepath.Join(t.TempDir(), "test.sqlite")},
+	}
+	db.MustInitDB(cfg)
+	if err := db.ApplyEmbeddedDbSchema(-2); err != nil {
+		t.Fatalf("apply schema: %v", err)
+	}
+	t.Cleanup(db.MustCloseDB)
+
+	ctx := context.Background()
+	logger := logrus.StandardLogger()
+	consensusPool := consensus.NewPool(ctx, logger)
+	executionPool := execution.NewPool(ctx, logger)
+	beaconIndexer := beacon.NewIndexer(ctx, logger, consensusPool)
+	indexerCtx := exectx.NewIndexerCtx(ctx, logger, executionPool, consensusPool, beaconIndexer)
+
+	return &contractIndexer[durableWriteTestTx]{
+		indexer: indexerCtx,
+		logger:  logger,
+		options: &contractIndexerOptions[durableWriteTestTx]{
+			stateKey: "test.state",
+			persistTxs: func(tx *sqlx.Tx, txs []*durableWriteTestTx) error {
+				return nil
+			},
+		},
+		state: &contractIndexerState{
+			FinalBlock:    100,
+			FinalQueueLen: 5,
+			ForkStates:    map[beacon.ForkKey]*contractIndexerForkState{},
+		},
+	}
+}
+
+// TestPersistFinalizedRequestTxs_FailedWriteRollsBackState verifies that when the persist
+// transaction fails, ci.state.FinalBlock/FinalQueueLen are rolled back to their prior
+// values instead of staying advanced. Before the fix, the in-memory cursor was mutated
+// inside the RunDBTransaction closure before persistState's commit was confirmed, and
+// never rolled back on failure - permanently skipping the block range for the rest of the
+// process's uptime. Fails without the fix, passes with it.
+func TestPersistFinalizedRequestTxs_FailedWriteRollsBackState(t *testing.T) {
+	ci := newDurableWriteTestIndexer(t)
+
+	if _, err := db.ReaderDb.Exec(`DROP TABLE explorer_state`); err != nil {
+		t.Fatalf("drop explorer_state table: %v", err)
+	}
+
+	err := ci.persistFinalizedRequestTxs(999999, 42, nil)
+	if err == nil {
+		t.Fatalf("expected persistFinalizedRequestTxs to report the failed persist, got nil error")
+	}
+
+	if ci.state.FinalBlock != 100 {
+		t.Fatalf("ci.state.FinalBlock = %v, want 100 (rolled back) after the failed transaction", ci.state.FinalBlock)
+	}
+	if ci.state.FinalQueueLen != 5 {
+		t.Fatalf("ci.state.FinalQueueLen = %v, want 5 (rolled back) after the failed transaction", ci.state.FinalQueueLen)
+	}
+}
+
+// TestPersistFinalizedRequestTxs_SuccessfulWriteAdvancesState is the happy-path mirror:
+// a successful persist must still advance the in-memory cursor.
+func TestPersistFinalizedRequestTxs_SuccessfulWriteAdvancesState(t *testing.T) {
+	ci := newDurableWriteTestIndexer(t)
+
+	err := ci.persistFinalizedRequestTxs(999999, 42, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ci.state.FinalBlock != 999999 {
+		t.Fatalf("ci.state.FinalBlock = %v, want 999999", ci.state.FinalBlock)
+	}
+	if ci.state.FinalQueueLen != 42 {
+		t.Fatalf("ci.state.FinalQueueLen = %v, want 42", ci.state.FinalQueueLen)
+	}
+}
+
+// TestPersistRecentRequestTxs_FailedWriteRollsBackNewForkState verifies the same rollback
+// for the fork-scoped state map, covering the case where the fork didn't have an entry
+// before the call (the entry must be removed entirely on failure, not left behind).
+func TestPersistRecentRequestTxs_FailedWriteRollsBackNewForkState(t *testing.T) {
+	ci := newDurableWriteTestIndexer(t)
+
+	if _, err := db.ReaderDb.Exec(`DROP TABLE explorer_state`); err != nil {
+		t.Fatalf("drop explorer_state table: %v", err)
+	}
+
+	forkId := beacon.ForkKey(7)
+	err := ci.persistRecentRequestTxs(forkId, 555, 3, nil)
+	if err == nil {
+		t.Fatalf("expected persistRecentRequestTxs to report the failed persist, got nil error")
+	}
+
+	if _, exists := ci.state.ForkStates[forkId]; exists {
+		t.Fatalf("ci.state.ForkStates[%v] still present after the failed transaction - should have been rolled back to absent", forkId)
+	}
+}
+
+// TestPersistRecentRequestTxs_FailedWriteRestoresPriorForkState covers the case where the
+// fork already had a state entry - a failed write must restore the OLD value, not just
+// delete it.
+func TestPersistRecentRequestTxs_FailedWriteRestoresPriorForkState(t *testing.T) {
+	ci := newDurableWriteTestIndexer(t)
+
+	forkId := beacon.ForkKey(7)
+	ci.state.ForkStates[forkId] = &contractIndexerForkState{Block: 111, QueueLen: 1}
+
+	if _, err := db.ReaderDb.Exec(`DROP TABLE explorer_state`); err != nil {
+		t.Fatalf("drop explorer_state table: %v", err)
+	}
+
+	err := ci.persistRecentRequestTxs(forkId, 555, 3, nil)
+	if err == nil {
+		t.Fatalf("expected persistRecentRequestTxs to report the failed persist, got nil error")
+	}
+
+	got, exists := ci.state.ForkStates[forkId]
+	if !exists {
+		t.Fatalf("ci.state.ForkStates[%v] missing after the failed transaction - should have been restored to its prior value", forkId)
+	}
+	if got.Block != 111 || got.QueueLen != 1 {
+		t.Fatalf("ci.state.ForkStates[%v] = %+v, want {Block:111 QueueLen:1} (restored)", forkId, got)
+	}
+}
+
+// TestPersistState_DirectCall_FailedWriteRestoresPrunedForkStates covers persistState's
+// own internal cleanup in isolation: it removes fork states whose block is behind the
+// finalized block before attempting the write. finalizedBlockNumber is forced above zero
+// by inserting a matching slot row, so the cleanup loop actually has something to remove.
+func TestPersistState_DirectCall_FailedWriteRestoresPrunedForkStates(t *testing.T) {
+	ci := newDurableWriteTestIndexer(t)
+
+	// getFinalizedBlockNumber() resolves the finalized root via
+	// indexer.BeaconIndexer.GetBlockByRoot (empty cache -> miss here) and then falls
+	// back to db.GetSlotByRoot. A fresh ChainState's GetFinalizedCheckpoint() returns
+	// (0, NullRoot) - consensus.NullRoot is the all-zero phase0.Root - so seeding a slot
+	// at that root with a known eth block number gives getFinalizedBlockNumber()
+	// something to find without needing access to ChainState's unexported setter.
+	ethBlockNumber := uint64(500)
+	if err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
+		return db.InsertSlot(context.Background(), tx, &dbtypes.Slot{
+			Root:               consensus.NullRoot[:],
+			Slot:               1,
+			ParentRoot:         consensus.NullRoot[:],
+			StateRoot:          consensus.NullRoot[:],
+			Status:             dbtypes.Canonical,
+			EthBlockNumber:     &ethBlockNumber,
+			EthBlockHash:       []byte{},
+			EthBlockParentHash: []byte{},
+			EthBlockExtra:      []byte{},
+			EthFeeRecipient:    []byte{},
+		})
+	}); err != nil {
+		t.Fatalf("seed finalized slot: %v", err)
+	}
+
+	staleForkId := beacon.ForkKey(1)
+	liveForkId := beacon.ForkKey(2)
+	ci.state.ForkStates[staleForkId] = &contractIndexerForkState{Block: 1, QueueLen: 0}  // < 500: eligible for cleanup
+	ci.state.ForkStates[liveForkId] = &contractIndexerForkState{Block: 600, QueueLen: 0} // >= 500: not eligible
+
+	if _, err := db.ReaderDb.Exec(`DROP TABLE explorer_state`); err != nil {
+		t.Fatalf("drop explorer_state table: %v", err)
+	}
+
+	err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
+		return ci.persistState(tx)
+	})
+	if err == nil {
+		t.Fatalf("expected persistState to report the failed write, got nil error")
+	}
+
+	if _, exists := ci.state.ForkStates[staleForkId]; !exists {
+		t.Fatalf("ci.state.ForkStates[%v] was removed by persistState's internal cleanup and never restored after the failed write", staleForkId)
+	}
+	if _, exists := ci.state.ForkStates[liveForkId]; !exists {
+		t.Fatalf("ci.state.ForkStates[%v] should never have been touched", liveForkId)
+	}
+}


### PR DESCRIPTION
## Summary

Two more instances of the bug class fixed in #784 (tx matcher, bid cache, `finalizeEpoch`), missed there because they live in different files.

### Beacon epoch pruning silently loses data on a failed write

`processEpochPruning` called `db.RunDBTransaction(...)` as a bare statement,  the returned error was never captured, not even logged. `indexer.lastPrunedEpoch` then advanced unconditionally, and the pruned blocks' bodies/epoch stats were evicted from cache regardless of whether the transaction (which durably records the prune checkpoint via `updatePruningState`) actually committed. The function's own error return was always `nil`, so the caller (`runCachePruning`) had no way to detect or retry the failure either. This runs on every finalization-driven pruning cycle, i.e. constantly, on the default (SQLite) config.

Fix: capture the transaction error; on failure, return before advancing `lastPrunedEpoch` or touching the cache, so the epoch is retried on the next pruning cycle instead of silently disappearing.

### System-contract indexer cursor advances before its write is confirmed

`persistFinalizedRequestTxs`/`persistRecentRequestTxs` (deposit/withdrawal/consolidation/builder-deposit/builder-exit indexers) mutated the in-memory `FinalBlock`/`ForkStates` cursor inside the `RunDBTransaction` closure *before* `persistState`'s commit was confirmed, with no rollback on failure. `ci.state` is loaded once at process start and drives every subsequent block-range computation, so a failed persist permanently skips that range for the rest of the process's uptime. `persistState` itself had the same problem one level down: it deletes stale `ForkStates` entries before attempting the write, also without rolling back on failure.

Fix: both callers now snapshot the value they're about to set and roll back to it if the transaction fails; `persistState` restores exactly what it removed if its write fails.

## Tests

Each fix has a test that fails without it and passes with it,  verified by temporarily reverting the fix, confirming the new tests fail as expected, then restoring it:
- `pruning_test.go`: failed persist doesn't advance `lastPrunedEpoch`; successful persist still does.
- `contract_indexer_durable_write_test.go`: failed persist rolls back `FinalBlock`/`FinalQueueLen`, rolls back a newly-set `ForkStates` entry to absent, restores a pre-existing `ForkStates` entry to its prior value, and `persistState`'s own internal cleanup restores fork states it removed.

`go build`, `go vet`, `gofmt`, and the full test suite (including `-race`) are clean.