### PR TITLE
Add per-client bid seen tracking

### DIFF
--- a/blockdb/blockdb.go
+++ b/blockdb/blockdb.go
@@ -16,9 +16,10 @@ import (
 
 // BlockDb is the main wrapper for block database operations.
 type BlockDb struct {
-	engine       types.BlockDbEngine
-	execEngine   types.ExecDataEngine // nil if engine doesn't support exec data
-	dutiesEngine types.DutiesEngine   // nil if engine doesn't support duties storage
+	engine         types.BlockDbEngine
+	execEngine     types.ExecDataEngine // nil if engine doesn't support exec data
+	dutiesEngine   types.DutiesEngine   // nil if engine doesn't support duties storage
+	slotBidsEngine types.SlotBidsEngine // nil if engine doesn't support per-slot bids storage
 
 	txHashIndex       types.TxHashIndex // nil until detected natively or injected
 	txHashIndexNative bool              // true if provided by the engine (write post-commit), false if a relational adapter (write in-tx)
@@ -72,6 +73,9 @@ func InitWithPebble(config dtypes.PebbleBlockDBConfig, logger logrus.FieldLogger
 	if dutiesEngine, ok := engine.(types.DutiesEngine); ok {
 		db.dutiesEngine = dutiesEngine
 	}
+	if slotBidsEngine, ok := engine.(types.SlotBidsEngine); ok {
+		db.slotBidsEngine = slotBidsEngine
+	}
 	if txHashIndex, ok := engine.(types.TxHashIndex); ok {
 		db.txHashIndex = txHashIndex
 		db.txHashIndexNative = true
@@ -109,6 +113,9 @@ func InitWithS3(config dtypes.S3BlockDBConfig) error {
 	if dutiesEngine, ok := engine.(types.DutiesEngine); ok {
 		db.dutiesEngine = dutiesEngine
 	}
+	if slotBidsEngine, ok := engine.(types.SlotBidsEngine); ok {
+		db.slotBidsEngine = slotBidsEngine
+	}
 	if txHashIndex, ok := engine.(types.TxHashIndex); ok {
 		db.txHashIndex = txHashIndex
 		db.txHashIndexNative = true
@@ -137,6 +144,9 @@ func InitWithTiered(pebbleConfig dtypes.PebbleBlockDBConfig, s3Config dtypes.S3B
 	}
 	if dutiesEngine, ok := engine.(types.DutiesEngine); ok {
 		db.dutiesEngine = dutiesEngine
+	}
+	if slotBidsEngine, ok := engine.(types.SlotBidsEngine); ok {
+		db.slotBidsEngine = slotBidsEngine
 	}
 	if txHashIndex, ok := engine.(types.TxHashIndex); ok {
 		db.txHashIndex = txHashIndex
@@ -392,4 +402,33 @@ func (db *BlockDb) PruneEpochDutiesBefore(ctx context.Context, maxFirstSlot uint
 		return 0, nil
 	}
 	return db.dutiesEngine.PruneEpochDutiesBefore(ctx, maxFirstSlot)
+}
+
+// SupportsSlotBids returns true if the underlying engine supports per-slot bids storage.
+func (db *BlockDb) SupportsSlotBids() bool {
+	return db != nil && db.slotBidsEngine != nil
+}
+
+// AddSlotBids stores the per-slot bids object. Returns stored size.
+func (db *BlockDb) AddSlotBids(ctx context.Context, bids *types.SlotBids) (int64, error) {
+	if db.slotBidsEngine == nil {
+		return 0, fmt.Errorf("per-slot bids storage not supported by engine")
+	}
+	return db.slotBidsEngine.AddSlotBids(ctx, bids)
+}
+
+// GetSlotBids retrieves the bids object for a slot (nil if not found).
+func (db *BlockDb) GetSlotBids(ctx context.Context, slot uint64) (*types.SlotBids, error) {
+	if db.slotBidsEngine == nil {
+		return nil, nil
+	}
+	return db.slotBidsEngine.GetSlotBids(ctx, slot)
+}
+
+// PruneSlotBidsBefore deletes bids objects for all slots before maxSlot.
+func (db *BlockDb) PruneSlotBidsBefore(ctx context.Context, maxSlot uint64) (int64, error) {
+	if db.slotBidsEngine == nil {
+		return 0, nil
+	}
+	return db.slotBidsEngine.PruneSlotBidsBefore(ctx, maxSlot)
 }

--- a/blockdb/pebble/bids.go
+++ b/blockdb/pebble/bids.go
@@ -1,0 +1,87 @@
+package pebble
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/pebble"
+
+	"github.com/ethpandaops/dora/blockdb/types"
+)
+
+// Per-slot bids objects (KeyNamespaceBids, see pebble.go) are stored as a
+// single key per slot holding the encoded BIDS object.
+const (
+	// BidsKeyLen: [ns:2][slot:8] = 10 bytes
+	BidsKeyLen = 2 + 8
+	// bidsEntityTailLen identifies one bids object: [slot:8].
+	bidsEntityTailLen = 8
+)
+
+// MakeBidsKey builds a Pebble key for a per-slot bids object. Exported so
+// tooling (e.g. the blockdb-copy utility) can read/write bids objects directly.
+func MakeBidsKey(slot uint64) []byte {
+	return makeNamespaceSlotKey(KeyNamespaceBids, slot)
+}
+
+// AddSlotBids stores the encoded bids object for a slot.
+func (e *PebbleEngine) AddSlotBids(_ context.Context, bids *types.SlotBids) (int64, error) {
+	data, err := types.EncodeSlotBids(bids)
+	if err != nil {
+		return 0, fmt.Errorf("failed to encode bids: %w", err)
+	}
+
+	key := makeNamespaceSlotKey(KeyNamespaceBids, bids.Slot)
+	if err := e.db.Set(key, data, pebble.Sync); err != nil {
+		return 0, fmt.Errorf("failed to set bids: %w", err)
+	}
+
+	return int64(len(key) + len(data)), nil
+}
+
+// GetSlotBids reads and decodes the bids object for a slot.
+func (e *PebbleEngine) GetSlotBids(_ context.Context, slot uint64) (*types.SlotBids, error) {
+	res, closer, err := e.db.Get(makeNamespaceSlotKey(KeyNamespaceBids, slot))
+	if err == pebble.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = closer.Close() }()
+
+	return types.DecodeSlotBids(res)
+}
+
+// PruneSlotBidsBefore deletes all bids objects for slots before maxSlot.
+// Returns the number of objects deleted.
+func (e *PebbleEngine) PruneSlotBidsBefore(_ context.Context, maxSlot uint64) (int64, error) {
+	rangeStart := makeNamespaceRangeStart(KeyNamespaceBids)
+	rangeEnd := makeNamespaceSlotKey(KeyNamespaceBids, maxSlot)
+
+	var count int64
+
+	iter, err := e.db.NewIter(&pebble.IterOptions{
+		LowerBound: rangeStart,
+		UpperBound: rangeEnd,
+	})
+	if err != nil {
+		return 0, err
+	}
+	for iter.First(); iter.Valid(); iter.Next() {
+		count++
+	}
+	if err := iter.Close(); err != nil {
+		return 0, err
+	}
+
+	if count == 0 {
+		return 0, nil
+	}
+
+	if err := e.db.DeleteRange(rangeStart, rangeEnd, pebble.Sync); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/blockdb/pebble/cleanup.go
+++ b/blockdb/pebble/cleanup.go
@@ -259,6 +259,12 @@ func (c *CacheCleanup) runCleanup() {
 	if c.cacheMode {
 		c.cleanupSlotNamespace(KeyNamespaceExecData, execDataKeyLen, execEntityTailLen, &c.config.ExecDataRetention)
 	}
+
+	// Bids objects are never cached in tiered mode (reads go straight to S3),
+	// so their retention only applies when Pebble is authoritative.
+	if !c.cacheMode {
+		c.cleanupSlotNamespace(KeyNamespaceBids, BidsKeyLen, bidsEntityTailLen, &c.config.BidsRetention)
+	}
 }
 
 // cleanupBlocks evicts block-component data (namespace 1) by the configured mode.

--- a/blockdb/pebble/pebble.go
+++ b/blockdb/pebble/pebble.go
@@ -20,6 +20,7 @@ const (
 	KeyNamespaceTxHash      uint16 = 4 // tx-hash index lookup: [ns4][prefix10][tx_uid8]
 	KeyNamespaceTxHashPrune uint16 = 5 // tx-hash index prune-order: [ns5][tx_uid8]
 	KeyNamespaceAccessTrack uint16 = 6 // exec/duties access records: [ns6][entityNs][slot][tail]
+	KeyNamespaceBids        uint16 = 7 // per-slot bids objects: [ns7][slot]
 )
 
 type PebbleEngine struct {

--- a/blockdb/s3/bids.go
+++ b/blockdb/s3/bids.go
@@ -1,0 +1,128 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/minio/minio-go/v7"
+
+	"github.com/ethpandaops/dora/blockdb/types"
+)
+
+// getBidsKey builds the S3 object key for a per-slot bids object.
+// Format: {pathPrefix}/{slot/10000}/{slot_padded}_bids
+// The shared tier folders and slot-padded name keep bids objects sorted
+// alongside the slot's block objects in S3 viewers.
+func (e *S3Engine) getBidsKey(slot uint64) string {
+	return path.Join(
+		e.pathPrefix,
+		fmt.Sprintf("%06d", slot/10000),
+		fmt.Sprintf("%010d_bids", slot),
+	)
+}
+
+// AddSlotBids packs the slot's bids into a single BIDS object and stores it.
+func (e *S3Engine) AddSlotBids(ctx context.Context, bids *types.SlotBids) (int64, error) {
+	data, err := types.EncodeSlotBids(bids)
+	if err != nil {
+		return 0, fmt.Errorf("failed to encode bids: %w", err)
+	}
+
+	key := e.getBidsKey(bids.Slot)
+	e.putCount.Add(1)
+
+	_, err = e.client.PutObject(
+		ctx,
+		e.bucket,
+		key,
+		bytes.NewReader(data),
+		int64(len(data)),
+		minio.PutObjectOptions{ContentType: "application/octet-stream"},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to upload bids: %w", err)
+	}
+
+	e.putBytes.Add(int64(len(data)))
+	return int64(len(data)), nil
+}
+
+// GetSlotBids retrieves and decodes the bids object for a slot.
+func (e *S3Engine) GetSlotBids(ctx context.Context, slot uint64) (*types.SlotBids, error) {
+	key := e.getBidsKey(slot)
+	e.getCount.Add(1)
+
+	obj, err := e.client.GetObject(ctx, e.bucket, key, minio.GetObjectOptions{})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get bids: %w", err)
+	}
+	defer func() { _ = obj.Close() }()
+
+	data, err := io.ReadAll(obj)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read bids: %w", err)
+	}
+
+	e.getBytes.Add(int64(len(data)))
+	return types.DecodeSlotBids(data)
+}
+
+// PruneSlotBidsBefore deletes bids objects for all slots before maxSlot,
+// filtering on the _bids suffix.
+func (e *S3Engine) PruneSlotBidsBefore(ctx context.Context, maxSlot uint64) (int64, error) {
+	var totalDeleted int64
+
+	maxTier := maxSlot / 10000
+
+	for tier := uint64(0); tier <= maxTier; tier++ {
+		prefix := path.Join(e.pathPrefix, fmt.Sprintf("%06d", tier)) + "/"
+
+		objectsCh := e.client.ListObjects(ctx, e.bucket, minio.ListObjectsOptions{
+			Prefix:    prefix,
+			Recursive: true,
+		})
+
+		deleteCh := make(chan minio.ObjectInfo, 100)
+
+		go func() {
+			defer close(deleteCh)
+			for obj := range objectsCh {
+				if obj.Err != nil {
+					continue
+				}
+
+				if !strings.HasSuffix(obj.Key, "_bids") {
+					continue
+				}
+
+				if parseSlotFromKey(obj.Key) >= maxSlot {
+					continue
+				}
+
+				deleteCh <- obj
+			}
+		}()
+
+		for err := range e.client.RemoveObjects(ctx, e.bucket, deleteCh, minio.RemoveObjectsOptions{}) {
+			if err.Err != nil {
+				return totalDeleted, fmt.Errorf(
+					"failed to delete bids object %s: %w",
+					err.ObjectName, err.Err,
+				)
+			}
+			totalDeleted++
+		}
+	}
+
+	return totalDeleted, nil
+}

--- a/blockdb/tiered/bids.go
+++ b/blockdb/tiered/bids.go
@@ -1,0 +1,26 @@
+package tiered
+
+import (
+	"context"
+
+	"github.com/ethpandaops/dora/blockdb/types"
+)
+
+// Bids objects are small and rarely read (only when a user expands the
+// seen-by details of a bid), so they are not cached in the Pebble tier -
+// all operations go straight to the S3 primary.
+
+// AddSlotBids stores the bids object for a slot in S3.
+func (e *TieredEngine) AddSlotBids(ctx context.Context, bids *types.SlotBids) (int64, error) {
+	return e.primary.AddSlotBids(ctx, bids)
+}
+
+// GetSlotBids retrieves the bids object for a slot from S3.
+func (e *TieredEngine) GetSlotBids(ctx context.Context, slot uint64) (*types.SlotBids, error) {
+	return e.primary.GetSlotBids(ctx, slot)
+}
+
+// PruneSlotBidsBefore prunes bids objects from S3.
+func (e *TieredEngine) PruneSlotBidsBefore(ctx context.Context, maxSlot uint64) (int64, error) {
+	return e.primary.PruneSlotBidsBefore(ctx, maxSlot)
+}

--- a/blockdb/tiered/tiered.go
+++ b/blockdb/tiered/tiered.go
@@ -54,6 +54,7 @@ var (
 	_ types.BlockDbEngine  = (*TieredEngine)(nil)
 	_ types.ExecDataEngine = (*TieredEngine)(nil)
 	_ types.DutiesEngine   = (*TieredEngine)(nil)
+	_ types.SlotBidsEngine = (*TieredEngine)(nil)
 	_ types.TxHashIndex    = (*TieredEngine)(nil)
 )
 

--- a/blockdb/types/bids_format.go
+++ b/blockdb/types/bids_format.go
@@ -1,0 +1,358 @@
+// Package types: per-slot bids object format (BIDS).
+//
+// One object stores all execution payload bids of a single slot together with
+// their gossip observations: which clients saw each bid and when. The object
+// is self-sufficient (full bid fields, not just key tuples), so historic bid
+// data could be served from the blockdb alone without the relational
+// block_bids table. Clients are identified by name via a per-object client
+// table, so objects stay decodable across client config changes. Per-bid
+// observations are stored as a bitmask over the client table plus one
+// first-seen offset (ms from slot start) per set bit.
+//
+// Object layout:
+//
+//	HEADER (20 bytes)
+//	├── Magic:       [4]byte = "BIDS"
+//	├── Version:     uint16
+//	├── Flags:       uint8   (reserved, 0)
+//	├── Reserved:    uint8
+//	├── Slot:        uint64
+//	├── ClientCount: uint16
+//	└── BidCount:    uint16
+//	CLIENT TABLE: per client: uint8 name length + name bytes
+//	BID RECORDS: per bid:
+//	├── ParentRoot:   32 bytes
+//	├── ParentHash:   32 bytes
+//	├── BlockHash:    32 bytes
+//	├── FeeRecipient: 20 bytes
+//	├── BuilderIndex: uint64 (two's complement int64)
+//	├── GasLimit:     uint64
+//	├── Value:        uint64
+//	├── ElPayment:    uint64
+//	├── SeenMask:     ceil(ClientCount/8) bytes (bit i = client table index i)
+//	└── SeenTimes:    int32 per set mask bit, in ascending client index order
+package types
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethpandaops/dora/dbtypes"
+)
+
+// BidsMagic identifies a per-slot bids object.
+var BidsMagic = [4]byte{'B', 'I', 'D', 'S'}
+
+const (
+	// BidsFormatVersion is the current bids object format version.
+	BidsFormatVersion uint16 = 1
+
+	// BidsHeaderSize is the fixed header size for version 1.
+	BidsHeaderSize = 20
+
+	// bidsRecordFixedSize is the fixed part of a bid record (key tuple + bid
+	// fields), before the variable seen mask and times.
+	bidsRecordFixedSize = 32 + 32 + 32 + 20 + 8 + 8 + 8 + 8
+)
+
+// SlotBids holds all bids of one slot with their gossip observations. It is
+// the input to EncodeSlotBids and the result of DecodeSlotBids.
+type SlotBids struct {
+	Slot    uint64
+	Clients []string
+	Bids    []*SlotBidsEntry
+}
+
+// SlotBidsEntry is one bid with its observations. Bid carries the full bid
+// fields; decoded entries derive Bid.Slot from the object and the seen
+// counters from the observations (SeenCount = observer count, SeenTotal =
+// client table size).
+type SlotBidsEntry struct {
+	Bid *dbtypes.BlockBid
+	// SeenMask bit i is set if the client at table index i observed the bid.
+	SeenMask []byte
+	// SeenTimes holds one first-seen offset (ms from slot start) per set mask
+	// bit, in ascending client index order.
+	SeenTimes []int32
+}
+
+// Key returns the string key identifying this bid across objects, built from
+// the bid's dedup tuple (parent root, parent hash, block hash, builder index).
+func (e *SlotBidsEntry) Key() string {
+	var buf bytes.Buffer
+	buf.Grow(len(e.Bid.ParentRoot) + len(e.Bid.ParentHash) + len(e.Bid.BlockHash) + 8)
+	buf.Write(e.Bid.ParentRoot)
+	buf.Write(e.Bid.ParentHash)
+	buf.Write(e.Bid.BlockHash)
+	_ = binary.Write(&buf, binary.BigEndian, e.Bid.BuilderIndex)
+	return buf.String()
+}
+
+// SeenBitSet returns whether the client at table index i observed the bid.
+func (e *SlotBidsEntry) SeenBitSet(i int) bool {
+	if i < 0 || i>>3 >= len(e.SeenMask) {
+		return false
+	}
+	return e.SeenMask[i>>3]&(1<<(i&7)) != 0
+}
+
+// SeenCount returns the number of clients that observed the bid.
+func (e *SlotBidsEntry) SeenCount() int {
+	count := 0
+	for _, b := range e.SeenMask {
+		for ; b != 0; b &= b - 1 {
+			count++
+		}
+	}
+	return count
+}
+
+// SeenByClientIndex returns a map from client table index to first-seen offset
+// (ms from slot start) for all clients that observed the bid.
+func (e *SlotBidsEntry) SeenByClientIndex() map[int]int32 {
+	seen := make(map[int]int32, len(e.SeenTimes))
+	timeIdx := 0
+	for i := 0; i < len(e.SeenMask)*8; i++ {
+		if !e.SeenBitSet(i) {
+			continue
+		}
+		var t int32
+		if timeIdx < len(e.SeenTimes) {
+			t = e.SeenTimes[timeIdx]
+		}
+		seen[i] = t
+		timeIdx++
+	}
+	return seen
+}
+
+// NewSeenObservations builds SeenMask/SeenTimes from a map of client table
+// index to first-seen offset, for a client table of the given size.
+func NewSeenObservations(seen map[int]int32, clientCount int) (mask []byte, times []int32) {
+	mask = make([]byte, (clientCount+7)/8)
+	times = make([]int32, 0, len(seen))
+	for i := range clientCount {
+		t, ok := seen[i]
+		if !ok {
+			continue
+		}
+		mask[i>>3] |= 1 << (i & 7)
+		times = append(times, t)
+	}
+	return mask, times
+}
+
+// EncodeSlotBids packs a SlotBids into a single BIDS object.
+func EncodeSlotBids(s *SlotBids) ([]byte, error) {
+	if len(s.Clients) > 0xffff {
+		return nil, fmt.Errorf("too many clients: %d", len(s.Clients))
+	}
+	if len(s.Bids) > 0xffff {
+		return nil, fmt.Errorf("too many bids: %d", len(s.Bids))
+	}
+
+	var buf bytes.Buffer
+	buf.Write(BidsMagic[:])
+	_ = binary.Write(&buf, binary.BigEndian, BidsFormatVersion)
+	buf.WriteByte(0) // flags
+	buf.WriteByte(0) // reserved
+	_ = binary.Write(&buf, binary.BigEndian, s.Slot)
+	_ = binary.Write(&buf, binary.BigEndian, uint16(len(s.Clients)))
+	_ = binary.Write(&buf, binary.BigEndian, uint16(len(s.Bids)))
+
+	for _, name := range s.Clients {
+		if len(name) > 0xff {
+			name = name[:0xff]
+		}
+		buf.WriteByte(uint8(len(name)))
+		buf.WriteString(name)
+	}
+
+	maskLen := (len(s.Clients) + 7) / 8
+	for _, entry := range s.Bids {
+		bid := entry.Bid
+		if len(bid.ParentRoot) != 32 || len(bid.ParentHash) != 32 || len(bid.BlockHash) != 32 {
+			return nil, fmt.Errorf("invalid bid key tuple lengths")
+		}
+		if len(bid.FeeRecipient) != 20 {
+			return nil, fmt.Errorf("invalid fee recipient length: %d", len(bid.FeeRecipient))
+		}
+		if len(entry.SeenMask) != maskLen {
+			return nil, fmt.Errorf("invalid seen mask length: %d != %d", len(entry.SeenMask), maskLen)
+		}
+		if len(entry.SeenTimes) != entry.SeenCount() {
+			return nil, fmt.Errorf("seen times count %d != seen count %d", len(entry.SeenTimes), entry.SeenCount())
+		}
+
+		buf.Write(bid.ParentRoot)
+		buf.Write(bid.ParentHash)
+		buf.Write(bid.BlockHash)
+		buf.Write(bid.FeeRecipient)
+		_ = binary.Write(&buf, binary.BigEndian, bid.BuilderIndex)
+		_ = binary.Write(&buf, binary.BigEndian, bid.GasLimit)
+		_ = binary.Write(&buf, binary.BigEndian, bid.Value)
+		_ = binary.Write(&buf, binary.BigEndian, bid.ElPayment)
+		buf.Write(entry.SeenMask)
+		for _, t := range entry.SeenTimes {
+			_ = binary.Write(&buf, binary.BigEndian, t)
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
+// DecodeSlotBids decodes a BIDS object.
+func DecodeSlotBids(data []byte) (*SlotBids, error) {
+	if len(data) < BidsHeaderSize {
+		return nil, fmt.Errorf("bids object too short: %d bytes", len(data))
+	}
+	if !bytes.Equal(data[0:4], BidsMagic[:]) {
+		return nil, fmt.Errorf("invalid bids magic")
+	}
+	if version := binary.BigEndian.Uint16(data[4:6]); version != BidsFormatVersion {
+		return nil, fmt.Errorf("unsupported bids version: %d", version)
+	}
+
+	s := &SlotBids{
+		Slot: binary.BigEndian.Uint64(data[8:16]),
+	}
+	clientCount := int(binary.BigEndian.Uint16(data[16:18]))
+	bidCount := int(binary.BigEndian.Uint16(data[18:20]))
+
+	pos := BidsHeaderSize
+	s.Clients = make([]string, 0, clientCount)
+	for range clientCount {
+		if pos >= len(data) {
+			return nil, fmt.Errorf("truncated client table")
+		}
+		nameLen := int(data[pos])
+		pos++
+		if pos+nameLen > len(data) {
+			return nil, fmt.Errorf("truncated client name")
+		}
+		s.Clients = append(s.Clients, string(data[pos:pos+nameLen]))
+		pos += nameLen
+	}
+
+	maskLen := (clientCount + 7) / 8
+	s.Bids = make([]*SlotBidsEntry, 0, bidCount)
+	for range bidCount {
+		if pos+bidsRecordFixedSize+maskLen > len(data) {
+			return nil, fmt.Errorf("truncated bid record")
+		}
+		entry := &SlotBidsEntry{
+			Bid: &dbtypes.BlockBid{
+				ParentRoot:   bytes.Clone(data[pos : pos+32]),
+				ParentHash:   bytes.Clone(data[pos+32 : pos+64]),
+				BlockHash:    bytes.Clone(data[pos+64 : pos+96]),
+				FeeRecipient: bytes.Clone(data[pos+96 : pos+116]),
+				BuilderIndex: int64(binary.BigEndian.Uint64(data[pos+116 : pos+124])),
+				GasLimit:     binary.BigEndian.Uint64(data[pos+124 : pos+132]),
+				Value:        binary.BigEndian.Uint64(data[pos+132 : pos+140]),
+				ElPayment:    binary.BigEndian.Uint64(data[pos+140 : pos+148]),
+				Slot:         s.Slot,
+			},
+			SeenMask: bytes.Clone(data[pos+bidsRecordFixedSize : pos+bidsRecordFixedSize+maskLen]),
+		}
+		pos += bidsRecordFixedSize + maskLen
+
+		seenCount := entry.SeenCount()
+		if pos+4*seenCount > len(data) {
+			return nil, fmt.Errorf("truncated bid seen times")
+		}
+		entry.SeenTimes = make([]int32, 0, seenCount)
+		for range seenCount {
+			entry.SeenTimes = append(entry.SeenTimes, int32(binary.BigEndian.Uint32(data[pos:pos+4])))
+			pos += 4
+		}
+
+		entry.Bid.SeenCount = uint32(seenCount)
+		entry.Bid.SeenTotal = uint32(clientCount)
+		if entry.Bid.SeenCount > entry.Bid.SeenTotal {
+			entry.Bid.SeenTotal = entry.Bid.SeenCount
+		}
+
+		s.Bids = append(s.Bids, entry)
+	}
+
+	return s, nil
+}
+
+// MergeSlotBids merges two bids objects for the same slot, unifying their
+// client tables and bid lists. Observations keep the earliest first-seen
+// offset per client; for bids present in both objects the bid fields of the
+// second (newer) object win. Either argument may be nil.
+func MergeSlotBids(a, b *SlotBids) *SlotBids {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+
+	merged := &SlotBids{
+		Slot:    a.Slot,
+		Clients: make([]string, 0, len(a.Clients)+len(b.Clients)),
+	}
+	clientIdx := make(map[string]int, len(a.Clients)+len(b.Clients))
+	addClient := func(name string) int {
+		if idx, ok := clientIdx[name]; ok {
+			return idx
+		}
+		idx := len(merged.Clients)
+		merged.Clients = append(merged.Clients, name)
+		clientIdx[name] = idx
+		return idx
+	}
+
+	// Register all clients from both tables up front so clients that observed
+	// nothing stay in the table (they are the "not seen" denominator).
+	for _, name := range a.Clients {
+		addClient(name)
+	}
+	for _, name := range b.Clients {
+		addClient(name)
+	}
+
+	// seen maps bid key -> merged client table index -> earliest offset.
+	seen := make(map[string]map[int]int32, len(a.Bids)+len(b.Bids))
+	bids := make(map[string]*dbtypes.BlockBid, len(a.Bids)+len(b.Bids))
+	bidOrder := make([]string, 0, len(a.Bids)+len(b.Bids))
+
+	for _, src := range []*SlotBids{a, b} {
+		for _, entry := range src.Bids {
+			key := entry.Key()
+			obs, exists := seen[key]
+			if !exists {
+				obs = make(map[int]int32, entry.SeenCount())
+				seen[key] = obs
+				bidOrder = append(bidOrder, key)
+			}
+			// Later sources overwrite the bid fields (b is the newer object).
+			bids[key] = entry.Bid
+
+			for srcIdx, t := range entry.SeenByClientIndex() {
+				if srcIdx >= len(src.Clients) {
+					continue
+				}
+				idx := addClient(src.Clients[srcIdx])
+				if existing, ok := obs[idx]; !ok || t < existing {
+					obs[idx] = t
+				}
+			}
+		}
+	}
+
+	merged.Bids = make([]*SlotBidsEntry, 0, len(bidOrder))
+	for _, key := range bidOrder {
+		mask, times := NewSeenObservations(seen[key], len(merged.Clients))
+		merged.Bids = append(merged.Bids, &SlotBidsEntry{
+			Bid:       bids[key],
+			SeenMask:  mask,
+			SeenTimes: times,
+		})
+	}
+
+	return merged
+}

--- a/blockdb/types/bids_format_test.go
+++ b/blockdb/types/bids_format_test.go
@@ -1,0 +1,167 @@
+package types
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/ethpandaops/dora/dbtypes"
+)
+
+// buildTestSlotBids constructs a SlotBids with the given per-bid observations
+// (client table index -> first-seen offset).
+func buildTestSlotBids(slot uint64, clients []string, observations []map[int]int32) *SlotBids {
+	s := &SlotBids{
+		Slot:    slot,
+		Clients: clients,
+		Bids:    make([]*SlotBidsEntry, 0, len(observations)),
+	}
+	for i, seen := range observations {
+		mask, times := NewSeenObservations(seen, len(clients))
+		entry := &SlotBidsEntry{
+			Bid: &dbtypes.BlockBid{
+				ParentRoot:   bytes.Repeat([]byte{byte(i + 1)}, 32),
+				ParentHash:   bytes.Repeat([]byte{byte(i + 2)}, 32),
+				BlockHash:    bytes.Repeat([]byte{byte(i + 3)}, 32),
+				FeeRecipient: bytes.Repeat([]byte{byte(i + 4)}, 20),
+				BuilderIndex: int64(i) - 1, // include the -1 self-built sentinel
+				GasLimit:     30_000_000 + uint64(i),
+				Value:        1_000_000 + uint64(i),
+				ElPayment:    2_000_000 + uint64(i),
+				Slot:         slot,
+			},
+			SeenMask:  mask,
+			SeenTimes: times,
+		}
+		s.Bids = append(s.Bids, entry)
+	}
+	return s
+}
+
+func TestSlotBidsRoundTrip(t *testing.T) {
+	tests := []struct {
+		name         string
+		clients      []string
+		observations []map[int]int32
+	}{
+		{
+			name:         "empty object",
+			clients:      []string{},
+			observations: []map[int]int32{},
+		},
+		{
+			name:         "bid without observations",
+			clients:      []string{"client-1", "client-2"},
+			observations: []map[int]int32{{}},
+		},
+		{
+			name:    "multiple bids and clients",
+			clients: []string{"lighthouse-1", "prysm-1", "teku-1", "nimbus-1", "lodestar-1", "grandine-1", "gossamer-1", "zeam-1", "extra-9"},
+			observations: []map[int]int32{
+				{0: 120, 1: -350, 8: 4000},
+				{2: 0, 3: 65_000},
+				{0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := buildTestSlotBids(12345, tt.clients, tt.observations)
+
+			data, err := EncodeSlotBids(src)
+			if err != nil {
+				t.Fatalf("encode failed: %v", err)
+			}
+
+			decoded, err := DecodeSlotBids(data)
+			if err != nil {
+				t.Fatalf("decode failed: %v", err)
+			}
+
+			if decoded.Slot != src.Slot {
+				t.Errorf("slot mismatch: %d != %d", decoded.Slot, src.Slot)
+			}
+			if len(decoded.Clients) != len(src.Clients) {
+				t.Fatalf("client count mismatch: %d != %d", len(decoded.Clients), len(src.Clients))
+			}
+			if len(src.Clients) > 0 && !reflect.DeepEqual(decoded.Clients, src.Clients) {
+				t.Errorf("clients mismatch: %v != %v", decoded.Clients, src.Clients)
+			}
+			if len(decoded.Bids) != len(src.Bids) {
+				t.Fatalf("bid count mismatch: %d != %d", len(decoded.Bids), len(src.Bids))
+			}
+			for i, entry := range decoded.Bids {
+				srcEntry := src.Bids[i]
+				if !reflect.DeepEqual(entry.SeenByClientIndex(), srcEntry.SeenByClientIndex()) {
+					t.Errorf("bid %d observations mismatch: %v != %v", i, entry.SeenByClientIndex(), srcEntry.SeenByClientIndex())
+				}
+
+				// All bid fields must round-trip; the decoder derives the seen
+				// counters, so align them before comparing.
+				wantBid := *srcEntry.Bid
+				wantBid.SeenCount = uint32(srcEntry.SeenCount())
+				wantBid.SeenTotal = uint32(len(src.Clients))
+				if wantBid.SeenCount > wantBid.SeenTotal {
+					wantBid.SeenTotal = wantBid.SeenCount
+				}
+				if !reflect.DeepEqual(*entry.Bid, wantBid) {
+					t.Errorf("bid %d fields mismatch: %+v != %+v", i, *entry.Bid, wantBid)
+				}
+			}
+		})
+	}
+}
+
+func TestSlotBidsMerge(t *testing.T) {
+	// Stored object: clients A/B, one bid seen by both.
+	stored := buildTestSlotBids(100, []string{"client-a", "client-b"}, []map[int]int32{
+		{0: 500, 1: 700},
+	})
+	// Live object: clients B/C, the same bid (same key tuple: index 0) seen by
+	// B (earlier) and C, plus a new bid.
+	live := buildTestSlotBids(100, []string{"client-b", "client-c"}, []map[int]int32{
+		{0: 300, 1: 900},
+		{1: 1200},
+	})
+
+	merged := MergeSlotBids(stored, live)
+
+	if !reflect.DeepEqual(merged.Clients, []string{"client-a", "client-b", "client-c"}) {
+		t.Fatalf("unexpected merged client table: %v", merged.Clients)
+	}
+	if len(merged.Bids) != 2 {
+		t.Fatalf("unexpected merged bid count: %d", len(merged.Bids))
+	}
+
+	// First bid: A@500, B@min(700,300)=300, C@900.
+	want := map[int]int32{0: 500, 1: 300, 2: 900}
+	if got := merged.Bids[0].SeenByClientIndex(); !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected merged observations: %v != %v", got, want)
+	}
+
+	// Second bid only exists in the live object: C@1200 (index 2 in merged table).
+	want = map[int]int32{2: 1200}
+	if got := merged.Bids[1].SeenByClientIndex(); !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected merged observations for live-only bid: %v != %v", got, want)
+	}
+
+	// For bids present in both objects the newer (live) bid fields win.
+	if merged.Bids[0].Bid != live.Bids[0].Bid {
+		t.Error("merged bid fields should come from the newer object")
+	}
+
+	// Nil handling.
+	if MergeSlotBids(nil, live) != live || MergeSlotBids(stored, nil) != stored {
+		t.Error("nil merge should return the non-nil object")
+	}
+
+	// Merged object must round-trip.
+	data, err := EncodeSlotBids(merged)
+	if err != nil {
+		t.Fatalf("encode of merged object failed: %v", err)
+	}
+	if _, err := DecodeSlotBids(data); err != nil {
+		t.Fatalf("decode of merged object failed: %v", err)
+	}
+}

--- a/blockdb/types/engine.go
+++ b/blockdb/types/engine.go
@@ -128,3 +128,19 @@ type DutiesEngine interface {
 	// before maxFirstSlot. Returns the number of epochs deleted.
 	PruneEpochDutiesBefore(ctx context.Context, maxFirstSlot uint64) (int64, error)
 }
+
+// SlotBidsEngine stores per-slot bids objects: all execution payload bids of
+// a slot with their gossip observations, keyed by slot.
+type SlotBidsEngine interface {
+	// AddSlotBids stores the bids object for a slot, replacing any existing
+	// object. Returns the stored size in bytes.
+	AddSlotBids(ctx context.Context, bids *SlotBids) (int64, error)
+
+	// GetSlotBids retrieves the bids object for a slot.
+	// Returns nil, nil if not found.
+	GetSlotBids(ctx context.Context, slot uint64) (*SlotBids, error)
+
+	// PruneSlotBidsBefore deletes bids objects for all slots before maxSlot.
+	// Returns the number of objects deleted.
+	PruneSlotBidsBefore(ctx context.Context, maxSlot uint64) (int64, error)
+}

--- a/cmd/dora-explorer/main.go
+++ b/cmd/dora-explorer/main.go
@@ -198,6 +198,7 @@ func startFrontend(router *mux.Router) {
 	router.HandleFunc("/slot/{slotOrHash}", handlers.Slot).Methods("GET")
 	router.HandleFunc("/slot/{slotOrHash}/tracoor", handlers.SlotTracoor).Methods("GET")
 	router.HandleFunc("/slot/{slotOrHash}/duties", handlers.SlotDuties).Methods("GET")
+	router.HandleFunc("/slot/{slotOrHash}/bidseen", handlers.SlotBidSeen).Methods("GET")
 	router.HandleFunc("/slot/{root}/blob/{index}", handlers.SlotBlob).Methods("GET")
 	router.HandleFunc("/blocks", handlers.Blocks).Methods("GET")
 	router.HandleFunc("/blocks/filtered", handlers.BlocksFiltered).Methods("GET")

--- a/cmd/dora-utils/blockdb_copy.go
+++ b/cmd/dora-utils/blockdb_copy.go
@@ -104,6 +104,7 @@ func init() {
 	blockdbCopyCmd.Flags().Bool("no-blocks", false, "Skip block data")
 	blockdbCopyCmd.Flags().Bool("no-execdata", false, "Skip execution data")
 	blockdbCopyCmd.Flags().Bool("no-duties", false, "Skip per-epoch duties data")
+	blockdbCopyCmd.Flags().Bool("no-bids", false, "Skip per-slot bids data")
 	blockdbCopyCmd.Flags().Int64("min-slot", -1, "Minimum slot to copy (inclusive, -1 = no limit)")
 	blockdbCopyCmd.Flags().Int64("max-slot", -1, "Maximum slot to copy (inclusive, -1 = no limit)")
 	blockdbCopyCmd.Flags().BoolP("verbose", "v", false, "Verbose output")
@@ -124,6 +125,7 @@ func runBlockdbCopy(cmd *cobra.Command, _ []string) error {
 	noBlocks, _ := cmd.Flags().GetBool("no-blocks")
 	noExecdata, _ := cmd.Flags().GetBool("no-execdata")
 	noDuties, _ := cmd.Flags().GetBool("no-duties")
+	noBids, _ := cmd.Flags().GetBool("no-bids")
 	minSlot, _ := cmd.Flags().GetInt64("min-slot")
 	maxSlot, _ := cmd.Flags().GetInt64("max-slot")
 	verbose, _ := cmd.Flags().GetBool("verbose")
@@ -141,8 +143,8 @@ func runBlockdbCopy(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--target-engine must be 'pebble' or 's3', got %q", targetEngine)
 	}
 
-	if noBlocks && noExecdata && noDuties {
-		return fmt.Errorf("--no-blocks, --no-execdata and --no-duties cannot all be set")
+	if noBlocks && noExecdata && noDuties && noBids {
+		return fmt.Errorf("--no-blocks, --no-execdata, --no-duties and --no-bids cannot all be set")
 	}
 
 	if threads < 1 {
@@ -155,6 +157,7 @@ func runBlockdbCopy(cmd *cobra.Command, _ []string) error {
 		copyBlocks:   !noBlocks,
 		copyExec:     !noExecdata,
 		copyDuties:   !noDuties,
+		copyBids:     !noBids,
 		minSlot:      minSlot,
 		maxSlot:      maxSlot,
 		sourceEngine: sourceEngine,
@@ -255,6 +258,7 @@ type blockdbCopier struct {
 	copyBlocks   bool
 	copyExec     bool
 	copyDuties   bool
+	copyBids     bool
 	minSlot      int64 // -1 = no limit
 	maxSlot      int64 // -1 = no limit
 	sourceEngine string
@@ -372,6 +376,14 @@ func (c *blockdbCopier) run(ctx context.Context) error {
 		}
 	}
 
+	// Bids objects use the same encoding on both backends, so they are copied
+	// as raw bytes via a dedicated pass.
+	if c.copyBids {
+		if err := c.copyBidsPass(ctx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -394,6 +406,12 @@ func (c *blockdbCopier) enumerateS3(ctx context.Context, workCh chan<- copyWorkI
 		}
 
 		c.objectsScanned.Add(1)
+
+		// Bids objects are handled by their own pass.
+		if strings.HasSuffix(obj.Key, "_bids") {
+			c.objectsSkipped.Add(1)
+			continue
+		}
 
 		isExec := strings.HasSuffix(obj.Key, "_exec")
 
@@ -528,6 +546,11 @@ func (c *blockdbCopier) enumeratePebble(ctx context.Context, workCh chan<- copyW
 		}
 
 		ns := binary.BigEndian.Uint16(key[:2])
+
+		// Bids objects (namespace 7) are handled by their own pass.
+		if ns == dpebble.KeyNamespaceBids {
+			continue
+		}
 
 		// Classify entry type.
 		isExecData := ns == pebbleNsExecData && len(key) == 14
@@ -1555,6 +1578,182 @@ func (c *blockdbCopier) writeDutiesPebble(d *btypes.EpochDuties) (int64, error) 
 func copyCmdBuildS3DutiesKey(prefix string, firstSlot uint64) string {
 	name := fmt.Sprintf("%010d_duties", firstSlot)
 	tier := fmt.Sprintf("%06d", firstSlot/10000)
+	if prefix == "" {
+		return path.Join(tier, name)
+	}
+	return path.Join(prefix, tier, name)
+}
+
+// copyBidsPass copies the per-slot bids objects from source to target. Both
+// backends store the same encoded object per slot, so entries are copied as
+// raw bytes without decoding.
+func (c *blockdbCopier) copyBidsPass(ctx context.Context) error {
+	slots, err := c.enumerateBids(ctx)
+	if err != nil {
+		return fmt.Errorf("enumerate bids: %w", err)
+	}
+
+	if len(slots) == 0 {
+		return nil
+	}
+
+	c.logger.WithField("slots", len(slots)).Info("copying bids")
+
+	work := make(chan uint64, c.threads*2)
+
+	var wg sync.WaitGroup
+	for i := 0; i < c.threads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for slot := range work {
+				if err := c.copyBidsSlot(ctx, slot); err != nil {
+					c.errors.Add(1)
+					c.logger.WithError(err).WithField("slot", slot).Error("copy bids failed")
+				}
+			}
+		}()
+	}
+
+	for _, slot := range slots {
+		work <- slot
+	}
+	close(work)
+	wg.Wait()
+
+	return nil
+}
+
+// enumerateBids returns the slots of all bids objects in the source that fall
+// within the configured slot range.
+func (c *blockdbCopier) enumerateBids(ctx context.Context) ([]uint64, error) {
+	switch c.sourceEngine {
+	case "s3":
+		return c.enumerateBidsS3(ctx)
+	case "pebble":
+		return c.enumerateBidsPebble()
+	}
+	return nil, nil
+}
+
+func (c *blockdbCopier) enumerateBidsS3(ctx context.Context) ([]uint64, error) {
+	prefix := c.sourceS3Prefix
+	if prefix != "" && prefix[len(prefix)-1] != '/' {
+		prefix += "/"
+	}
+
+	var slots []uint64
+	objectsCh := c.sourceS3.ListObjects(ctx, c.sourceS3Bucket, minio.ListObjectsOptions{
+		Prefix:    prefix,
+		Recursive: true,
+	})
+	for obj := range objectsCh {
+		if obj.Err != nil {
+			return nil, obj.Err
+		}
+		if !strings.HasSuffix(obj.Key, "_bids") {
+			continue
+		}
+		slot := copyCmdParseSlotFromS3Key(obj.Key)
+		if !c.slotInRange(slot) {
+			c.slotsOutOfRange.Add(1)
+			continue
+		}
+		slots = append(slots, slot)
+	}
+	return slots, nil
+}
+
+func (c *blockdbCopier) enumerateBidsPebble() ([]uint64, error) {
+	lower := make([]byte, 2)
+	binary.BigEndian.PutUint16(lower, dpebble.KeyNamespaceBids)
+	upper := make([]byte, 2)
+	binary.BigEndian.PutUint16(upper, dpebble.KeyNamespaceBids+1)
+
+	iter, err := c.sourcePebble.NewIter(&cpebble.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = iter.Close() }()
+
+	var slots []uint64
+	for iter.First(); iter.Valid(); iter.Next() {
+		key := iter.Key()
+		if len(key) != dpebble.BidsKeyLen {
+			continue
+		}
+		slot := binary.BigEndian.Uint64(key[2:10])
+		if !c.slotInRange(slot) {
+			c.slotsOutOfRange.Add(1)
+			continue
+		}
+		slots = append(slots, slot)
+	}
+	return slots, iter.Error()
+}
+
+// copyBidsSlot reads one slot's bids object from the source and writes it to
+// the target as raw bytes.
+func (c *blockdbCopier) copyBidsSlot(ctx context.Context, slot uint64) error {
+	data, err := c.readBidsRaw(ctx, slot)
+	if err != nil {
+		return err
+	}
+	if data == nil {
+		c.objectsSkipped.Add(1)
+		return nil
+	}
+
+	if err := c.writeBidsRaw(ctx, slot, data); err != nil {
+		return err
+	}
+
+	c.objectsCopied.Add(1)
+	c.bytesCopied.Add(int64(len(data)))
+	return nil
+}
+
+func (c *blockdbCopier) readBidsRaw(ctx context.Context, slot uint64) ([]byte, error) {
+	switch c.sourceEngine {
+	case "s3":
+		key := copyCmdBuildS3BidsKey(c.sourceS3Prefix, slot)
+		obj, err := c.sourceS3.GetObject(ctx, c.sourceS3Bucket, key, minio.GetObjectOptions{})
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = obj.Close() }()
+
+		data, err := io.ReadAll(obj)
+		if err != nil {
+			if minio.ToErrorResponse(err).Code == "NoSuchKey" {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return data, nil
+	case "pebble":
+		return pebbleGet(c.sourcePebble, dpebble.MakeBidsKey(slot))
+	}
+	return nil, nil
+}
+
+func (c *blockdbCopier) writeBidsRaw(ctx context.Context, slot uint64, data []byte) error {
+	switch c.targetEngine {
+	case "s3":
+		key := copyCmdBuildS3BidsKey(c.targetS3Prefix, slot)
+		_, err := c.targetS3.PutObject(ctx, c.targetS3Bucket, key, bytes.NewReader(data), int64(len(data)),
+			minio.PutObjectOptions{ContentType: "application/octet-stream"})
+		return err
+	case "pebble":
+		return c.targetPebble.Set(dpebble.MakeBidsKey(slot), data, cpebble.Sync)
+	}
+	return nil
+}
+
+// copyCmdBuildS3BidsKey builds the S3 object key for a slot's bids object.
+func copyCmdBuildS3BidsKey(prefix string, slot uint64) string {
+	name := fmt.Sprintf("%010d_bids", slot)
+	tier := fmt.Sprintf("%06d", slot/10000)
 	if prefix == "" {
 		return path.Join(tier, name)
 	}

--- a/db/block_bids.go
+++ b/db/block_bids.go
@@ -16,11 +16,11 @@ func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 			dbtypes.DBEnginePgsql:  "INSERT INTO block_bids ",
 			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO block_bids ",
 		}),
-		"(parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment)",
+		"(parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment, seen_count, seen_total)",
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 9
+	fieldCount := 11
 
 	args := make([]any, len(bids)*fieldCount)
 	for i, bid := range bids {
@@ -45,6 +45,8 @@ func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 		args[argIdx+6] = bid.Slot
 		args[argIdx+7] = bid.Value
 		args[argIdx+8] = bid.ElPayment
+		args[argIdx+9] = bid.SeenCount
+		args[argIdx+10] = bid.SeenTotal
 		argIdx += fieldCount
 	}
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
@@ -53,7 +55,9 @@ func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 			"gas_limit = excluded.gas_limit, " +
 			"slot = excluded.slot, " +
 			"value = excluded.value, " +
-			"el_payment = excluded.el_payment",
+			"el_payment = excluded.el_payment, " +
+			"seen_count = excluded.seen_count, " +
+			"seen_total = excluded.seen_total",
 		dbtypes.DBEngineSqlite: "",
 	}))
 
@@ -73,7 +77,7 @@ func GetBidsForSlot(ctx context.Context, slot uint64) []*dbtypes.BlockBid {
 	}
 	fmt.Fprint(&sql, `
 	SELECT
-		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment
+		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment, seen_count, seen_total
 	FROM block_bids
 	WHERE slot = $1
 	ORDER BY value DESC
@@ -95,7 +99,7 @@ func GetBidsForSlotRange(ctx context.Context, minSlot uint64) []*dbtypes.BlockBi
 	}
 	fmt.Fprint(&sql, `
 	SELECT
-		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment
+		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment, seen_count, seen_total
 	FROM block_bids
 	WHERE slot >= $1
 	ORDER BY slot DESC, value DESC
@@ -128,7 +132,7 @@ func GetBidsByBlockHashes(ctx context.Context, blockHashes [][]byte, builderInde
 
 	fmt.Fprint(&sql, `
 	SELECT
-		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment
+		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment, seen_count, seen_total
 	FROM block_bids
 	WHERE builder_index = $1 AND block_hash IN (`)
 
@@ -170,7 +174,7 @@ func GetBidsBySlots(ctx context.Context, slots []uint64, builderIndex int64) map
 
 	fmt.Fprint(&sql, `
 	SELECT
-		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment
+		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment, seen_count, seen_total
 	FROM block_bids
 	WHERE builder_index = $1 AND slot IN (`)
 
@@ -222,7 +226,7 @@ func GetBidsByBuilderIndex(ctx context.Context, builderIndex uint64, minSlot *ui
 	var sql strings.Builder
 	fmt.Fprintf(&sql, `
 	SELECT
-		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment
+		parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment, seen_count, seen_total
 	FROM block_bids
 	%s
 	ORDER BY slot DESC, value DESC

--- a/db/schema/pgsql/20260806000000_bid-seen.sql
+++ b/db/schema/pgsql/20260806000000_bid-seen.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE public."block_bids"
+ ADD COLUMN "seen_count" int NOT NULL DEFAULT 0,
+ ADD COLUMN "seen_total" int NOT NULL DEFAULT 0;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE public."block_bids"
+ DROP COLUMN "seen_count",
+ DROP COLUMN "seen_total";
+
+-- +goose StatementEnd

--- a/db/schema/sqlite/20260806000000_bid-seen.sql
+++ b/db/schema/sqlite/20260806000000_bid-seen.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE "block_bids" ADD "seen_count" int NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE "block_bids" ADD "seen_total" int NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE "block_bids" DROP COLUMN "seen_count";
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE "block_bids" DROP COLUMN "seen_total";
+-- +goose StatementEnd

--- a/dbtypes/dbtypes.go
+++ b/dbtypes/dbtypes.go
@@ -741,6 +741,11 @@ type BlockBid struct {
 	Slot         uint64 `db:"slot"`
 	Value        uint64 `db:"value"`
 	ElPayment    uint64 `db:"el_payment"`
+	// SeenCount is the number of clients that observed the bid on gossip.
+	// SeenTotal is the number of connected clients that could have seen it
+	// (0/0 = unknown, e.g. rows from before seen tracking existed).
+	SeenCount uint32 `db:"seen_count"`
+	SeenTotal uint32 `db:"seen_total"`
 }
 
 type Builder struct {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4273,6 +4273,13 @@ const docTemplate = `{
                 "reorg_depth": {
                     "type": "integer"
                 },
+                "seen_count": {
+                    "description": "Gossip visibility: SeenCount of SeenTotal connected clients observed the bid\non gossip. SeenTotal 0 = no observation data available for this bid.\nPer-client details are served by the /slot/{slotOrHash}/bidseen page endpoint.",
+                    "type": "integer"
+                },
+                "seen_total": {
+                    "type": "integer"
+                },
                 "slot": {
                     "type": "integer"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4270,6 +4270,13 @@
                 "reorg_depth": {
                     "type": "integer"
                 },
+                "seen_count": {
+                    "description": "Gossip visibility: SeenCount of SeenTotal connected clients observed the bid\non gossip. SeenTotal 0 = no observation data available for this bid.\nPer-client details are served by the /slot/{slotOrHash}/bidseen page endpoint.",
+                    "type": "integer"
+                },
+                "seen_total": {
+                    "type": "integer"
+                },
                 "slot": {
                     "type": "integer"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1189,6 +1189,14 @@ definitions:
         type: integer
       reorg_depth:
         type: integer
+      seen_count:
+        description: |-
+          Gossip visibility: SeenCount of SeenTotal connected clients observed the bid
+          on gossip. SeenTotal 0 = no observation data available for this bid.
+          Per-client details are served by the /slot/{slotOrHash}/bidseen page endpoint.
+        type: integer
+      seen_total:
+        type: integer
       slot:
         type: integer
       total_value:

--- a/handlers/api/slot_bids_v1.go
+++ b/handlers/api/slot_bids_v1.go
@@ -64,6 +64,12 @@ type APISlotBid struct {
 	// grandparent_full, grandparent_empty, ancestor-N_full/-empty); empty for orphaned-fork
 	// and unknown-parent bids.
 	CandidateKey string `json:"candidate_key,omitempty"`
+
+	// Gossip visibility: SeenCount of SeenTotal connected clients observed the bid
+	// on gossip. SeenTotal 0 = no observation data available for this bid.
+	// Per-client details are served by the /slot/{slotOrHash}/bidseen page endpoint.
+	SeenCount uint32 `json:"seen_count"`
+	SeenTotal uint32 `json:"seen_total"`
 }
 
 // APISlotBidsV1 returns all execution payload bids submitted for a slot (ePBS, EIP-7732)
@@ -130,6 +136,8 @@ func APISlotBidsV1(w http.ResponseWriter, r *http.Request) {
 			ParentSlot:         bid.ParentSlot,
 			ElParentUnrevealed: bid.ElParentUnrevealed,
 			CandidateKey:       bidCandidateKey(bid),
+			SeenCount:          bid.SeenCount,
+			SeenTotal:          bid.SeenTotal,
 		}
 		if bid.ElParentKnown {
 			elParentSlot := bid.ElParentSlot

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -1556,8 +1556,11 @@ func getSlotPageBids(ctx context.Context, pageData *models.SlotPageBlockData, bl
 			ParentSlot:   bid.ParentSlot,
 			ParentKnown:  bid.ParentKnown,
 			IsParentBid:  bid.ParentClass == services.BidParentClassParent,
+			SeenCount:    bid.SeenCount,
+			SeenTotal:    bid.SeenTotal,
 		}
 		bidData.ClassLabel, bidData.ClassColor, bidData.ClassTitle = describeBidClass(bid)
+		bidData.SeenColor = seenBadgeColor(bid.SeenCount, bid.SeenTotal)
 
 		pageData.Bids = append(pageData.Bids, bidData)
 	}
@@ -1572,6 +1575,21 @@ func getSlotPageBids(ctx context.Context, pageData *models.SlotPageBlockData, bl
 	})
 
 	pageData.BidsCount = uint64(len(pageData.Bids))
+}
+
+// seenBadgeColor derives the badge color for a bid's gossip visibility:
+// green = all connected clients saw it, yellow = majority, red = minority.
+func seenBadgeColor(seenCount, seenTotal uint32) string {
+	switch {
+	case seenTotal == 0:
+		return "secondary"
+	case seenCount >= seenTotal:
+		return "success"
+	case seenCount*2 >= seenTotal:
+		return "warning"
+	default:
+		return "danger"
+	}
 }
 
 // describeBidClass derives the display label, badge color and tooltip for a classified bid.

--- a/handlers/slot_bidseen.go
+++ b/handlers/slot_bidseen.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+
+	"github.com/ethpandaops/dora/services"
+	"github.com/ethpandaops/dora/types/models"
+)
+
+// SlotBidSeen returns which clients observed each execution payload bid of the
+// path slot on gossip, as JSON for the lazy seen-by callout on the slot page.
+func SlotBidSeen(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	vars := mux.Vars(r)
+	slot, err := strconv.ParseUint(vars["slotOrHash"], 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid slot", http.StatusBadRequest)
+		return
+	}
+
+	cacheKey := fmt.Sprintf("slotbidseen:%d", slot)
+	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(cacheKey, true, &models.SlotBidSeenResponse{}, func(pageCall *services.FrontendCacheProcessingPage) any {
+		data, cacheTimeout := buildSlotBidSeenData(pageCall.CallCtx, phase0.Slot(slot))
+		pageCall.CacheTimeout = cacheTimeout
+		return data
+	})
+	if pageErr != nil {
+		logrus.WithError(pageErr).Error("error building slot bid seen data")
+		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
+		return
+	}
+
+	result, ok := pageRes.(*models.SlotBidSeenResponse)
+	if !ok {
+		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		logrus.WithError(err).Error("error encoding slot bid seen data")
+		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
+	}
+}
+
+// buildSlotBidSeenData resolves the bid observations for the slot and returns
+// the response and the cache timeout (long once the slot is out of the live
+// bid cache window, short while observations can still arrive).
+func buildSlotBidSeenData(ctx context.Context, slot phase0.Slot) (*models.SlotBidSeenResponse, time.Duration) {
+	cs := services.GlobalBeaconService
+	chainState := cs.GetChainState()
+
+	result := &models.SlotBidSeenResponse{
+		Clients: []string{},
+		Bids:    []*models.SlotBidSeenBid{},
+	}
+
+	bidSeen := cs.GetSlotBidSeen(ctx, slot)
+	if bidSeen != nil {
+		result.Clients = bidSeen.Clients
+		for _, entry := range bidSeen.Bids {
+			bid := &models.SlotBidSeenBid{
+				ParentRoot:   fmt.Sprintf("0x%x", entry.Bid.ParentRoot),
+				ParentHash:   fmt.Sprintf("0x%x", entry.Bid.ParentHash),
+				BlockHash:    fmt.Sprintf("0x%x", entry.Bid.BlockHash),
+				BuilderIndex: entry.Bid.BuilderIndex,
+				Seen:         make([]*models.SlotBidSeenObservation, 0, len(entry.SeenTimes)),
+			}
+			for clientIdx, seenTime := range entry.SeenByClientIndex() {
+				bid.Seen = append(bid.Seen, &models.SlotBidSeenObservation{
+					Client: clientIdx,
+					Time:   seenTime,
+				})
+			}
+			result.Bids = append(result.Bids, bid)
+		}
+	}
+
+	// Observations can still arrive while the slot is within the live bid
+	// cache window; once past it the stored object no longer changes.
+	cacheTimeout := 12 * time.Second
+	if chainState.CurrentSlot() > slot+32 {
+		cacheTimeout = 30 * time.Minute
+	}
+
+	return result, cacheTimeout
+}

--- a/indexer/beacon/bidcache.go
+++ b/indexer/beacon/bidcache.go
@@ -3,6 +3,8 @@ package beacon
 import (
 	"sync"
 
+	"github.com/ethpandaops/dora/blockdb"
+	btypes "github.com/ethpandaops/dora/blockdb/types"
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
@@ -26,26 +28,113 @@ type bidCacheKey struct {
 	BuilderIndex int64
 }
 
-// blockBidCache caches execution payload bids for recent blocks.
-// Bids for older slots are ignored. The cache is flushed to DB on shutdown
-// or when the slot span exceeds the threshold.
+// cachedBid is a bid with its per-client gossip observations.
+type cachedBid struct {
+	bid *dbtypes.BlockBid
+	// seen maps cache client-table index -> first-seen offset (ms from slot start)
+	seen map[int]int32
+}
+
+// blockBidCache caches execution payload bids for recent blocks and tracks
+// which clients observed each bid on gossip. Bids for older slots are ignored.
+// The cache is flushed to DB (and, when available, the per-slot observations
+// to the blockdb) on shutdown or when the slot span exceeds the threshold.
 type blockBidCache struct {
 	indexer    *Indexer
 	cacheMutex sync.RWMutex
-	bids       map[bidCacheKey]*dbtypes.BlockBid
+	bids       map[bidCacheKey]*cachedBid
 	minSlot    phase0.Slot
 	maxSlot    phase0.Slot
+
+	// clientNames interns observer client names; per-bid observations
+	// reference table indexes. The table only grows within a session.
+	clientNames []string
+	clientIdx   map[string]int
 }
 
 // newBlockBidCache creates a new instance of blockBidCache.
 func newBlockBidCache(indexer *Indexer) *blockBidCache {
 	return &blockBidCache{
-		indexer: indexer,
-		bids:    make(map[bidCacheKey]*dbtypes.BlockBid, 64),
+		indexer:     indexer,
+		bids:        make(map[bidCacheKey]*cachedBid, 64),
+		clientNames: make([]string, 0, 32),
+		clientIdx:   make(map[string]int, 32),
 	}
 }
 
-// loadFromDB loads bids from the last N slots from the database.
+// makeBidCacheKey builds the cache key for a bid.
+func makeBidCacheKey(bid *dbtypes.BlockBid) bidCacheKey {
+	return bidCacheKey{
+		ParentRoot:   phase0.Root(bid.ParentRoot),
+		ParentHash:   phase0.Hash32(bid.ParentHash),
+		BlockHash:    phase0.Hash32(bid.BlockHash),
+		BuilderIndex: bid.BuilderIndex,
+	}
+}
+
+// registerClientLocked interns a client name and returns its table index.
+// Caller must hold the write lock.
+func (cache *blockBidCache) registerClientLocked(name string) int {
+	if idx, ok := cache.clientIdx[name]; ok {
+		return idx
+	}
+	idx := len(cache.clientNames)
+	cache.clientNames = append(cache.clientNames, name)
+	cache.clientIdx[name] = idx
+	return idx
+}
+
+// recordSeenLocked records a gossip observation for a cached bid, keeping the
+// earliest offset per client. Caller must hold the write lock.
+func (cache *blockBidCache) recordSeenLocked(cached *cachedBid, client string, offset int32) {
+	if client == "" {
+		return
+	}
+	idx := cache.registerClientLocked(client)
+	if existing, ok := cached.seen[idx]; !ok || offset < existing {
+		cached.seen[idx] = offset
+	}
+}
+
+// annotateBidLocked returns a copy of the cached bid with up-to-date seen
+// counters. Caller must hold at least the read lock.
+func (cache *blockBidCache) annotateBidLocked(cached *cachedBid) *dbtypes.BlockBid {
+	bid := *cached.bid
+	if count := uint32(len(cached.seen)); count > bid.SeenCount {
+		bid.SeenCount = count
+	}
+	if total := uint32(len(cache.indexer.clients)); total > bid.SeenTotal {
+		bid.SeenTotal = total
+	}
+	if bid.SeenCount > bid.SeenTotal {
+		bid.SeenTotal = bid.SeenCount
+	}
+	return &bid
+}
+
+// seenByNameLocked converts a cached bid's observations to name-keyed form.
+// Caller must hold at least the read lock.
+func (cache *blockBidCache) seenByNameLocked(cached *cachedBid) map[string]int32 {
+	seen := make(map[string]int32, len(cached.seen))
+	for idx, offset := range cached.seen {
+		if idx < len(cache.clientNames) {
+			seen[cache.clientNames[idx]] = offset
+		}
+	}
+	return seen
+}
+
+// sessionClientNames returns the names of all clients attached to the indexer.
+func (cache *blockBidCache) sessionClientNames() []string {
+	names := make([]string, 0, len(cache.indexer.clients))
+	for _, client := range cache.indexer.clients {
+		names = append(names, client.client.GetName())
+	}
+	return names
+}
+
+// loadFromDB loads bids from the last N slots from the database and restores
+// their gossip observations from the blockdb where available.
 func (cache *blockBidCache) loadFromDB(currentSlot phase0.Slot) {
 	cache.cacheMutex.Lock()
 	defer cache.cacheMutex.Unlock()
@@ -55,15 +144,14 @@ func (cache *blockBidCache) loadFromDB(currentSlot phase0.Slot) {
 		minSlot = currentSlot - bidCacheRetainSlots
 	}
 
+	slots := map[uint64]bool{}
 	dbBids := db.GetBidsForSlotRange(cache.indexer.ctx, uint64(minSlot))
 	for _, bid := range dbBids {
-		key := bidCacheKey{
-			ParentRoot:   phase0.Root(bid.ParentRoot),
-			ParentHash:   phase0.Hash32(bid.ParentHash),
-			BlockHash:    phase0.Hash32(bid.BlockHash),
-			BuilderIndex: bid.BuilderIndex,
+		cache.bids[makeBidCacheKey(bid)] = &cachedBid{
+			bid:  bid,
+			seen: make(map[int]int32, 8),
 		}
-		cache.bids[key] = bid
+		slots[bid.Slot] = true
 
 		slot := phase0.Slot(bid.Slot)
 		if cache.minSlot == 0 || slot < cache.minSlot {
@@ -74,14 +162,45 @@ func (cache *blockBidCache) loadFromDB(currentSlot phase0.Slot) {
 		}
 	}
 
+	// Restore per-client observations so a later re-flush merges instead of
+	// starting from scratch.
+	if blockdb.GlobalBlockDb.SupportsSlotBids() {
+		for slot := range slots {
+			slotBids, err := blockdb.GlobalBlockDb.GetSlotBids(cache.indexer.ctx, slot)
+			if err != nil {
+				cache.indexer.logger.Warnf("error loading bid observations for slot %d: %v", slot, err)
+				continue
+			}
+			if slotBids == nil {
+				continue
+			}
+
+			for _, entry := range slotBids.Bids {
+				cached := cache.bids[makeBidCacheKey(entry.Bid)]
+				if cached == nil {
+					continue
+				}
+
+				for clientIdx, offset := range entry.SeenByClientIndex() {
+					if clientIdx < len(slotBids.Clients) {
+						cache.recordSeenLocked(cached, slotBids.Clients[clientIdx], offset)
+					}
+				}
+			}
+		}
+	}
+
 	if len(dbBids) > 0 {
 		cache.indexer.logger.Infof("loaded %d bids from DB (slots %d-%d)", len(dbBids), cache.minSlot, cache.maxSlot)
 	}
 }
 
-// AddBid adds a bid to the cache. Returns true if the bid was added,
-// false if it was ignored (too old) or already exists.
-func (cache *blockBidCache) AddBid(bid *dbtypes.BlockBid) bool {
+// AddBid adds a bid to the cache. seenClient identifies the client that
+// observed the bid on gossip ("" for bids extracted from block bodies) and
+// seenOffset is the observation time as ms offset from the bid's slot start.
+// Returns true if the bid was added, false if it was ignored (too old) or
+// already exists (the observation is still recorded).
+func (cache *blockBidCache) AddBid(bid *dbtypes.BlockBid, seenClient string, seenOffset int32) bool {
 	cache.cacheMutex.Lock()
 	defer cache.cacheMutex.Unlock()
 
@@ -92,19 +211,20 @@ func (cache *blockBidCache) AddBid(bid *dbtypes.BlockBid) bool {
 		return false
 	}
 
-	key := bidCacheKey{
-		ParentRoot:   phase0.Root(bid.ParentRoot),
-		ParentHash:   phase0.Hash32(bid.ParentHash),
-		BlockHash:    phase0.Hash32(bid.BlockHash),
-		BuilderIndex: bid.BuilderIndex,
-	}
+	key := makeBidCacheKey(bid)
 
-	// Check if bid already exists
-	if _, exists := cache.bids[key]; exists {
+	cached, exists := cache.bids[key]
+	if exists {
+		cache.recordSeenLocked(cached, seenClient, seenOffset)
 		return false
 	}
 
-	cache.bids[key] = bid
+	cached = &cachedBid{
+		bid:  bid,
+		seen: make(map[int]int32, 8),
+	}
+	cache.bids[key] = cached
+	cache.recordSeenLocked(cached, seenClient, seenOffset)
 
 	// Update slot bounds
 	if cache.minSlot == 0 || slot < cache.minSlot {
@@ -124,9 +244,9 @@ func (cache *blockBidCache) GetBidsForSlot(slot phase0.Slot) []*dbtypes.BlockBid
 	defer cache.cacheMutex.RUnlock()
 
 	result := make([]*dbtypes.BlockBid, 0)
-	for _, bid := range cache.bids {
-		if phase0.Slot(bid.Slot) == slot {
-			result = append(result, bid)
+	for _, cached := range cache.bids {
+		if phase0.Slot(cached.bid.Slot) == slot {
+			result = append(result, cache.annotateBidLocked(cached))
 		}
 	}
 
@@ -141,20 +261,163 @@ func (cache *blockBidCache) GetBidsByBuilderIndex(builderIndex int64, minSlot ui
 	defer cache.cacheMutex.RUnlock()
 
 	result := make([]*dbtypes.BlockBid, 0)
-	for key, bid := range cache.bids {
+	for key, cached := range cache.bids {
 		if key.BuilderIndex != builderIndex {
 			continue
 		}
-		if bid.Slot < minSlot {
+		if cached.bid.Slot < minSlot {
 			continue
 		}
-		if maxSlot != nil && bid.Slot > *maxSlot {
+		if maxSlot != nil && cached.bid.Slot > *maxSlot {
 			continue
 		}
-		result = append(result, bid)
+		result = append(result, cache.annotateBidLocked(cached))
 	}
 
 	return result
+}
+
+// GetSlotBids assembles the slot's bids with their per-client observations
+// from the cache. Returns nil if the cache holds no bids for the slot.
+func (cache *blockBidCache) GetSlotBids(slot phase0.Slot) *btypes.SlotBids {
+	cache.cacheMutex.RLock()
+	defer cache.cacheMutex.RUnlock()
+
+	bids := make([]*dbtypes.BlockBid, 0, 16)
+	seen := make([]map[string]int32, 0, 16)
+	for _, cached := range cache.bids {
+		if phase0.Slot(cached.bid.Slot) != slot {
+			continue
+		}
+		bids = append(bids, cached.bid)
+		seen = append(seen, cache.seenByNameLocked(cached))
+	}
+
+	if len(bids) == 0 {
+		return nil
+	}
+
+	return buildSlotBids(uint64(slot), cache.sessionClientNames(), bids, seen)
+}
+
+// buildSlotBids assembles a SlotBids object for one slot. The client table
+// holds all session clients (so silent clients stay part of the "not seen"
+// denominator) plus any other observer names present in the data.
+func buildSlotBids(slot uint64, sessionClients []string, bids []*dbtypes.BlockBid, seen []map[string]int32) *btypes.SlotBids {
+	clients := make([]string, 0, len(sessionClients))
+	clientIdx := make(map[string]int, len(sessionClients))
+	addClient := func(name string) int {
+		if idx, ok := clientIdx[name]; ok {
+			return idx
+		}
+		idx := len(clients)
+		clients = append(clients, name)
+		clientIdx[name] = idx
+		return idx
+	}
+	for _, name := range sessionClients {
+		addClient(name)
+	}
+	for _, bidSeen := range seen {
+		for name := range bidSeen {
+			addClient(name)
+		}
+	}
+
+	obj := &btypes.SlotBids{
+		Slot:    slot,
+		Clients: clients,
+		Bids:    make([]*btypes.SlotBidsEntry, 0, len(bids)),
+	}
+	for i, bid := range bids {
+		observations := make(map[int]int32, len(seen[i]))
+		for name, offset := range seen[i] {
+			observations[clientIdx[name]] = offset
+		}
+		mask, times := btypes.NewSeenObservations(observations, len(clients))
+		obj.Bids = append(obj.Bids, &btypes.SlotBidsEntry{
+			Bid:       bid,
+			SeenMask:  mask,
+			SeenTimes: times,
+		})
+	}
+
+	return obj
+}
+
+// flushEntry carries a bid and its name-keyed observations out of the lock.
+type flushEntry struct {
+	bid  *dbtypes.BlockBid
+	seen map[string]int32
+}
+
+// collectFlushEntriesLocked removes the given cached bids from the cache and
+// converts them to flush entries with final seen counters. Caller must hold
+// the write lock.
+func (cache *blockBidCache) collectFlushEntriesLocked(toFlush map[bidCacheKey]*cachedBid) []*flushEntry {
+	entries := make([]*flushEntry, 0, len(toFlush))
+	for key, cached := range toFlush {
+		annotated := cache.annotateBidLocked(cached)
+		entries = append(entries, &flushEntry{
+			bid:  annotated,
+			seen: cache.seenByNameLocked(cached),
+		})
+		delete(cache.bids, key)
+	}
+	return entries
+}
+
+// persistFlushEntries writes flushed bids to the SQL DB and their per-slot
+// observations to the blockdb (merged with any previously stored object).
+// Must be called without holding the cache lock.
+func (cache *blockBidCache) persistFlushEntries(entries []*flushEntry, sessionClients []string) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	if blockdb.GlobalBlockDb.SupportsSlotBids() {
+		bySlot := make(map[uint64][]*flushEntry, bidCacheMaxSlots)
+		for _, entry := range entries {
+			bySlot[entry.bid.Slot] = append(bySlot[entry.bid.Slot], entry)
+		}
+
+		for slot, slotEntries := range bySlot {
+			bids := make([]*dbtypes.BlockBid, 0, len(slotEntries))
+			seen := make([]map[string]int32, 0, len(slotEntries))
+			for _, entry := range slotEntries {
+				bids = append(bids, entry.bid)
+				seen = append(seen, entry.seen)
+			}
+			obj := buildSlotBids(slot, sessionClients, bids, seen)
+
+			// Merge with a previously stored object: the slot may have been
+			// flushed before (partial late bids, restart overlap).
+			stored, err := blockdb.GlobalBlockDb.GetSlotBids(cache.indexer.ctx, slot)
+			if err != nil {
+				cache.indexer.logger.Warnf("error loading stored bids object for slot %d: %v", slot, err)
+			}
+			merged := btypes.MergeSlotBids(stored, obj)
+
+			if _, err := blockdb.GlobalBlockDb.AddSlotBids(cache.indexer.ctx, merged); err != nil {
+				cache.indexer.logger.Errorf("error persisting bids object for slot %d: %v", slot, err)
+			}
+		}
+	}
+
+	bidsToFlush := make([]*dbtypes.BlockBid, 0, len(entries))
+	for _, entry := range entries {
+		bidsToFlush = append(bidsToFlush, entry.bid)
+	}
+
+	err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
+		return db.InsertBids(bidsToFlush, tx)
+	})
+	if err != nil {
+		cache.indexer.logger.Errorf("error flushing bids to db: %v", err)
+		return err
+	}
+
+	return nil
 }
 
 // checkAndFlush checks if the cache needs to be flushed and performs the flush if necessary.
@@ -172,13 +435,14 @@ func (cache *blockBidCache) checkAndFlush() error {
 	cutoffSlot := cache.maxSlot - bidCacheRetainSlots
 
 	// Collect bids to flush (from minSlot to cutoffSlot)
-	bidsToFlush := make([]*dbtypes.BlockBid, 0)
-	for key, bid := range cache.bids {
-		if phase0.Slot(bid.Slot) < cutoffSlot {
-			bidsToFlush = append(bidsToFlush, bid)
-			delete(cache.bids, key)
+	toFlush := make(map[bidCacheKey]*cachedBid, len(cache.bids))
+	for key, cached := range cache.bids {
+		if phase0.Slot(cached.bid.Slot) < cutoffSlot {
+			toFlush[key] = cached
 		}
 	}
+	entries := cache.collectFlushEntriesLocked(toFlush)
+	sessionClients := cache.sessionClientNames()
 
 	// Update minSlot
 	cache.minSlot = cutoffSlot
@@ -186,15 +450,11 @@ func (cache *blockBidCache) checkAndFlush() error {
 	cache.cacheMutex.Unlock()
 
 	// Write to DB outside of lock
-	if len(bidsToFlush) > 0 {
-		err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
-			return db.InsertBids(bidsToFlush, tx)
-		})
-		if err != nil {
-			cache.indexer.logger.Errorf("error flushing bids to db: %v", err)
+	if len(entries) > 0 {
+		if err := cache.persistFlushEntries(entries, sessionClients); err != nil {
 			return err
 		}
-		cache.indexer.logger.Debugf("flushed %d bids to DB (slots < %d)", len(bidsToFlush), cutoffSlot)
+		cache.indexer.logger.Debugf("flushed %d bids to DB (slots < %d)", len(entries), cutoffSlot)
 	}
 
 	return nil
@@ -210,27 +470,23 @@ func (cache *blockBidCache) flushAll() error {
 		return nil
 	}
 
-	bidsToFlush := make([]*dbtypes.BlockBid, 0, len(cache.bids))
-	for _, bid := range cache.bids {
-		bidsToFlush = append(bidsToFlush, bid)
+	toFlush := make(map[bidCacheKey]*cachedBid, len(cache.bids))
+	for key, cached := range cache.bids {
+		toFlush[key] = cached
 	}
+	entries := cache.collectFlushEntriesLocked(toFlush)
+	sessionClients := cache.sessionClientNames()
 
-	// Clear the cache
-	cache.bids = make(map[bidCacheKey]*dbtypes.BlockBid, 64)
 	cache.minSlot = 0
 	cache.maxSlot = 0
 
 	cache.cacheMutex.Unlock()
 
 	// Write to DB outside of lock
-	err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
-		return db.InsertBids(bidsToFlush, tx)
-	})
-	if err != nil {
-		cache.indexer.logger.Errorf("error flushing all bids to db: %v", err)
+	if err := cache.persistFlushEntries(entries, sessionClients); err != nil {
 		return err
 	}
 
-	cache.indexer.logger.Infof("flushed %d bids to DB on shutdown", len(bidsToFlush))
+	cache.indexer.logger.Infof("flushed %d bids to DB on shutdown", len(entries))
 	return nil
 }

--- a/indexer/beacon/client.go
+++ b/indexer/beacon/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -687,6 +688,17 @@ func (c *Client) processExecutionPayloadBidEvent(executionPayloadBidEvent *gloas
 		Value:        uint64(executionPayloadBidEvent.Message.Value),
 		ElPayment:    uint64(executionPayloadBidEvent.Message.ExecutionPayment),
 	}
-	c.indexer.blockBidCache.AddBid(bid)
+
+	// Track this client's observation with the receive time as offset from
+	// the bid's slot start (may be negative for bids gossiped ahead of slot).
+	chainState := c.client.GetPool().GetChainState()
+	seenOffset := time.Since(chainState.SlotToTime(executionPayloadBidEvent.Message.Slot)).Milliseconds()
+	if seenOffset > math.MaxInt32 {
+		seenOffset = math.MaxInt32
+	} else if seenOffset < math.MinInt32 {
+		seenOffset = math.MinInt32
+	}
+
+	c.indexer.blockBidCache.AddBid(bid, c.client.GetName(), int32(seenOffset))
 	return nil
 }

--- a/indexer/beacon/indexer_getter.go
+++ b/indexer/beacon/indexer_getter.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"sort"
 
+	btypes "github.com/ethpandaops/dora/blockdb/types"
 	"github.com/ethpandaops/dora/clients/consensus"
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
@@ -572,6 +573,13 @@ func (indexer *Indexer) GetBlockBidsForSlot(slot phase0.Slot) []*dbtypes.BlockBi
 // the given slot window. Callers merge these with the DB results (see ChainService.GetBuilderBids).
 func (indexer *Indexer) GetCachedBidsByBuilderIndex(builderIndex int64, minSlot uint64, maxSlot *uint64) []*dbtypes.BlockBid {
 	return indexer.blockBidCache.GetBidsByBuilderIndex(builderIndex, minSlot, maxSlot)
+}
+
+// GetSlotBidsWithSeen returns the slot's bids with their per-client gossip
+// observations from the bid cache. Returns nil if the cache holds no bids for
+// the slot (flushed or never seen).
+func (indexer *Indexer) GetSlotBidsWithSeen(slot phase0.Slot) *btypes.SlotBids {
+	return indexer.blockBidCache.GetSlotBids(slot)
 }
 
 // StreamActiveBuilderDataForRoot streams the available builder set data for a given blockRoot.

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -430,9 +430,11 @@ func (dbw *dbWriter) buildDbBlock(block *Block, epochStats *EpochStats, override
 
 	// Extract execution payload bid from Gloas/Heze blocks and add to bid cache.
 	// This ensures bids are persisted even when syncing from blocks (not just SSE events).
+	// A bid extracted from a block body is not a gossip observation, so no
+	// observer client is recorded.
 	blockBid := getBlockBid(blockBody)
 	if blockBid != nil {
-		dbw.indexer.blockBidCache.AddBid(blockBid)
+		dbw.indexer.blockBidCache.AddBid(blockBid, "", 0)
 	}
 
 	// Post-Gloas the blob commitments come from the bid, but the blobs themselves only

--- a/services/chainservice_bids.go
+++ b/services/chainservice_bids.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 
+	"github.com/ethpandaops/dora/blockdb"
+	btypes "github.com/ethpandaops/dora/blockdb/types"
 	"github.com/ethpandaops/dora/dbtypes"
 )
 
@@ -67,6 +69,25 @@ type ClassifiedBlockBid struct {
 	// ElParentUnrevealed indicates the bid's parent hash matches a committed payload hash
 	// that was never revealed on the reference chain - such a bid can never become valid.
 	ElParentUnrevealed bool
+}
+
+// GetSlotBidSeen returns which clients observed each execution payload bid of
+// the given slot on gossip, merging live cache observations with the persisted
+// blockdb bids object (recent slots live in the cache; flushed slots only in
+// the blockdb). Returns nil if no observation data is available.
+func (bs *ChainService) GetSlotBidSeen(ctx context.Context, slot phase0.Slot) *btypes.SlotBids {
+	cached := bs.beaconIndexer.GetSlotBidsWithSeen(slot)
+
+	var stored *btypes.SlotBids
+	if blockdb.GlobalBlockDb.SupportsSlotBids() {
+		var err error
+		stored, err = blockdb.GlobalBlockDb.GetSlotBids(ctx, uint64(slot))
+		if err != nil {
+			bs.logger.Warnf("error loading bids object for slot %d: %v", slot, err)
+		}
+	}
+
+	return btypes.MergeSlotBids(stored, cached)
 }
 
 // GetSlotBidsClassified returns all execution payload bids for the given slot (regardless

--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -13,6 +13,7 @@
           <th class="border-0">Value</th>
           <th class="border-0">EL Payment</th>
           <th class="border-0">Total</th>
+          <th class="border-0">Seen by</th>
         </tr>
       </thead>
       <tbody>
@@ -60,9 +61,100 @@
             <td>{{ formatEthFromGwei $bid.Value }}</td>
             <td>{{ formatEthFromGwei $bid.ElPayment }}</td>
             <td><strong>{{ formatEthFromGwei $bid.TotalValue }}</strong></td>
+            <td>
+              {{ if gt $bid.SeenTotal 0 }}
+                <a class="badge bg-{{ $bid.SeenColor }}{{ if eq $bid.SeenColor "warning" }} text-dark{{ end }} text-decoration-none" data-bs-toggle="collapse" href="#bid-seen-{{ $i }}" role="button" title="{{ $bid.SeenCount }} of {{ $bid.SeenTotal }} connected clients saw this bid on gossip - click for details">{{ $bid.SeenCount }}/{{ $bid.SeenTotal }} <i class="fas fa-caret-down"></i></a>
+              {{ else }}
+                <span class="text-muted" data-bs-toggle="tooltip" title="No gossip observation data for this bid">-</span>
+              {{ end }}
+            </td>
           </tr>
+          {{ if gt $bid.SeenTotal 0 }}
+            <tr class="collapse" id="bid-seen-{{ $i }}">
+              <td colspan="11" class="bid-seen-details border-top-0 pt-0"
+                  data-block-hash="0x{{ printf "%x" $bid.BlockHash }}"
+                  data-builder-index="{{ if $bid.IsSelfBuilt }}-1{{ else }}{{ $bid.BuilderIndex }}{{ end }}"
+                  data-parent-root="0x{{ printf "%x" $bid.ParentRoot }}"
+                  data-parent-hash="0x{{ printf "%x" $bid.ParentHash }}">
+                <span class="text-muted">Loading...</span>
+              </td>
+            </tr>
+          {{ end }}
         {{ end }}
       </tbody>
     </table>
   </div>
+  {{ if .Block.Bids }}
+    <script type="text/javascript">
+      (function() {
+        var bidSeenSlot = {{ .Slot }};
+        var bidSeenPromise = null;
+
+        function loadBidSeen() {
+          if (bidSeenPromise) return bidSeenPromise;
+          bidSeenPromise = fetch('/slot/' + bidSeenSlot + '/bidseen')
+            .then(function(r) { return r.json(); });
+          return bidSeenPromise;
+        }
+        function escapeHtml(s) {
+          return String(s).replace(/[&<>"']/g, function(c) {
+            return {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c];
+          });
+        }
+        function formatOffset(ms) {
+          var sign = ms < 0 ? '-' : '+';
+          var abs = Math.abs(ms);
+          if (abs >= 1000) return sign + (abs / 1000).toFixed(2) + 's';
+          return sign + abs + 'ms';
+        }
+        function render(el, clients, bid) {
+          var seen = bid && bid.seen ? bid.seen.slice() : [];
+          seen.sort(function(a, b) { return a.time - b.time; });
+          var seenIdx = {};
+          var html = '<div class="pt-1">';
+          html += '<div><strong>Seen by ' + seen.length + ' client' + (seen.length === 1 ? '' : 's') + ':</strong> ';
+          if (seen.length) {
+            seen.forEach(function(o) {
+              seenIdx[o.client] = true;
+              var name = clients[o.client] !== undefined ? clients[o.client] : ('client-' + o.client);
+              html += '<span class="badge bg-success me-1 mb-1">' + escapeHtml(name) +
+                ' <span class="opacity-75">' + formatOffset(o.time) + '</span></span>';
+            });
+          } else {
+            html += '<span class="text-muted">none (bid known from block body only)</span>';
+          }
+          html += '</div>';
+          var notSeen = [];
+          clients.forEach(function(name, idx) { if (!seenIdx[idx]) notSeen.push(name); });
+          if (notSeen.length) {
+            html += '<div><strong>Not seen by ' + notSeen.length + ':</strong> ';
+            notSeen.forEach(function(name) {
+              html += '<span class="badge bg-secondary me-1 mb-1">' + escapeHtml(name) + '</span>';
+            });
+            html += '</div>';
+          }
+          html += '</div>';
+          el.innerHTML = html;
+        }
+
+        document.querySelectorAll('.bid-seen-details').forEach(function(el) {
+          el.closest('tr').addEventListener('shown.bs.collapse', function() {
+            if (el.dataset.loaded) return;
+            loadBidSeen().then(function(data) {
+              var bid = (data.bids || []).find(function(b) {
+                return b.block_hash === el.dataset.blockHash &&
+                  String(b.builder_index) === el.dataset.builderIndex &&
+                  b.parent_root === el.dataset.parentRoot &&
+                  b.parent_hash === el.dataset.parentHash;
+              });
+              render(el, data.clients || [], bid);
+              el.dataset.loaded = '1';
+            }).catch(function() {
+              el.innerHTML = '<span class="text-danger">Failed to load bid observations</span>';
+            });
+          });
+        });
+      })();
+    </script>
+  {{ end }}
 {{ end }}

--- a/types/config.go
+++ b/types/config.go
@@ -323,6 +323,9 @@ type PebbleBlockDBConfig struct {
 	BlockRetention    BlockDbRetentionConfig `yaml:"blockRetention"`
 	ExecDataRetention BlockDbRetentionConfig `yaml:"execDataRetention"`
 	DutiesRetention   BlockDbRetentionConfig `yaml:"dutiesRetention"`
+	// BidsRetention governs per-slot bids objects (bids + gossip observations).
+	// Only applies in pebble mode - in tiered mode bids objects live in S3 only.
+	BidsRetention BlockDbRetentionConfig `yaml:"bidsRetention"`
 
 	// Interval between retention cleanup runs (default 12h, negative = disabled).
 	CleanupInterval time.Duration `yaml:"cleanupInterval" envconfig:"BLOCKDB_PEBBLE_CLEANUP_INTERVAL"`

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -184,6 +184,32 @@ type SlotDutiesResponse struct {
 	Names      map[uint64]string `json:"names"`
 }
 
+// SlotBidSeenResponse is the JSON payload returned by the lazy bid observation
+// endpoint (/slot/{slot}/bidseen). Clients holds the observer client names;
+// per-bid observations reference them by index.
+type SlotBidSeenResponse struct {
+	Clients []string          `json:"clients"`
+	Bids    []*SlotBidSeenBid `json:"bids"`
+}
+
+// SlotBidSeenBid holds the observations for a single bid, identified by its
+// dedup key tuple (parent root, parent hash, block hash, builder index).
+type SlotBidSeenBid struct {
+	ParentRoot   string                    `json:"parent_root"`
+	ParentHash   string                    `json:"parent_hash"`
+	BlockHash    string                    `json:"block_hash"`
+	BuilderIndex int64                     `json:"builder_index"`
+	Seen         []*SlotBidSeenObservation `json:"seen"`
+}
+
+// SlotBidSeenObservation is one client's first sighting of a bid.
+type SlotBidSeenObservation struct {
+	// Client is an index into SlotBidSeenResponse.Clients.
+	Client int `json:"client"`
+	// Time is the first-seen offset in ms from the bid's slot start.
+	Time int32 `json:"time"`
+}
+
 type SlotPageAttestation struct {
 	Slot           uint64   `json:"slot"`
 	CommitteeIndex []uint64 `json:"committeeindex"`
@@ -400,6 +426,12 @@ type SlotPageBid struct {
 	ParentSlot  uint64 `json:"parent_slot"`   // slot of the targeted beacon parent block
 	ParentKnown bool   `json:"parent_known"`  // targeted beacon parent block was resolved (enables linking)
 	IsParentBid bool   `json:"is_parent_bid"` // targets the displayed block's actual parent root (others are listed last, grayed out)
+
+	// Gossip visibility: how many of the connected clients observed the bid.
+	// SeenTotal 0 = no observation data (rows from before seen tracking).
+	SeenCount uint32 `json:"seen_count"`
+	SeenTotal uint32 `json:"seen_total"`
+	SeenColor string `json:"seen_color"` // badge color key: success|warning|danger
 }
 
 // SlotPageBuilderPayment holds the Gloas builder-payment vote quorum for a slot: the same-slot


### PR DESCRIPTION
## Overview

Dora tracks and deduplicates execution payload bids (ePBS), but discarded *which* clients observed each bid on gossip — a major visibility gap. This PR records per-client bid observations (including first-seen timing) with minimal overhead and surfaces them in the slot page's bid list.

<img width="1506" height="137" alt="image" src="https://github.com/user-attachments/assets/41a51dfc-6d1a-4b20-9cb0-088e37e40678" />

## How it works

**Ingestion:** The bid cache (`blockBidCache`) interns observer client names and keeps a per-bid map of `client → first-seen offset` (ms from slot start, negative = gossiped ahead of the slot). Duplicate SSE bid events — previously discarded — now record the observation: the hot path goes from "map lookup, drop" to "map lookup, record one entry". Bids extracted from block bodies record no observer, so `0/N` genuinely means "nobody saw it on gossip".

**Storage (two tiers):**
- `block_bids` (SQL) only gains two int columns: `seen_count` / `seen_total`, stamped at flush time. `0/0` marks pre-feature rows.
- The full data goes to the blockdb as a self-sufficient per-slot `BIDS` object (`<slot>_bids` in S3, namespace 7 in pebble): client-name table + full bid fields + seen bitmask + per-client first-seen offsets (~5 KB/slot). Since entries carry the complete bid, historic bid data could later be served from the blockdb alone, without the relational table. Flushes do read-merge-write so restarts and late-arriving bids union instead of clobber; observations are restored into the cache on startup. Persistence is optional — without a blockdb, counts still work for all slots and the detail view covers cached slots.

**UI:** The bids table gets a "Seen by" column with a colored `42/50` badge (green = all clients, yellow = majority, red = minority) rendered purely from the SQL columns — no blockdb access on page load. Expanding the callout row lazily fetches `/slot/{slot}/bidseen` once per page (frontend-cached), showing "Seen by" chips with per-client delays (`+380ms`) and a "Not seen by" group.

**API:** `seen_count` / `seen_total` added to `/v1/slot/{slotOrHash}/bids`; docs regenerated.

## Config

- `blockDb.pebble.bidsRetention` — optional retention for bids objects (pebble mode; tiered mode stores them in S3 only, uncached).

## Tooling

- `dora-utils blockdb-copy` gains a `--no-bids` flag and a dedicated raw-bytes bids pass (identical encoding on both backends); the block passes explicitly skip `_bids` objects / namespace 7.

## Overhead

Hot path: one bitset/map insert per duplicate event. Memory: <200 KB for the cache window. Storage: ~5 KB/slot, one blockdb write per slot at flush. Historic slot pages only touch the blockdb when the seen callout is expanded.
