### PR TITLE
Bid seen tracking: popover callout, counter fixes, nimbus event support

### DIFF
--- a/clients/consensus/rpc/beaconstream.go
+++ b/clients/consensus/rpc/beaconstream.go
@@ -444,26 +444,35 @@ func (bs *BeaconStream) processExecutionPayloadAvailableEvent(evt eventstream.St
 	}
 }
 
-func (bs *BeaconStream) processExecutionPayloadBidEvent(evt eventstream.StreamEvent) {
-	// the event is wrapped in a versioned envelope: {"version":"gloas","data":{...}}
+// parseExecutionPayloadBidEvent decodes an execution_payload_bid stream event.
+// Most clients wrap the event in a versioned envelope ({"version":"gloas","data":{...}}),
+// but Nimbus sends the bare SignedExecutionPayloadBid container. The envelope is
+// unwrapped when present, otherwise the raw payload is decoded directly.
+func parseExecutionPayloadBidEvent(data []byte) (*gloas.SignedExecutionPayloadBid, error) {
 	var envelope struct {
 		Data json.RawMessage `json:"data"`
 	}
-
-	if err := json.Unmarshal([]byte(evt.Data()), &envelope); err != nil {
-		bs.logger.Warnf("beacon block stream failed to decode execution_payload_bid event: %v", err)
-		return
+	if err := json.Unmarshal(data, &envelope); err == nil && len(envelope.Data) > 0 && string(envelope.Data) != "null" {
+		data = envelope.Data
 	}
 
-	var parsed gloas.SignedExecutionPayloadBid
-	if err := json.Unmarshal(envelope.Data, &parsed); err != nil {
+	parsed := &gloas.SignedExecutionPayloadBid{}
+	if err := json.Unmarshal(data, parsed); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func (bs *BeaconStream) processExecutionPayloadBidEvent(evt eventstream.StreamEvent) {
+	parsed, err := parseExecutionPayloadBidEvent([]byte(evt.Data()))
+	if err != nil {
 		bs.logger.Warnf("beacon block stream failed to decode execution_payload_bid event: %v", err)
 		return
 	}
 
 	bs.EventChan <- &BeaconStreamEvent{
 		Event: StreamExecutionPayloadBidEvent,
-		Data:  &parsed,
+		Data:  parsed,
 	}
 }
 

--- a/clients/consensus/rpc/beaconstream_test.go
+++ b/clients/consensus/rpc/beaconstream_test.go
@@ -1,0 +1,48 @@
+package rpc
+
+import (
+	"fmt"
+	"testing"
+)
+
+// bidEventPayload is a SignedExecutionPayloadBid container as sent by Nimbus
+// (captured from a glamsterdam-devnet-7 node), which omits the versioned
+// envelope other clients wrap the event in.
+const bidEventPayload = `{"message":{"parent_block_hash":"0xd82482d1aef3ee998e6a638ddc8ee7f7540aa121af3a1e89f65fed989f56e449","parent_block_root":"0xf9b85fb511fa7a8561fac828fc390e61a64804e851da4816d7a62cc4648d3e2e","block_hash":"0xd18d394228734ff07fd17542df9294c86b779999805e7895379b9f6699b68487","prev_randao":"0xf66c5be439378224329f796401778ab62f725192604ba4a4a5be5b4514d04817","fee_recipient":"0xf97e180c050e5ab072211ad2c213eb5aee4df134","gas_limit":"300000000","builder_index":"3","slot":"168775","value":"471708347","execution_payment":"0","blob_kzg_commitments":["0xa95caabd009e189b9f205e0328ff847ad886e4f8e719bd7219875fbb9688fb3fbe7704bb1dfa7e2993a3dea8d0cf767d"],"execution_requests_root":"0x87b69a306c8e430d0857f7c4ac5e27cecffa1108d43c2e5df7388056fea7a423"},"signature":"0xb399a174693747e9437ba1d94be3ad3e7556a388a6d3e4e7589cea7310735e04296086a957f9a3652d5e14731561151900f4532f72227b60f06449068d610794e8ee273bd00b3179030242096fb95a17cf0277528c7c6c8ddf5a408fca069ad2"}`
+
+func TestParseExecutionPayloadBidEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{
+			name: "versioned envelope",
+			data: fmt.Sprintf(`{"version":"gloas","data":%s}`, bidEventPayload),
+		},
+		{
+			name: "bare container (nimbus)",
+			data: bidEventPayload,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bid, err := parseExecutionPayloadBidEvent([]byte(tt.data))
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			if bid.Message == nil {
+				t.Fatal("parsed bid has no message")
+			}
+			if uint64(bid.Message.Slot) != 168775 {
+				t.Errorf("unexpected slot: %d", bid.Message.Slot)
+			}
+			if uint64(bid.Message.BuilderIndex) != 3 {
+				t.Errorf("unexpected builder index: %d", bid.Message.BuilderIndex)
+			}
+			if uint64(bid.Message.Value) != 471708347 {
+				t.Errorf("unexpected value: %d", bid.Message.Value)
+			}
+		})
+	}
+}

--- a/db/block_bids.go
+++ b/db/block_bids.go
@@ -12,10 +12,7 @@ import (
 func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 	var sql strings.Builder
 	fmt.Fprint(&sql,
-		EngineQuery(map[dbtypes.DBEngineType]string{
-			dbtypes.DBEnginePgsql:  "INSERT INTO block_bids ",
-			dbtypes.DBEngineSqlite: "INSERT OR REPLACE INTO block_bids ",
-		}),
+		"INSERT INTO block_bids ",
 		"(parent_root, parent_hash, block_hash, fee_recipient, gas_limit, builder_index, slot, value, el_payment, seen_count, seen_total)",
 		" VALUES ",
 	)
@@ -49,6 +46,9 @@ func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 		args[argIdx+10] = bid.SeenTotal
 		argIdx += fieldCount
 	}
+	// Bids can be re-added to the cache with a fresh (empty) observation state
+	// after their slot was already flushed (e.g. re-extracted from a block body),
+	// so a later flush must never shrink the seen counters of an existing row.
 	fmt.Fprint(&sql, EngineQuery(map[dbtypes.DBEngineType]string{
 		dbtypes.DBEnginePgsql: " ON CONFLICT (parent_root, parent_hash, block_hash, builder_index) DO UPDATE SET " +
 			"fee_recipient = excluded.fee_recipient, " +
@@ -56,9 +56,16 @@ func InsertBids(bids []*dbtypes.BlockBid, tx *sqlx.Tx) error {
 			"slot = excluded.slot, " +
 			"value = excluded.value, " +
 			"el_payment = excluded.el_payment, " +
-			"seen_count = excluded.seen_count, " +
-			"seen_total = excluded.seen_total",
-		dbtypes.DBEngineSqlite: "",
+			"seen_count = GREATEST(block_bids.seen_count, excluded.seen_count), " +
+			"seen_total = GREATEST(block_bids.seen_total, excluded.seen_total)",
+		dbtypes.DBEngineSqlite: " ON CONFLICT (parent_root, parent_hash, block_hash, builder_index) DO UPDATE SET " +
+			"fee_recipient = excluded.fee_recipient, " +
+			"gas_limit = excluded.gas_limit, " +
+			"slot = excluded.slot, " +
+			"value = excluded.value, " +
+			"el_payment = excluded.el_payment, " +
+			"seen_count = MAX(block_bids.seen_count, excluded.seen_count), " +
+			"seen_total = MAX(block_bids.seen_total, excluded.seen_total)",
 	}))
 
 	_, err := tx.Exec(sql.String(), args...)

--- a/indexer/beacon/indexer_getter.go
+++ b/indexer/beacon/indexer_getter.go
@@ -540,33 +540,39 @@ func (indexer *Indexer) GetInclusionListsBySlot(slot phase0.Slot) []*v1.SignedIn
 
 // GetBlockBidsForSlot returns all execution payload bids for a slot regardless of their
 // parent root, so bids targeting other forks or deeper ancestors (reorg bids) are included.
-// Cache and DB results are merged since a slot's bids can be spread across both around a flush.
+// Cache and DB results are merged since a slot's bids can be spread across both around a
+// flush. A bid present in both may carry a fresh (empty) observation state in the cache
+// (re-added after its slot was flushed), so the seen counters are merged by maximum.
 func (indexer *Indexer) GetBlockBidsForSlot(slot phase0.Slot) []*dbtypes.BlockBid {
 	bids := indexer.blockBidCache.GetBidsForSlot(slot)
 
-	seenBids := make(map[bidCacheKey]bool, len(bids))
+	cachedBids := make(map[bidCacheKey]*dbtypes.BlockBid, len(bids))
 	for _, bid := range bids {
-		seenBids[bidCacheKey{
-			ParentRoot:   phase0.Root(bid.ParentRoot),
-			ParentHash:   phase0.Hash32(bid.ParentHash),
-			BlockHash:    phase0.Hash32(bid.BlockHash),
-			BuilderIndex: bid.BuilderIndex,
-		}] = true
+		cachedBids[makeBidCacheKey(bid)] = bid
 	}
 
 	for _, bid := range db.GetBidsForSlot(indexer.ctx, uint64(slot)) {
-		key := bidCacheKey{
-			ParentRoot:   phase0.Root(bid.ParentRoot),
-			ParentHash:   phase0.Hash32(bid.ParentHash),
-			BlockHash:    phase0.Hash32(bid.BlockHash),
-			BuilderIndex: bid.BuilderIndex,
+		if cached := cachedBids[makeBidCacheKey(bid)]; cached != nil {
+			mergeBidSeenCounters(cached, bid)
+			continue
 		}
-		if !seenBids[key] {
-			bids = append(bids, bid)
-		}
+		bids = append(bids, bid)
 	}
 
 	return bids
+}
+
+// mergeBidSeenCounters raises dst's seen counters to at least src's values.
+func mergeBidSeenCounters(dst *dbtypes.BlockBid, src *dbtypes.BlockBid) {
+	if src.SeenCount > dst.SeenCount {
+		dst.SeenCount = src.SeenCount
+	}
+	if src.SeenTotal > dst.SeenTotal {
+		dst.SeenTotal = src.SeenTotal
+	}
+	if dst.SeenCount > dst.SeenTotal {
+		dst.SeenTotal = dst.SeenCount
+	}
 }
 
 // GetCachedBidsByBuilderIndex returns the not-yet-flushed (recent) bids for a builder index within

--- a/services/chainservice_builder.go
+++ b/services/chainservice_builder.go
@@ -342,15 +342,23 @@ func (bs *ChainService) GetBuilderBids(ctx context.Context, builderIndex uint64,
 		parentHash string
 		blockHash  string
 	}
-	seen := make(map[bidKey]bool, len(cacheBids)+len(dbBids))
+	seen := make(map[bidKey]*dbtypes.BlockBid, len(cacheBids)+len(dbBids))
 	merged := make([]*dbtypes.BlockBid, 0, len(cacheBids)+len(dbBids))
 	appendUnique := func(bids []*dbtypes.BlockBid) {
 		for _, bid := range bids {
 			key := bidKey{string(bid.ParentRoot), string(bid.ParentHash), string(bid.BlockHash)}
-			if seen[key] {
+			if existing := seen[key]; existing != nil {
+				// A bid re-added to the cache after its slot was flushed carries a
+				// fresh (empty) observation state; keep the higher seen counters.
+				if bid.SeenCount > existing.SeenCount {
+					existing.SeenCount = bid.SeenCount
+				}
+				if bid.SeenTotal > existing.SeenTotal {
+					existing.SeenTotal = bid.SeenTotal
+				}
 				continue
 			}
-			seen[key] = true
+			seen[key] = bid
 			merged = append(merged, bid)
 		}
 	}

--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -71,12 +71,14 @@
           </tr>
           {{ if gt $bid.SeenTotal 0 }}
             <tr class="collapse" id="bid-seen-{{ $i }}">
-              <td colspan="11" class="bid-seen-details border-top-0 pt-0"
+              <td colspan="11" class="bid-seen-details border-top-0 py-0"
                   data-block-hash="0x{{ printf "%x" $bid.BlockHash }}"
                   data-builder-index="{{ if $bid.IsSelfBuilt }}-1{{ else }}{{ $bid.BuilderIndex }}{{ end }}"
                   data-parent-root="0x{{ printf "%x" $bid.ParentRoot }}"
                   data-parent-hash="0x{{ printf "%x" $bid.ParentHash }}">
-                <span class="text-muted">Loading...</span>
+                <div class="bid-seen-callout my-2">
+                  <span class="text-muted">Loading...</span>
+                </div>
               </td>
             </tr>
           {{ end }}
@@ -84,6 +86,47 @@
       </tbody>
     </table>
   </div>
+  <style>
+    /* the .table-ellipsis wrapper clamps every descendant td to 200px with
+       hidden overflow; lift that for the seen-details cell and its inner table */
+    #block_bids td.bid-seen-details {
+      max-width: none;
+      overflow: visible;
+      white-space: normal;
+    }
+    #block_bids .bid-seen-callout {
+      max-width: 34rem;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid var(--bs-border-color);
+      border-left: 3px solid var(--bs-primary);
+      border-radius: var(--bs-border-radius);
+      background-color: var(--bs-tertiary-bg);
+    }
+    #block_bids .bid-seen-scroll {
+      max-height: 16rem;
+      overflow-y: auto;
+    }
+    #block_bids .bid-seen-callout .table {
+      --bs-table-bg: transparent;
+    }
+    #block_bids .bid-seen-callout .table th,
+    #block_bids .bid-seen-callout .table td {
+      max-width: none;
+      overflow: visible;
+      white-space: nowrap;
+    }
+    #block_bids .bid-seen-callout .table td:nth-child(2) {
+      max-width: 22rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    #block_bids .bid-seen-scroll thead th {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background-color: var(--bs-tertiary-bg);
+    }
+  </style>
   {{ if .Block.Bids }}
     <script type="text/javascript">
       (function() {
@@ -107,37 +150,51 @@
           if (abs >= 1000) return sign + (abs / 1000).toFixed(2) + 's';
           return sign + abs + 'ms';
         }
-        function render(el, clients, bid) {
-          var seen = bid && bid.seen ? bid.seen.slice() : [];
-          seen.sort(function(a, b) { return a.time - b.time; });
-          var seenIdx = {};
-          var html = '<div class="pt-1">';
-          html += '<div><strong>Seen by ' + seen.length + ' client' + (seen.length === 1 ? '' : 's') + ':</strong> ';
-          if (seen.length) {
-            seen.forEach(function(o) {
-              seenIdx[o.client] = true;
-              var name = clients[o.client] !== undefined ? clients[o.client] : ('client-' + o.client);
-              html += '<span class="badge bg-success me-1 mb-1">' + escapeHtml(name) +
-                ' <span class="opacity-75">' + formatOffset(o.time) + '</span></span>';
-            });
-          } else {
-            html += '<span class="text-muted">none (bid known from block body only)</span>';
-          }
-          html += '</div>';
+        function render(target, clients, bid) {
+          var obs = bid && bid.seen ? bid.seen.slice() : [];
+          obs.sort(function(a, b) { return a.time - b.time; });
+
+          var seenClients = {};
+          var rows = [];
+          obs.forEach(function(o) {
+            seenClients[o.client] = true;
+            var name = clients[o.client] !== undefined ? clients[o.client] : ('client-' + o.client);
+            rows.push({ name: name, time: o.time, seen: true });
+          });
           var notSeen = [];
-          clients.forEach(function(name, idx) { if (!seenIdx[idx]) notSeen.push(name); });
-          if (notSeen.length) {
-            html += '<div><strong>Not seen by ' + notSeen.length + ':</strong> ';
-            notSeen.forEach(function(name) {
-              html += '<span class="badge bg-secondary me-1 mb-1">' + escapeHtml(name) + '</span>';
-            });
-            html += '</div>';
+          clients.forEach(function(name, idx) {
+            if (!seenClients[idx]) notSeen.push({ name: name, seen: false });
+          });
+          notSeen.sort(function(a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
+          rows = rows.concat(notSeen);
+
+          var html = '<div class="fw-bold">Seen by ' + obs.length + ' of ' + clients.length + ' clients</div>';
+          if (!obs.length) {
+            html += '<div class="text-muted">This bid was not observed on gossip (known from the block body only).</div>';
           }
-          html += '</div>';
-          el.innerHTML = html;
+          if (rows.length) {
+            html += '<div class="bid-seen-scroll mt-1">' +
+              '<table class="table table-sm mb-0"><thead><tr>' +
+              '<th style="width: 1.5rem;"></th><th>Client</th><th class="text-end">First seen</th>' +
+              '</tr></thead><tbody>';
+            rows.forEach(function(row) {
+              if (row.seen) {
+                html += '<tr><td><i class="fas fa-check text-success"></i></td>' +
+                  '<td>' + escapeHtml(row.name) + '</td>' +
+                  '<td class="text-end text-monospace">' + formatOffset(row.time) + '</td></tr>';
+              } else {
+                html += '<tr class="text-muted"><td><i class="fas fa-times text-danger"></i></td>' +
+                  '<td>' + escapeHtml(row.name) + '</td>' +
+                  '<td class="text-end">not seen</td></tr>';
+              }
+            });
+            html += '</tbody></table></div>';
+          }
+          target.innerHTML = html;
         }
 
         document.querySelectorAll('.bid-seen-details').forEach(function(el) {
+          var target = el.querySelector('.bid-seen-callout');
           el.closest('tr').addEventListener('shown.bs.collapse', function() {
             if (el.dataset.loaded) return;
             loadBidSeen().then(function(data) {
@@ -147,10 +204,10 @@
                   b.parent_root === el.dataset.parentRoot &&
                   b.parent_hash === el.dataset.parentHash;
               });
-              render(el, data.clients || [], bid);
+              render(target, data.clients || [], bid);
               el.dataset.loaded = '1';
             }).catch(function() {
-              el.innerHTML = '<span class="text-danger">Failed to load bid observations</span>';
+              target.innerHTML = '<span class="text-danger">Failed to load bid observations</span>';
             });
           });
         });

--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -214,13 +214,16 @@
                   b.parent_hash === btn.dataset.parentHash;
               });
               var content = renderContent(data.clients || [], bid);
-              var header = document.querySelector('.bid-seen-popover .popover-header');
-              var body = document.querySelector('.bid-seen-popover .popover-body');
+              // target this popover's own tip: a previously opened popover may
+              // still be fading out in the DOM, so a global selector can hit it
+              var header = popover.tip ? popover.tip.querySelector('.popover-header') : null;
+              var body = popover.tip ? popover.tip.querySelector('.popover-body') : null;
               if (header) header.textContent = content.title;
               if (body) body.innerHTML = content.html;
               popover.update();
             }).catch(function() {
-              var body = document.querySelector('.bid-seen-popover .popover-body');
+              if (lastPopover !== popover) return;
+              var body = popover.tip ? popover.tip.querySelector('.popover-body') : null;
               if (body) body.innerHTML = '<span class="text-danger">Failed to load bid observations</span>';
             });
             return;

--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -111,6 +111,10 @@
       .bid-seen-popover .table tr.bid-seen-proposer td {
         background-color: rgba(var(--bs-primary-rgb), 0.15);
       }
+      .bid-seen-popover .bid-seen-stats {
+        border-bottom: 1px solid var(--bs-border-color);
+        padding-bottom: 4px;
+      }
     </style>
     <script type="text/javascript">
       (function() {
@@ -162,6 +166,26 @@
           var html = '';
           if (!obs.length) {
             html += '<div class="text-muted mb-1">This bid was not observed on gossip (known from the block body only).</div>';
+          } else {
+            // obs is sorted by time, so min/max/median come straight from the ends/middle
+            var times = obs.map(function(o) { return o.time; });
+            var sum = times.reduce(function(a, b) { return a + b; }, 0);
+            var mid = Math.floor(times.length / 2);
+            var median = times.length % 2 ? times[mid] : Math.round((times[mid - 1] + times[mid]) / 2);
+            var stats = [
+              { label: 'min', value: times[0] },
+              { label: 'avg', value: Math.round(sum / times.length) },
+              { label: 'med', value: median },
+              { label: 'max', value: times[times.length - 1] }
+            ];
+            html += '<div class="d-flex bid-seen-stats mb-1">';
+            stats.forEach(function(stat) {
+              html += '<div class="text-center flex-fill">' +
+                '<div class="text-muted small">' + stat.label + '</div>' +
+                '<div class="text-monospace">' + formatOffset(stat.value) + '</div>' +
+                '</div>';
+            });
+            html += '</div>';
           }
           if (rows.length) {
             html += '<div class="bid-seen-scroll">' +

--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -63,75 +63,57 @@
             <td><strong>{{ formatEthFromGwei $bid.TotalValue }}</strong></td>
             <td>
               {{ if gt $bid.SeenTotal 0 }}
-                <a class="badge bg-{{ $bid.SeenColor }}{{ if eq $bid.SeenColor "warning" }} text-dark{{ end }} text-decoration-none" data-bs-toggle="collapse" href="#bid-seen-{{ $i }}" role="button" title="{{ $bid.SeenCount }} of {{ $bid.SeenTotal }} connected clients saw this bid on gossip - click for details">{{ $bid.SeenCount }}/{{ $bid.SeenTotal }} <i class="fas fa-caret-down"></i></a>
+                <a class="badge bg-{{ $bid.SeenColor }}{{ if eq $bid.SeenColor "warning" }} text-dark{{ end }} text-decoration-none bid-seen-btn" role="button"
+                   data-block-hash="0x{{ printf "%x" $bid.BlockHash }}"
+                   data-builder-index="{{ if $bid.IsSelfBuilt }}-1{{ else }}{{ $bid.BuilderIndex }}{{ end }}"
+                   data-parent-root="0x{{ printf "%x" $bid.ParentRoot }}"
+                   data-parent-hash="0x{{ printf "%x" $bid.ParentHash }}">{{ $bid.SeenCount }}/{{ $bid.SeenTotal }} <i class="fas fa-caret-down"></i></a>
               {{ else }}
                 <span class="text-muted" data-bs-toggle="tooltip" title="No gossip observation data for this bid">-</span>
               {{ end }}
             </td>
           </tr>
-          {{ if gt $bid.SeenTotal 0 }}
-            <tr class="collapse" id="bid-seen-{{ $i }}">
-              <td colspan="11" class="bid-seen-details border-top-0 py-0"
-                  data-block-hash="0x{{ printf "%x" $bid.BlockHash }}"
-                  data-builder-index="{{ if $bid.IsSelfBuilt }}-1{{ else }}{{ $bid.BuilderIndex }}{{ end }}"
-                  data-parent-root="0x{{ printf "%x" $bid.ParentRoot }}"
-                  data-parent-hash="0x{{ printf "%x" $bid.ParentHash }}">
-                <div class="bid-seen-callout my-2">
-                  <span class="text-muted">Loading...</span>
-                </div>
-              </td>
-            </tr>
-          {{ end }}
         {{ end }}
       </tbody>
     </table>
   </div>
-  <style>
-    /* the .table-ellipsis wrapper clamps every descendant td to 200px with
-       hidden overflow; lift that for the seen-details cell and its inner table */
-    #block_bids td.bid-seen-details {
-      max-width: none;
-      overflow: visible;
-      white-space: normal;
-    }
-    #block_bids .bid-seen-callout {
-      max-width: 34rem;
-      padding: 0.5rem 0.75rem;
-      border: 1px solid var(--bs-border-color);
-      border-left: 3px solid var(--bs-primary);
-      border-radius: var(--bs-border-radius);
-      background-color: var(--bs-tertiary-bg);
-    }
-    #block_bids .bid-seen-scroll {
-      max-height: 16rem;
-      overflow-y: auto;
-    }
-    #block_bids .bid-seen-callout .table {
-      --bs-table-bg: transparent;
-    }
-    #block_bids .bid-seen-callout .table th,
-    #block_bids .bid-seen-callout .table td {
-      max-width: none;
-      overflow: visible;
-      white-space: nowrap;
-    }
-    #block_bids .bid-seen-callout .table td:nth-child(2) {
-      max-width: 22rem;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    #block_bids .bid-seen-scroll thead th {
-      position: sticky;
-      top: 0;
-      z-index: 1;
-      background-color: var(--bs-tertiary-bg);
-    }
-  </style>
   {{ if .Block.Bids }}
+    <style>
+      .bid-seen-popover {
+        max-width: 470px;
+      }
+      .bid-seen-popover .popover-body {
+        padding: 8px;
+      }
+      .bid-seen-popover .bid-seen-scroll {
+        max-height: 16rem;
+        overflow-y: auto;
+      }
+      .bid-seen-popover .table {
+        --bs-table-bg: transparent;
+        margin-bottom: 0;
+      }
+      .bid-seen-popover .table th,
+      .bid-seen-popover .table td {
+        white-space: nowrap;
+      }
+      .bid-seen-popover .table td:nth-child(2) {
+        max-width: 18rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .bid-seen-popover .bid-seen-scroll thead th {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background-color: var(--bs-popover-bg);
+      }
+    </style>
     <script type="text/javascript">
       (function() {
         var bidSeenSlot = {{ .Slot }};
         var bidSeenPromise = null;
+        var lastPopover = null;
 
         function loadBidSeen() {
           if (bidSeenPromise) return bidSeenPromise;
@@ -150,7 +132,9 @@
           if (abs >= 1000) return sign + (abs / 1000).toFixed(2) + 's';
           return sign + abs + 'ms';
         }
-        function render(target, clients, bid) {
+
+        // renderContent builds the popover title and body for one bid's observations.
+        function renderContent(clients, bid) {
           var obs = bid && bid.seen ? bid.seen.slice() : [];
           obs.sort(function(a, b) { return a.time - b.time; });
 
@@ -168,13 +152,13 @@
           notSeen.sort(function(a, b) { return a.name < b.name ? -1 : a.name > b.name ? 1 : 0; });
           rows = rows.concat(notSeen);
 
-          var html = '<div class="fw-bold">Seen by ' + obs.length + ' of ' + clients.length + ' clients</div>';
+          var html = '';
           if (!obs.length) {
-            html += '<div class="text-muted">This bid was not observed on gossip (known from the block body only).</div>';
+            html += '<div class="text-muted mb-1">This bid was not observed on gossip (known from the block body only).</div>';
           }
           if (rows.length) {
-            html += '<div class="bid-seen-scroll mt-1">' +
-              '<table class="table table-sm mb-0"><thead><tr>' +
+            html += '<div class="bid-seen-scroll">' +
+              '<table class="table table-sm"><thead><tr>' +
               '<th style="width: 1.5rem;"></th><th>Client</th><th class="text-end">First seen</th>' +
               '</tr></thead><tbody>';
             rows.forEach(function(row) {
@@ -190,26 +174,65 @@
             });
             html += '</tbody></table></div>';
           }
-          target.innerHTML = html;
+
+          return {
+            title: 'Seen by ' + obs.length + ' of ' + clients.length + ' clients',
+            html: html
+          };
         }
 
-        document.querySelectorAll('.bid-seen-details').forEach(function(el) {
-          var target = el.querySelector('.bid-seen-callout');
-          el.closest('tr').addEventListener('shown.bs.collapse', function() {
-            if (el.dataset.loaded) return;
-            loadBidSeen().then(function(data) {
-              var bid = (data.bids || []).find(function(b) {
-                return b.block_hash === el.dataset.blockHash &&
-                  String(b.builder_index) === el.dataset.builderIndex &&
-                  b.parent_root === el.dataset.parentRoot &&
-                  b.parent_hash === el.dataset.parentHash;
-              });
-              render(target, data.clients || [], bid);
-              el.dataset.loaded = '1';
-            }).catch(function() {
-              target.innerHTML = '<span class="text-danger">Failed to load bid observations</span>';
+        document.addEventListener('click', function(evt) {
+          var btn = evt.target.closest('.bid-seen-btn');
+          if (btn) {
+            evt.preventDefault();
+
+            var popover = bootstrap.Popover.getOrCreateInstance(btn, {
+              html: true,
+              title: 'Bid visibility',
+              content: '<span class="text-muted">Loading...</span>',
+              trigger: 'manual',
+              placement: 'left',
+              container: 'body',
+              customClass: 'bid-seen-popover'
             });
-          });
+
+            if (lastPopover === popover) {
+              return;
+            }
+            if (lastPopover) {
+              lastPopover.hide();
+            }
+            lastPopover = popover;
+            popover.show();
+
+            loadBidSeen().then(function(data) {
+              if (lastPopover !== popover) return;
+              var bid = (data.bids || []).find(function(b) {
+                return b.block_hash === btn.dataset.blockHash &&
+                  String(b.builder_index) === btn.dataset.builderIndex &&
+                  b.parent_root === btn.dataset.parentRoot &&
+                  b.parent_hash === btn.dataset.parentHash;
+              });
+              var content = renderContent(data.clients || [], bid);
+              var header = document.querySelector('.bid-seen-popover .popover-header');
+              var body = document.querySelector('.bid-seen-popover .popover-body');
+              if (header) header.textContent = content.title;
+              if (body) body.innerHTML = content.html;
+              popover.update();
+            }).catch(function() {
+              var body = document.querySelector('.bid-seen-popover .popover-body');
+              if (body) body.innerHTML = '<span class="text-danger">Failed to load bid observations</span>';
+            });
+            return;
+          }
+
+          if (evt.target.closest('.bid-seen-popover')) {
+            return;
+          }
+          if (lastPopover) {
+            lastPopover.hide();
+            lastPopover = null;
+          }
         });
       })();
     </script>

--- a/templates/slot/bids.html
+++ b/templates/slot/bids.html
@@ -108,10 +108,17 @@
         z-index: 1;
         background-color: var(--bs-popover-bg);
       }
+      .bid-seen-popover .table tr.bid-seen-proposer td {
+        background-color: rgba(var(--bs-primary-rgb), 0.15);
+      }
     </style>
     <script type="text/javascript">
       (function() {
         var bidSeenSlot = {{ .Slot }};
+        // In devnets the validator names usually equal the client names, so the
+        // proposer's own client can be highlighted in the seen list. On networks
+        // where the names differ nothing matches and nothing is highlighted.
+        var proposerName = {{ .ProposerName }};
         var bidSeenPromise = null;
         var lastPopover = null;
 
@@ -162,13 +169,17 @@
               '<th style="width: 1.5rem;"></th><th>Client</th><th class="text-end">First seen</th>' +
               '</tr></thead><tbody>';
             rows.forEach(function(row) {
+              var isProposer = proposerName && row.name === proposerName;
+              var rowClass = isProposer ? ' class="bid-seen-proposer"' : '';
+              var nameHtml = escapeHtml(row.name) +
+                (isProposer ? ' <span class="badge bg-primary">proposer</span>' : '');
               if (row.seen) {
-                html += '<tr><td><i class="fas fa-check text-success"></i></td>' +
-                  '<td>' + escapeHtml(row.name) + '</td>' +
+                html += '<tr' + rowClass + '><td><i class="fas fa-check text-success"></i></td>' +
+                  '<td>' + nameHtml + '</td>' +
                   '<td class="text-end text-monospace">' + formatOffset(row.time) + '</td></tr>';
               } else {
-                html += '<tr class="text-muted"><td><i class="fas fa-times text-danger"></i></td>' +
-                  '<td>' + escapeHtml(row.name) + '</td>' +
+                html += '<tr class="text-muted' + (isProposer ? ' bid-seen-proposer' : '') + '"><td><i class="fas fa-times text-danger"></i></td>' +
+                  '<td>' + nameHtml + '</td>' +
                   '<td class="text-end">not seen</td></tr>';
               }
             });


### PR DESCRIPTION
Follow-up to #824 with fixes and UX improvements for the bid seen tracking.

<img width="416" height="408" alt="image" src="https://github.com/user-attachments/assets/63cb7f59-7bf2-4f67-88b0-707de30c935b" />

## Seen-details callout rework

The chip-based expand row is replaced with an anchored Bootstrap popover (same pattern as the tx detail callouts):

- Clicking the "Seen by" badge opens a popover with a tabular client list — status icon, client name, right-aligned first-seen delay. Clients that saw the bid come first (sorted by delay), then the not-seen ones (alphabetical, muted).
- The list scrolls (sticky header) when it exceeds ~16rem, long client names truncate with ellipsis, and the font matches the rest of the UI (`table table-sm`).
- A stats strip above the table shows min/avg/med/max propagation delay.
- The proposer's client is highlighted (tinted row + "proposer" badge) when its name matches the slot's proposer validator name — lights up on devnets where validator names mirror node names, inert elsewhere.
- Fixed a race where opening a second popover while the first was fading out rendered the content into the stale popover ("stuck at Loading...") — content now targets the instance's own tip element.

## Fix: winning bids losing their seen counters

Winning bids frequently showed `0/N` while the expand list had observations. Root cause: `buildDbBlock` re-extracts the winning bid on every unfinalized-block view/persist and re-adds it to the bid cache with no observer. The cache accepts bids up to 15 slots old but flushes at 10, so already-flushed winning bids got resurrected as fresh entries with empty observation state, shadowed the correct DB row in the live merge, and the next flush upserted zeros over the good counts (the blockdb object survived thanks to its union merge — hence the correct expand list).

Guards:
- the `block_bids` upsert uses `GREATEST`/`MAX` on `seen_count`/`seen_total`, so a flush can never shrink an existing row's counters
- the cache/DB merges (`GetBlockBidsForSlot`, `GetBuilderBids`) merge seen counters by maximum instead of letting the cache copy shadow the DB row

## Fix: Nimbus bid events failed to decode

Nimbus sends `execution_payload_bid` SSE events as the bare `SignedExecutionPayloadBid` container without the versioned `{"version","data"}` envelope, which failed with "unexpected end of JSON input". The decoder now unwraps the envelope when present and falls back to the raw container; regression test included with a payload captured from a glamsterdam-devnet-7 nimbus node.
