### PR TITLE
Drop named-fork entries from EL blob schedule (geth 1.17.5 compat)

### DIFF
--- a/clients/execution/chainstate.go
+++ b/clients/execution/chainstate.go
@@ -242,6 +242,8 @@ func (cache *ChainState) GetFullBlobSchedule() []BlobScheduleEntry {
 	chainConfig := cache.config.Config
 	blobConfig := chainConfig.BlobScheduleConfig
 
+	// Named forks (Osaka/Amsterdam/UBT) no longer carry their own blob schedule
+	// since geth 1.17.5 and inherit from the BPO chain below them.
 	forks := []struct {
 		time      *uint64
 		schedule  *params.BlobConfig
@@ -249,14 +251,11 @@ func (cache *ChainState) GetFullBlobSchedule() []BlobScheduleEntry {
 	}{
 		{chainConfig.CancunTime, blobConfig.Cancun, 0},
 		{chainConfig.PragueTime, blobConfig.Prague, 0},
-		{chainConfig.OsakaTime, blobConfig.Osaka, 0},
 		{chainConfig.BPO1Time, blobConfig.BPO1, 1},
 		{chainConfig.BPO2Time, blobConfig.BPO2, 2},
 		{chainConfig.BPO3Time, blobConfig.BPO3, 3},
 		{chainConfig.BPO4Time, blobConfig.BPO4, 4},
 		{chainConfig.BPO5Time, blobConfig.BPO5, 5},
-		{chainConfig.AmsterdamTime, blobConfig.Amsterdam, 0},
-		{chainConfig.UBTTime, blobConfig.UBT, 0},
 	}
 
 	for _, fork := range forks {

--- a/clients/execution/chainstate.go
+++ b/clients/execution/chainstate.go
@@ -242,8 +242,6 @@ func (cache *ChainState) GetFullBlobSchedule() []BlobScheduleEntry {
 	chainConfig := cache.config.Config
 	blobConfig := chainConfig.BlobScheduleConfig
 
-	// Named forks (Osaka/Amsterdam/UBT) no longer carry their own blob schedule
-	// since geth 1.17.5 and inherit from the BPO chain below them.
 	forks := []struct {
 		time      *uint64
 		schedule  *params.BlobConfig


### PR DESCRIPTION
## Summary

go-ethereum v1.17.5 removed the named-hardfork fields (`Osaka`, `Amsterdam`, `UBT`) from `params.BlobScheduleConfig` (ethereum/go-ethereum#35029 "Remove named hardforks from the BPO schedule"). Named forks no longer carry their own blob schedule; they inherit from the BPO chain below them.

This PR removes the three rows referencing those fields from the fork table in `GetFullBlobSchedule` (`clients/execution/chainstate.go`), keeping Cancun, Prague, and BPO1-5. It still compiles against the currently-pinned v1.17.4 and unblocks the dora side of the dependabot bump in #814.

## Why this is behavior-safe

Both consumers of `GetFullBlobSchedule` are unaffected:

- `GetBpoForks` (`services/chainservice_forks.go`) only uses entries with `IsBpo == true`; the removed rows were all non-BPO.
- `GetBlobScheduleForTimestamp` picks the last entry before a timestamp. Under geth's new model a named fork never changes blob params — its schedule always equals the preceding BPO/Prague/Cancun entry — so those rows were redundant duplicates.

## Notes

The go-ethereum bump itself is not included here; it remains blocked on an ethcore update for geth 1.17.5, which is in progress separately.