### PR TITLE
feat: ENS name search in the main search bar

### DIFF
--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -192,8 +192,9 @@ rpcProxy:
 # Optional ENS resolver: resolves execution addresses to their primary ENS name.
 ensResolver:
   enabled: false # enable ENS name resolution & display
-  # optional dedicated EL RPC endpoints (usually Ethereum mainnet). If empty, an
-  # available client from the main execution pool is used.
+  # EL RPC endpoints used for ENS lookups. ENS lives on Ethereum mainnet, so these
+  # should always point at a mainnet RPC regardless of the chain being explored.
+  # If empty, a public mainnet RPC (ethereum-rpc.publicnode.com) is used.
   endpoints: []
   #  - url: "https://ethereum-rpc.publicnode.com"
   #    name: "mainnet"

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -59,6 +59,7 @@ func InitPageData(w http.ResponseWriter, r *http.Request, active, path, title st
 		MainMenuItems:           createMenuItems(active),
 		ApiEnabled:              utils.Config.Api.Enabled && !utils.Config.Api.RequireAuth,
 		ExecutionIndexerEnabled: utils.Config.ExecutionIndexer.Enabled,
+		EnsSearchEnabled:        ensSearchEnabled(),
 	}
 
 	chainState := services.GlobalBeaconService.GetChainState()

--- a/handlers/search.go
+++ b/handlers/search.go
@@ -27,6 +27,16 @@ import (
 
 var searchLikeRE = regexp.MustCompile(`^[0-9a-fA-F]{0,96}$`)
 
+// ensNameRE loosely matches a complete ENS name: dot-separated non-empty labels
+// without whitespace, ending in a TLD-like label of at least 3 chars (e.g. "eth").
+var ensNameRE = regexp.MustCompile(`^[^\s.]+(\.[^\s.]+)*\.[^\s.]{3,}$`)
+
+// ensSearchEnabled reports whether ENS names can be searched: the resolver must be
+// active and the execution indexer enabled (resolved names redirect to /address).
+func ensSearchEnabled() bool {
+	return utils.Config.EnsResolver.Enabled && utils.Config.ExecutionIndexer.Enabled
+}
+
 // searchResolverResult is the cached outcome of resolving a search query (redirect URL or empty = not found).
 type searchResolverResult struct {
 	RedirectURL string `json:"redirect_url"`
@@ -150,6 +160,12 @@ func buildSearchResolverResult(ctx context.Context, searchQuery string) (searchR
 		}
 	}
 
+	if ensSearchEnabled() && ensNameRE.MatchString(searchQuery) {
+		if addr, ok := services.GlobalBeaconService.GetEnsResolver().ResolveEnsName(ctx, searchQuery); ok {
+			return searchResolverResult{RedirectURL: fmt.Sprintf("/address/0x%x", addr)}, cacheTimeout
+		}
+	}
+
 	if nameMatch, err := db.HasValidatorNameMatch(ctx, "%"+searchQuery+"%"); err == nil && nameMatch {
 		return searchResolverResult{RedirectURL: "/slots/filtered?f&f.missing=1&f.orphaned=1&f.pname=" + searchQuery}, cacheTimeout
 	}
@@ -188,8 +204,12 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 	searchType := vars["type"]
 	urlArgs := r.URL.Query()
 	search := strings.Trim(urlArgs.Get("q"), " \t")
-	search = strings.Replace(search, "0x", "", -1)
-	search = strings.Replace(search, "0X", "", -1)
+	if searchType != "ens" {
+		// hex-based types accept queries with or without 0x prefix; ENS labels may
+		// legitimately contain "0x", so the raw query is kept for them
+		search = strings.Replace(search, "0x", "", -1)
+		search = strings.Replace(search, "0X", "", -1)
+	}
 
 	// 404 before cache so we don't cache disabled/unknown types
 	allowedTypes := map[string]bool{
@@ -201,6 +221,7 @@ func SearchAhead(w http.ResponseWriter, r *http.Request) {
 		"validator":    true,
 		"addresses":    utils.Config.ExecutionIndexer.Enabled,
 		"transactions": utils.Config.ExecutionIndexer.Enabled,
+		"ens":          ensSearchEnabled(),
 	}
 	if !allowedTypes[searchType] {
 		http.Error(w, "Not found", 404)
@@ -569,6 +590,21 @@ func buildSearchAheadResult(ctx context.Context, searchType, search string) (*se
 					}
 				}
 				result = model
+			}
+		}
+	case "ens":
+		if !ensNameRE.MatchString(search) {
+			break
+		}
+		if addr, ok := services.GlobalBeaconService.GetEnsResolver().ResolveEnsName(ctx, search); ok {
+			account, _ := db.GetElAccountByAddress(ctx, addr.Bytes())
+			result = &[]models.SearchAheadEnsResult{
+				{
+					EnsName:    utils.FormatGraffitiString(strings.ToLower(search)),
+					Address:    strings.ToLower(addr.Hex()),
+					IsContract: account != nil && account.IsContract,
+					HasData:    account != nil && account.ID > 0,
+				},
 			}
 		}
 	case "transactions":

--- a/services/chainservice.go
+++ b/services/chainservice.go
@@ -69,7 +69,7 @@ func InitChainService(ctx context.Context, logger logrus.FieldLogger) {
 	buildoorInventory := NewBuildoorInventory(ctx)
 	mevRelayIndexer := mevrelay.NewMevIndexer(ctx, logger.WithField("service", "mev-relay"), beaconIndexer, chainState)
 	snooperManager := snooper.NewSnooperManager(ctx, logger.WithField("service", "snooper-manager"), beaconIndexer)
-	ensResolver := NewEnsResolver(ctx, logger.WithField("service", "ens-resolver"), executionPool)
+	ensResolver := NewEnsResolver(ctx, logger.WithField("service", "ens-resolver"))
 
 	// Set execution time provider
 	beaconIndexer.SetExecutionTimeProvider(snooper.NewExecutionTimeProvider(snooperManager.GetCache()))

--- a/services/ensresolver.go
+++ b/services/ensresolver.go
@@ -15,24 +15,29 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/sirupsen/logrus"
 
-	"github.com/ethpandaops/dora/clients/execution"
 	exerpc "github.com/ethpandaops/dora/clients/execution/rpc"
 	"github.com/ethpandaops/dora/clients/sshtunnel"
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/types"
 	"github.com/ethpandaops/dora/utils"
 )
 
 // EnsResolver resolves execution addresses to their primary ENS name. Resolution is
 // batched, asynchronous and persisted to the ens_names table. Handlers call
 // ResolveNames once per page to warm the in-memory cache and feed the resolve queue.
+//
+// ENS lookups always run against Ethereum mainnet (via the configured endpoints or a
+// public mainnet RPC default), independent of the chain this explorer indexes.
 type EnsResolver struct {
-	ctx      context.Context
-	logger   logrus.FieldLogger
-	execPool *execution.Pool
+	ctx    context.Context
+	logger logrus.FieldLogger
 
 	started atomic.Bool
 	cache   *lru.Cache[common.Address, *ensCacheEntry]
+
+	// forward resolution cache (name -> address), used by the search bar
+	forwardCache *lru.Cache[string, *ensForwardCacheEntry]
 
 	queue   chan common.Address
 	pending sync.Map // common.Address -> struct{}
@@ -41,7 +46,7 @@ type EnsResolver struct {
 	dedicatedInit    sync.Once
 	dedicatedClients []*ensEndpointClient
 
-	// probe results (worker-goroutine only, guarded by probeMutex until probed)
+	// probe results (immutable once probed; guarded by probeMutex until then)
 	probeMutex       sync.Mutex
 	probed           bool
 	registries       []common.Address
@@ -55,17 +60,23 @@ type ensCacheEntry struct {
 	resolvedTime int64
 }
 
+// ensForwardCacheEntry is a cached forward-resolution result (name -> address).
+// A zero address is a negative result.
+type ensForwardCacheEntry struct {
+	address      common.Address
+	resolvedTime int64
+}
+
 // ensEndpointClient is a dedicated ENS RPC client with its configured name (for logs).
 type ensEndpointClient struct {
 	name   string
 	client *exerpc.ExecutionClient
 }
 
-func NewEnsResolver(ctx context.Context, logger logrus.FieldLogger, execPool *execution.Pool) *EnsResolver {
+func NewEnsResolver(ctx context.Context, logger logrus.FieldLogger) *EnsResolver {
 	return &EnsResolver{
-		ctx:      ctx,
-		logger:   logger.WithField("service", "ens-resolver"),
-		execPool: execPool,
+		ctx:    ctx,
+		logger: logger.WithField("service", "ens-resolver"),
 	}
 }
 
@@ -147,6 +158,12 @@ func (e *EnsResolver) StartUpdater() {
 	if len(cfg.RegistryAddresses) == 0 {
 		cfg.RegistryAddresses = []string{"0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"}
 	}
+	if len(cfg.Endpoints) == 0 {
+		// ENS lives on Ethereum mainnet, so resolution always runs against a mainnet
+		// RPC - never against the local chain (devnets/testnets have no ENS registry).
+		// Default to a public mainnet endpoint when no dedicated endpoint is configured.
+		cfg.Endpoints = []types.EndpointConfig{{Name: "mainnet-public", Url: "https://ethereum-rpc.publicnode.com"}}
+	}
 	if cfg.MulticallAddress == "" {
 		cfg.MulticallAddress = "0xcA11bde05977b3631167028862bE2a173976CA11"
 	}
@@ -157,7 +174,14 @@ func (e *EnsResolver) StartUpdater() {
 		return
 	}
 
+	forwardCache, err := lru.New[string, *ensForwardCacheEntry](cfg.CacheSize)
+	if err != nil {
+		e.logger.Errorf("failed to create ens forward cache: %v", err)
+		return
+	}
+
 	e.cache = cache
+	e.forwardCache = forwardCache
 	e.queue = make(chan common.Address, cfg.QueueSize)
 	e.started.Store(true)
 
@@ -239,6 +263,57 @@ func (e *EnsResolver) ResolveNames(ctx context.Context, addrs [][]byte) map[stri
 func (e *EnsResolver) isStale(entry *ensCacheEntry, now int64) bool {
 	refresh := utils.Config.EnsResolver.RefreshPositive
 	if entry.name == "" {
+		refresh = utils.Config.EnsResolver.RefreshNegative
+	}
+	if refresh <= 0 {
+		return false
+	}
+	return now-entry.resolvedTime > int64(refresh/time.Second)
+}
+
+// ResolveEnsName forward-resolves an ENS name to its address (EIP-137), using a
+// synchronous eth_call on cache miss. The bool result reports whether the name
+// resolved to a non-zero address.
+//
+// It is called from the search handlers — results are cached here (LRU) and again
+// at the page-cache layer, so on-chain lookups stay bounded.
+func (e *EnsResolver) ResolveEnsName(ctx context.Context, name string) (common.Address, bool) {
+	if e == nil || !e.started.Load() {
+		return common.Address{}, false
+	}
+
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" || !strings.Contains(name, ".") {
+		return common.Address{}, false
+	}
+
+	if entry, ok := e.forwardCache.Get(name); ok && !e.isForwardStale(entry, time.Now().Unix()) {
+		return entry.address, entry.address != (common.Address{})
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	ethClient, err := e.getEthClient(ctx)
+	if err != nil {
+		e.logger.Warnf("ens forward resolve %q: %v", name, err)
+		return common.Address{}, false
+	}
+	if err := e.ensureProbed(ctx, ethClient); err != nil {
+		e.logger.Warnf("ens forward resolve %q: %v", name, err)
+		return common.Address{}, false
+	}
+
+	addr := e.resolveForward(ctx, ethClient, name)
+	e.forwardCache.Add(name, &ensForwardCacheEntry{address: addr, resolvedTime: time.Now().Unix()})
+	return addr, addr != (common.Address{})
+}
+
+// isForwardStale reports whether a forward cache entry is past its refresh interval
+// (positive and negative results use separate intervals).
+func (e *EnsResolver) isForwardStale(entry *ensForwardCacheEntry, now int64) bool {
+	refresh := utils.Config.EnsResolver.RefreshPositive
+	if entry.address == (common.Address{}) {
 		refresh = utils.Config.EnsResolver.RefreshNegative
 	}
 	if refresh <= 0 {
@@ -396,32 +471,22 @@ func (e *EnsResolver) ensureProbed(ctx context.Context, ethClient *ethclient.Cli
 	return nil
 }
 
-// getEthClient returns an eth client for ENS lookups, preferring dedicated endpoints
-// and falling back to a ready client from the main execution pool.
+// getEthClient returns an eth client for ENS lookups. ENS is always resolved against
+// mainnet: only the dedicated endpoints are used (defaulted to a public mainnet RPC in
+// StartUpdater), never the local execution pool, which on devnets/testnets serves a
+// chain without an ENS deployment.
 func (e *EnsResolver) getEthClient(ctx context.Context) (*ethclient.Client, error) {
-	if len(utils.Config.EnsResolver.Endpoints) > 0 {
-		e.dedicatedInit.Do(e.initDedicatedClients)
-		for _, ec := range e.dedicatedClients {
-			if err := ec.client.Initialize(ctx); err != nil {
-				e.logger.Warnf("ens endpoint %s init failed: %v", ec.name, err)
-				continue
-			}
-			if ethClient := ec.client.GetEthClient(); ethClient != nil {
-				return ethClient, nil
-			}
+	e.dedicatedInit.Do(e.initDedicatedClients)
+	for _, ec := range e.dedicatedClients {
+		if err := ec.client.Initialize(ctx); err != nil {
+			e.logger.Warnf("ens endpoint %s init failed: %v", ec.name, err)
+			continue
 		}
-		return nil, fmt.Errorf("no usable dedicated ens endpoint")
+		if ethClient := ec.client.GetEthClient(); ethClient != nil {
+			return ethClient, nil
+		}
 	}
-
-	client := e.execPool.GetReadyEndpoint(execution.AnyClient)
-	if client == nil {
-		return nil, fmt.Errorf("no ready execution client available for ens resolution")
-	}
-	ethClient := client.GetRPCClient().GetEthClient()
-	if ethClient == nil {
-		return nil, fmt.Errorf("execution client has no eth client")
-	}
-	return ethClient, nil
+	return nil, fmt.Errorf("no usable ens endpoint")
 }
 
 // initDedicatedClients builds RPC clients from the configured ENS endpoints.

--- a/services/ensresolver_ens.go
+++ b/services/ensresolver_ens.go
@@ -81,6 +81,42 @@ func reverseNode(addr common.Address) [32]byte {
 	return namehash(strings.ToLower(addr.Hex()[2:]) + ".addr.reverse")
 }
 
+// resolveForward resolves a name to its address (forward resolution, EIP-137):
+// resolver = registry.resolver(namehash(name)); addr = resolver.addr(node).
+// Registries are tried in configured order; the first non-zero address wins.
+func (e *EnsResolver) resolveForward(ctx context.Context, ethClient *ethclient.Client, name string) common.Address {
+	node := namehash(name)
+
+	for _, registry := range e.registries {
+		res, err := e.callBatch(ctx, ethClient, []ensCall{{target: registry, data: appendNode(selectorResolver, node)}})
+		if err != nil {
+			e.logger.Warnf("ens forward stage1 (resolver) failed: %v", err)
+			continue
+		}
+		if !res[0].success {
+			continue
+		}
+		resolver := decodeAddress(res[0].data)
+		if resolver == (common.Address{}) {
+			continue
+		}
+
+		res, err = e.callBatch(ctx, ethClient, []ensCall{{target: resolver, data: appendNode(selectorEnsAddr, node)}})
+		if err != nil {
+			e.logger.Warnf("ens forward stage2 (addr) failed: %v", err)
+			continue
+		}
+		if !res[0].success {
+			continue
+		}
+		if addr := decodeAddress(res[0].data); addr != (common.Address{}) {
+			return addr
+		}
+	}
+
+	return common.Address{}
+}
+
 // resolveBatch resolves primary ENS names for the given addresses, trying the usable
 // registries in configured order and keeping the first verified name per address.
 func (e *EnsResolver) resolveBatch(ctx context.Context, ethClient *ethclient.Client, addrs []common.Address) map[common.Address]string {

--- a/static/js/explorer.js
+++ b/static/js/explorer.js
@@ -368,6 +368,7 @@
     var searchEl = jQuery("#explorer-search");
     let requestNum = 9
     var executionIndexerEnabled = searchEl.data("execution-indexer-enabled") === true || searchEl.attr("data-execution-indexer-enabled") === "true" || searchEl.data("executionIndexerEnabled") === true;
+    var ensSearchEnabled = searchEl.data("ens-search-enabled") === true || searchEl.attr("data-ens-search-enabled") === "true" || searchEl.data("ensSearchEnabled") === true;
 
     var prepareQueryFn = function(query, settings) {
       settings.url += encodeURIComponent(query);
@@ -469,6 +470,22 @@
         },
         remote: {
           url: "/search/transactions?q=",
+          prepare: prepareQueryFn,
+          maxPendingRequests: requestNum,
+        },
+      });
+    }
+
+    var bhEnsNames = null;
+    if (ensSearchEnabled) {
+      bhEnsNames = new Bloodhound({
+        datumTokenizer: Bloodhound.tokenizers.whitespace,
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        identify: function (obj) {
+          return obj.ens_name
+        },
+        remote: {
+          url: "/search/ens?q=",
           prepare: prepareQueryFn,
           maxPendingRequests: requestNum,
         },
@@ -600,6 +617,26 @@
       });
     }
 
+    // Add ENS dataset conditionally
+    if (ensSearchEnabled && bhEnsNames) {
+      datasets.push({
+        limit: 5,
+        name: "ens",
+        source: bhEnsNames,
+        display: "ens_name",
+        templates: {
+          header: '<h3 class="h5">ENS Names:</h3>',
+          suggestion: function (data) {
+            var badges = "";
+            if (data.is_contract) {
+              badges += `<span class="search-cell"><span class="badge rounded-pill text-bg-warning">Contract</span></span>`;
+            }
+            return `<div class="text-monospace"><div class="search-table"><span class="search-cell">${data.ens_name}</span><span class="search-cell search-truncate text-muted">${data.address}</span>${badges}</div></div>`;
+          },
+        },
+      });
+    }
+
     // Initialize typeahead with all datasets
     searchEl.typeahead.apply(searchEl, [
       {
@@ -638,6 +675,8 @@
         window.location = "/slots/filtered?f&f.orphaned=1&f.graffiti=" + encodeURIComponent(el.value)
       } else if (sug.pubkey !== undefined) {
         window.location = "/validator/" + sug.index
+      } else if (sug.ens_name !== undefined) {
+        window.location = "/address/" + sug.address
       } else if (sug.name !== undefined) {
           // sug.name is html-escaped to prevent xss, we need to unescape it
           var el = document.createElement("textarea")

--- a/templates/_layout/header.html
+++ b/templates/_layout/header.html
@@ -54,7 +54,7 @@
             {{ if .IsReady }}
             <form action="/search">
               <div class="main-search-wrapper">
-                <input id="explorer-search" name="q" type="search" class="form-control form-control-dark search-input" placeholder="Slots / Epochs / Roots / EL-Blocks / Graffitis / Validators{{ if .ExecutionIndexerEnabled }} / Addresses / Transactions{{ end }}" aria-label="Search" autocomplete="off" data-execution-indexer-enabled="{{ .ExecutionIndexerEnabled }}">
+                <input id="explorer-search" name="q" type="search" class="form-control form-control-dark search-input" placeholder="Slots / Epochs / Roots / EL-Blocks / Graffitis / Validators{{ if .ExecutionIndexerEnabled }} / Addresses / Transactions{{ end }}{{ if .EnsSearchEnabled }} / ENS Names{{ end }}" aria-label="Search" autocomplete="off" data-execution-indexer-enabled="{{ .ExecutionIndexerEnabled }}" data-ens-search-enabled="{{ .EnsSearchEnabled }}">
               </div>
             </form>
             {{ end }}

--- a/types/config.go
+++ b/types/config.go
@@ -215,8 +215,9 @@ type Config struct {
 	} `yaml:"rpcProxy"`
 
 	// EnsResolver optionally resolves execution addresses to their primary ENS name.
-	// ENS lives on Ethereum mainnet, so Endpoints usually point at a mainnet RPC; when
-	// empty the resolver falls back to an available client from the main execution pool.
+	// ENS lives on Ethereum mainnet, so lookups always run against a mainnet RPC:
+	// the configured Endpoints, or a public mainnet RPC when empty. The local
+	// execution pool is never used (devnets/testnets have no ENS deployment).
 	EnsResolver struct {
 		Enabled           bool             `yaml:"enabled" envconfig:"ENSRESOLVER_ENABLED"`
 		Endpoints         []EndpointConfig `yaml:"endpoints"`

--- a/types/models.go
+++ b/types/models.go
@@ -33,6 +33,7 @@ type PageData struct {
 	MainMenuItems           []MainMenuItem
 	ApiEnabled              bool
 	ExecutionIndexerEnabled bool
+	EnsSearchEnabled        bool
 }
 
 type MainMenuItem struct {

--- a/types/models/search.go
+++ b/types/models/search.go
@@ -61,6 +61,14 @@ type SearchAheadAddressResult struct {
 	HasData    bool   `json:"has_data,omitempty"`
 }
 
+// SearchAheadEnsResult is a struct to hold the search ahead ENS name results
+type SearchAheadEnsResult struct {
+	EnsName    string `json:"ens_name,omitempty"`
+	Address    string `json:"address,omitempty"`
+	IsContract bool   `json:"is_contract,omitempty"`
+	HasData    bool   `json:"has_data,omitempty"`
+}
+
 // SearchAheadTransactionResult is a struct to hold the search ahead transaction results
 type SearchAheadTransactionResult struct {
 	TxHash      string `json:"tx_hash,omitempty"`


### PR DESCRIPTION
## Summary

Adds **forward ENS resolution** (`vitalik.eth` → address) to the main search bar, building on the existing reverse-resolution (address → name) subsystem — no new dependencies.

- Typing a complete ENS name shows an **"ENS Names"** typeahead section with the resolved address (plus a `Contract` badge when applicable); selecting it goes to `/address/0x…`
- Submitting the search form with an ENS name redirects straight to the address page (checked after the numeric/hex resolvers, before validator-name/graffiti fallbacks; falls through if the name doesn't resolve)
- Subdomains (`sub.name.eth`), non-`.eth` TLDs and emoji names are supported; a shape check (complete name, TLD label ≥ 3 chars) avoids per-keystroke eth_calls while typing

## ENS is always resolved against mainnet

ENS lives on Ethereum mainnet, so lookups now always use the dedicated `ensResolver.endpoints` — **defaulting to `https://ethereum-rpc.publicnode.com` when unset**. The previous fallback to the local execution pool is removed: on devnets/testnets that pool serves a chain without an ENS deployment, so it could never resolve anything. This applies to the existing reverse resolution too. Operators who don't want the public-RPC dependency can point `ensResolver.endpoints` at their own mainnet node.

## Implementation notes

- `services/ensresolver_ens.go`: new `resolveForward()` — `registry.resolver(namehash(name))` → `resolver.addr(node)`, reusing the existing namehash/calldata/eth_call helpers and registry priority order
- `services/ensresolver.go`: exported `ResolveEnsName()` with its own LRU cache (positive/negative entries honor `refreshPositive`/`refreshNegative`), 10s call timeout
- `handlers/search.go`: ENS branch in the full-search resolver + new `ens` search-ahead type; the global `0x` strip is skipped for ENS queries since labels like `0xdeadbeef.eth` are legal
- Feature is gated on `ensResolver.enabled && executionIndexer.enabled` (results redirect to `/address`, which requires the indexer)
- ENS names in typeahead suggestions are HTML-escaped (same as graffiti results)

Same known limitations as the existing reverse path: lowercase normalization only (no UTS-46/ENSIP-15), no wildcard/CCIP-read (ENSIP-10) resolvers.

## Testing

- `go build ./...` and `go vet` clean
- Name-shape regex verified against `vitalik.eth`, `sub.vitalik.eth`, `0xdeadbeef.eth`, `nick.xyz`, emoji names, and partial-keystroke negatives