### PR TITLE
Add ENR fields to execution clients page

### DIFF
--- a/handlers/clients_el.go
+++ b/handlers/clients_el.go
@@ -194,6 +194,35 @@ func buildELClientsPageData(sortOrder string) (*models.ClientsELPageData, time.D
 		ShowSensitivePeerInfos: utils.Config.Frontend.ShowSensitivePeerInfos,
 		Nodes:                  []*models.ClientsELPageDataNode{},
 	}
+
+	// getEnrValues decodes an "enr:..." record into a sorted key/value list.
+	// Some clients report an enode URL in the enr field, so only decode real ENRs.
+	enrValuesMap := map[string][]*models.ClientELPageDataNodeENRValue{}
+	getEnrValues := func(enrStr string) []*models.ClientELPageDataNodeENRValue {
+		if !strings.HasPrefix(enrStr, "enr:") {
+			return []*models.ClientELPageDataNodeENRValue{}
+		}
+		if values, ok := enrValuesMap[enrStr]; ok {
+			return values
+		}
+		enrValues := []*models.ClientELPageDataNodeENRValue{}
+		rec, err := utils.DecodeENR(enrStr)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{"enr": enrStr}).Warn("failed to decode enr. ", err)
+		} else {
+			for k, v := range utils.GetKeyValuesFromENR(rec) {
+				enrValues = append(enrValues, &models.ClientELPageDataNodeENRValue{
+					Key:   k,
+					Value: fmt.Sprintf("%v", v),
+				})
+			}
+			sort.Slice(enrValues, func(i, j int) bool {
+				return enrValues[i].Key < enrValues[j].Key
+			})
+		}
+		enrValuesMap[enrStr] = enrValues
+		return enrValues
+	}
 	chainState := services.GlobalBeaconService.GetChainState()
 	specs := chainState.GetSpecs()
 	cacheTime := time.Duration(specs.SlotDurationMs) * time.Millisecond
@@ -238,7 +267,7 @@ func buildELClientsPageData(sortOrder string) (*models.ClientsELPageData, time.D
 				direction = "inbound"
 			}
 
-			resPeers = append(resPeers, &models.ClientELPageDataNodePeers{
+			resPeer := &models.ClientELPageDataNodePeers{
 				ID:        peerID,
 				State:     peer.Name,
 				Direction: direction,
@@ -248,7 +277,14 @@ func buildELClientsPageData(sortOrder string) (*models.ClientsELPageData, time.D
 				Caps:      peer.Caps,
 				Protocols: buildPeerProtocols(peer.Protocols),
 				Type:      peerType,
-			})
+			}
+
+			if pageData.ShowSensitivePeerInfos && strings.HasPrefix(peer.ENR, "enr:") {
+				resPeer.ENR = peer.ENR
+				resPeer.ENRKeyValues = getEnrValues(peer.ENR)
+			}
+
+			resPeers = append(resPeers, resPeer)
 
 			if direction == "inbound" {
 				inPeerCount++
@@ -268,6 +304,7 @@ func buildELClientsPageData(sortOrder string) (*models.ClientsELPageData, time.D
 		peerID := fmt.Sprintf("unknown-%v", idx)
 		peerName := "unknown"
 		enoderaw := "unknown"
+		enrRaw := ""
 		ipAddr := "unknown"
 		listenAddr := "unknown"
 		if nodeInfo != nil {
@@ -277,6 +314,7 @@ func buildELClientsPageData(sortOrder string) (*models.ClientsELPageData, time.D
 				enoderaw = en.String()
 			}
 			peerName = nodeInfo.Name
+			enrRaw = nodeInfo.ENR
 			ipAddr = nodeInfo.IP
 			listenAddr = nodeInfo.ListenAddr
 		}
@@ -313,6 +351,8 @@ func buildELClientsPageData(sortOrder string) (*models.ClientsELPageData, time.D
 
 		if pageData.ShowSensitivePeerInfos {
 			resNode.Enode = enoderaw
+			resNode.ENR = enrRaw
+			resNode.ENRKeyValues = getEnrValues(enrRaw)
 			resNode.IPAddr = ipAddr
 			resNode.ListenAddr = listenAddr
 		}

--- a/templates/clients/clients_el.html
+++ b/templates/clients/clients_el.html
@@ -219,6 +219,17 @@
                     </div>
                   </td>
                 </tr>
+                {{ html "<!-- ko if: enr -->" }}
+                <tr style="vertical-align: top;">
+                  <td style="white-space: nowrap;">ENR</td>
+                  <td>
+                    <div style="word-break: break-all; text-wrap: pretty;">
+                      <code data-bind="text: enr"></code>
+                      <i class="fa fa-copy text-muted p-1" role="button" data-bs-placement="right" data-bs-toggle="tooltip" title="Copy to clipboard" data-bind="attr: {'data-clipboard-text': enr}"></i>
+                    </div>
+                  </td>
+                </tr>
+                {{ html "<!-- /ko -->" }}
                 <tr style="vertical-align: top;">
                   <td style="white-space: nowrap;">IP Address</td>
                   <td>
@@ -241,7 +252,26 @@
               </tbody>
             </table>
           </div>
-          
+
+          {{ html "<!-- ko if: showSensitivePeerInfos && enr() -->" }}
+          <div class="client-row-divider">ENR fields</div>
+          <div class="client-node-peerinfo">
+            <table class="table table-borderless table-sm client-table-info">
+              <tbody>
+                {{ html "<!-- ko foreach: enr_kv -->" }}
+                <tr>
+                  <td data-bind="text: key"></td>
+                  <td>
+                    <code data-bind="text: value"></code>
+                    <i class="fa fa-copy text-muted p-1" role="button" data-bs-placement="right" data-bs-toggle="tooltip" data-bind="attr: {'data-clipboard-text': $data.value, title: 'Copy ' + $data.key + ' to clipboard'}"></i>
+                  </td>
+                </tr>
+                {{ html "<!-- /ko -->" }}
+              </tbody>
+            </table>
+          </div>
+          {{ html "<!-- /ko -->" }}
+
           <div class="client-row-divider">
             Fork Configuration
             <span class="text-muted" style="float: right; font-size: 0.9em;">
@@ -347,6 +377,28 @@
                             </div>
                           </td>
                         </tr>
+                        {{ html "<!-- ko if: enr -->" }}
+                        <tr>
+                          <td>ENR</td>
+                          <td>
+                            <div style="word-break: break-all; text-wrap: pretty;">
+                              <code data-bind="text: enr"></code>
+                              <i class="fa fa-copy text-muted p-1" role="button" data-bs-placement="right" data-bs-toggle="tooltip" title="Copy to clipboard" data-bind="attr: {'data-clipboard-text': enr}"></i>
+                            </div>
+                          </td>
+                        </tr>
+                        {{ html "<!-- ko foreach: enr_kv -->" }}
+                        <tr>
+                          <td data-bind="text: key"></td>
+                          <td>
+                            <div style="word-break: break-all; text-wrap: pretty;">
+                              <code data-bind="text: value"></code>
+                              <i class="fa fa-copy text-muted p-1" role="button" data-bs-placement="right" data-bs-toggle="tooltip" data-bind="attr: {'data-clipboard-text': value, title: 'Copy ' + key + ' to clipboard'}"></i>
+                            </div>
+                          </td>
+                        </tr>
+                        {{ html "<!-- /ko -->" }}
+                        {{ html "<!-- /ko -->" }}
                         <tr>
                           <td>Name</td>
                           <td>

--- a/types/models/clients_el.go
+++ b/types/models/clients_el.go
@@ -35,17 +35,19 @@ type ClientsELPageDataClient struct {
 }
 
 type ClientsELPageDataNode struct {
-	PeerID        string                       `json:"peer_id"`
-	Name          string                       `json:"name"`
-	Version       string                       `json:"version"`
-	Status        string                       `json:"status"`
-	PeerName      string                       `json:"peer_name"`
-	Enode         string                       `json:"enode"`
-	IPAddr        string                       `json:"ip_addr"`
-	ListenAddr    string                       `json:"listen_addr"`
-	Peers         []*ClientELPageDataNodePeers `json:"peers"`
-	DidFetchPeers bool                         `json:"peers_fetched"`
-	ForkConfig    *ClientELPageDataForkConfig  `json:"fork_config"`
+	PeerID        string                          `json:"peer_id"`
+	Name          string                          `json:"name"`
+	Version       string                          `json:"version"`
+	Status        string                          `json:"status"`
+	PeerName      string                          `json:"peer_name"`
+	Enode         string                          `json:"enode"`
+	ENR           string                          `json:"enr"`
+	ENRKeyValues  []*ClientELPageDataNodeENRValue `json:"enr_kv"`
+	IPAddr        string                          `json:"ip_addr"`
+	ListenAddr    string                          `json:"listen_addr"`
+	Peers         []*ClientELPageDataNodePeers    `json:"peers"`
+	DidFetchPeers bool                            `json:"peers_fetched"`
+	ForkConfig    *ClientELPageDataForkConfig     `json:"fork_config"`
 }
 
 type ClientELPageDataForkConfig struct {
@@ -75,15 +77,23 @@ type EthConfigKeyValue struct {
 }
 
 type ClientELPageDataNodePeers struct {
-	ID        string                          `json:"id"`
-	Alias     string                          `json:"alias"`
-	Enode     string                          `json:"enode"`
-	Name      string                          `json:"name"`
-	Type      string                          `json:"type"`
-	State     string                          `json:"state"`
-	Direction string                          `json:"direction"`
-	Caps      []string                        `json:"caps"`
-	Protocols []*ClientELPageDataNodeProtocol `json:"protocols"`
+	ID           string                          `json:"id"`
+	Alias        string                          `json:"alias"`
+	Enode        string                          `json:"enode"`
+	ENR          string                          `json:"enr"`
+	ENRKeyValues []*ClientELPageDataNodeENRValue `json:"enr_kv"`
+	Name         string                          `json:"name"`
+	Type         string                          `json:"type"`
+	State        string                          `json:"state"`
+	Direction    string                          `json:"direction"`
+	Caps         []string                        `json:"caps"`
+	Protocols    []*ClientELPageDataNodeProtocol `json:"protocols"`
+}
+
+// ClientELPageDataNodeENRValue is a single decoded key/value pair of a node's ENR.
+type ClientELPageDataNodeENRValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // ClientELPageDataNodeProtocol holds a single sub-protocol metadata entry of a


### PR DESCRIPTION
## Summary

Surfaces the `enr` field already returned by `admin_nodeInfo` / `admin_peers` on the execution clients page, mirroring the ENR display on the consensus clients page:

- **Node identity**: new ENR row (with copy button) plus an "ENR fields" section listing the decoded key/value pairs (seq, ip, tcp, udp, eth, etc.).
- **Connected peers**: each peer's detail table shows its ENR and decoded fields when the client reports one.

## Details

- ENRs are decoded with the existing `utils.DecodeENR` / `utils.GetKeyValuesFromENR` helpers into a sorted key/value list, cached per unique ENR string.
- Only strings starting with `enr:` are decoded — some clients report an enode URL in the `enr` field for peers without a signed record.
- Like the CL page, ENR data is only included server-side when `ShowSensitivePeerInfos` is enabled (ENRs contain IPs), and the template only renders the rows when an ENR is actually present.

## Client support (verified on glamsterdam-devnet-8)

| Client | own ENR (`admin_nodeInfo`) | peer ENRs (`admin_peers`) |
|---|---|---|
| geth | ✅ | partial |
| erigon | ✅ | partial |
| besu | ✅ | ❌ |
| nethermind | ✅ | ❌ |
| reth | ✅ | ❌ |
| ethrex | ✅ | ❌ |
| nimbus-el | ✅ | ❌ |

All clients expose their own ENR, so the node identity section populates everywhere; per-peer ENRs currently only show up on geth/erigon (and only for peers found via discovery). Clients without ENR data render unchanged.