### PR TITLE
Extend execution clients search to enode, ENR, IP and peers

### DIFF
--- a/handlers/clients_el.go
+++ b/handlers/clients_el.go
@@ -269,19 +269,24 @@ func buildELClientsPageData(sortOrder string) (*models.ClientsELPageData, time.D
 
 			resPeer := &models.ClientELPageDataNodePeers{
 				ID:        peerID,
-				State:     peer.Name,
 				Direction: direction,
 				Alias:     peerAlias,
-				Name:      peer.Name,
-				Enode:     enoderaw,
-				Caps:      peer.Caps,
-				Protocols: buildPeerProtocols(peer.Protocols),
 				Type:      peerType,
 			}
 
-			if pageData.ShowSensitivePeerInfos && strings.HasPrefix(peer.ENR, "enr:") {
-				resPeer.ENR = peer.ENR
-				resPeer.ENRKeyValues = getEnrValues(peer.ENR)
+			// The peer details (enode, name, caps, protocols, ENR) are only rendered
+			// when ShowSensitivePeerInfos is enabled, so gate them server-side like
+			// the node's own enode/ENR/IPs to keep them out of the page data.
+			if pageData.ShowSensitivePeerInfos {
+				resPeer.State = peer.Name
+				resPeer.Name = peer.Name
+				resPeer.Enode = enoderaw
+				resPeer.Caps = peer.Caps
+				resPeer.Protocols = buildPeerProtocols(peer.Protocols)
+				if strings.HasPrefix(peer.ENR, "enr:") {
+					resPeer.ENR = peer.ENR
+					resPeer.ENRKeyValues = getEnrValues(peer.ENR)
+				}
 			}
 
 			resPeers = append(resPeers, resPeer)

--- a/templates/clients/clients_el.html
+++ b/templates/clients/clients_el.html
@@ -44,7 +44,7 @@
           <div style="margin-bottom: 15px; padding: 0 15px;">
             <div class="input-group">
               <span class="input-group-text"><i class="fas fa-search"></i></span>
-              <input type="text" class="form-control" id="clientSearchInput" placeholder="Search clients by name...">
+              <input type="text" class="form-control" id="clientSearchInput" placeholder="Search by name, peer ID, enode, ENR, or IP...">
               <button class="btn btn-outline-secondary" type="button" id="clearClientSearch">Clear</button>
             </div>
           </div>
@@ -547,6 +547,25 @@
     $('#peerInfo-' + peerId).collapse('show');
   });
 
+  // Match a node's own identity fields (name, enode, ENR, IPs) and those of
+  // its connected peers, so searching for an enode, ENR, or IP address also
+  // finds the clients connected to that peer. Sensitive fields are empty
+  // when ShowSensitivePeerInfos is disabled, so they simply never match.
+  function nodeMatchesSearch(node, searchText) {
+    var fields = [node.name, node.peer_name, node.version, node.enode, node.enr, node.ip_addr, node.listen_addr];
+    for (var i = 0; i < fields.length; i++) {
+      if (fields[i] && fields[i].toLowerCase().includes(searchText)) return true;
+    }
+    var peers = node.peers || [];
+    for (var i = 0; i < peers.length; i++) {
+      var peerFields = [peers[i].id, peers[i].enode, peers[i].enr, peers[i].name];
+      for (var j = 0; j < peerFields.length; j++) {
+        if (peerFields[j] && peerFields[j].toLowerCase().includes(searchText)) return true;
+      }
+    }
+    return false;
+  }
+
   // Client search functionality
   $('#clientSearchInput').on('input', function() {
     var searchText = $(this).val().trim().toLowerCase();
@@ -554,9 +573,16 @@
     $('#clients tbody tr').each(function() {
       if (!$(this).hasClass('peerInfo')) {
         var clientName = $(this).find('.client-row a').text().toLowerCase();
+        var peerId = ($(this).find('.client-row').data('peerid') || '') + '';
         var peerInfoRow = $(this).next('.peerInfo');
+        var node = nodes[peerId] || {};
 
-        if (searchText === '' || clientName.includes(searchText)) {
+        var matches = searchText === '' ||
+          clientName.includes(searchText) ||
+          peerId.toLowerCase().includes(searchText) ||
+          nodeMatchesSearch(node, searchText);
+
+        if (matches) {
           $(this).show();
           peerInfoRow.css('display', '');
         } else {


### PR DESCRIPTION
## Summary

The search box on the execution clients page only matched the client name. This brings it in line with the CL page search (name / peer ID / ENR) and extends it further.

A client row now matches when the search text is found in any of:

- client name, peer ID, version
- the node's own **enode**, **ENR**, **IP address**, or **listen address**
- any connected **peer's** enode, ENR, peer ID, or name

Matching against connected peers means you can paste an IP address, enode, or ENR into the search box and find which of your clients are connected to that peer — handy for tracking down who is peered with a specific node on a devnet.

## Notes

- Placeholder text updated to "Search by name, peer ID, enode, ENR, or IP...".
- Sensitive fields (enode/ENR/IPs) are empty in the page model when `ShowSensitivePeerInfos` is disabled, so they simply never match — no information leak through search behavior.
- Builds on the ENR fields added in #838.