### PR TITLE
fix(ui): include in-block request count in EIP-8282 queue fee calculation

### DIFF
--- a/ui-package/src/components/SubmitBuilderDepositsForm/BuilderDepositsTable.tsx
+++ b/ui-package/src/components/SubmitBuilderDepositsForm/BuilderDepositsTable.tsx
@@ -62,6 +62,10 @@ const BuilderDepositsTable = (props: IBuilderDepositsTableProps): React.ReactEle
   }, [dataSourceKey, blsReady]);
 
   // Compute the predeploy queue fee (shared across all rows).
+  // Unlike EIP-7002/7251, the EIP-8282 contract charges fees per write path: the fee
+  // numerator is the excess (slot 0) plus the requests already added in the current
+  // block (slot 1) beyond TARGET_PER_BLOCK, so the fee rises within a block.
+  const targetPerBlock = 8n; // TARGET_PER_BLOCK of the builder deposit contract
   let queueLength = 0n;
   let isPreFork = false;
   let requiredFee = 0n;
@@ -73,12 +77,16 @@ const BuilderDepositsTable = (props: IBuilderDepositsTableProps): React.ReactEle
     if (queueLength === 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn) {
       isPreFork = true;
     } else {
-      requiredFee = getRequiredFee(queueLength);
+      let feeNumerator = queueLength;
+      if (queueData.blockCount > targetPerBlock) {
+        feeNumerator += queueData.blockCount - targetPerBlock;
+      }
+      requiredFee = getRequiredFee(feeNumerator);
       if (addExtraFee && cachedLogData) {
         for (let block in cachedLogData.logCount) avgRequestPerBlock += cachedLogData.logCount[block];
         avgRequestPerBlock /= logLookbackRange;
         let extra = avgRequestPerBlock < 2 ? 3 : avgRequestPerBlock + 1;
-        requestFee = getRequiredFee(queueLength + BigInt(Math.ceil(extra)));
+        requestFee = getRequiredFee(feeNumerator + BigInt(Math.ceil(extra)));
       } else {
         requestFee = requiredFee;
       }

--- a/ui-package/src/components/SubmitBuilderExitsForm/BuilderExitReview.tsx
+++ b/ui-package/src/components/SubmitBuilderExitsForm/BuilderExitReview.tsx
@@ -41,7 +41,14 @@ const BuilderExitReview = (props: IBuilderExitReviewProps) => {
       if (queueLength === 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffn) {
         isPreFork = true;
       } else {
-        requiredFee = getRequiredFee(queueLength);
+        // Unlike EIP-7002/7251, the EIP-8282 contract charges fees per write path: the fee
+        // numerator is the excess (slot 0) plus the requests already added in the current
+        // block (slot 1) beyond TARGET_PER_BLOCK (2 for the builder exit contract).
+        let feeNumerator = queueLength;
+        if (queueData.blockCount > 2n) {
+          feeNumerator += queueData.blockCount - 2n;
+        }
+        requiredFee = getRequiredFee(feeNumerator);
 
         if (addExtraFee && cachedLogData) {
           for (let block in cachedLogData.logCount) {
@@ -56,7 +63,7 @@ const BuilderExitReview = (props: IBuilderExitReviewProps) => {
             extraFeeForRequest++;
           }
 
-          requestFee = getRequiredFee(queueLength + BigInt(Math.ceil(extraFeeForRequest)));
+          requestFee = getRequiredFee(feeNumerator + BigInt(Math.ceil(extraFeeForRequest)));
         } else {
           requestFee = requiredFee;
         }

--- a/ui-package/src/hooks/useQueueDataCache.ts
+++ b/ui-package/src/hooks/useQueueDataCache.ts
@@ -104,8 +104,13 @@ export const useQueueDataCache = (contractAddress: string, chainId?: number) => 
       ]);
 
       if (result.data) {
+        // refetch() resolves even on query errors; a missing slot-1 value must not
+        // silently degrade to 0n, as that would understate the quoted fee
+        if (countResult.data == null) {
+          throw countResult.error ?? new Error('Failed to read request count (slot 0x01)');
+        }
         const queueLength = BigInt(result.data as string);
-        const blockCount = countResult.data ? BigInt(countResult.data as string) : 0n;
+        const blockCount = BigInt(countResult.data as string);
         const queueData: QueueData = {
           queueLength,
           blockCount,

--- a/ui-package/src/hooks/useQueueDataCache.ts
+++ b/ui-package/src/hooks/useQueueDataCache.ts
@@ -3,6 +3,7 @@ import { useStorageAt, useBlockNumber, usePublicClient } from 'wagmi';
 
 interface QueueData {
   queueLength: bigint;
+  blockCount: bigint;
   lastFetch: number;
   isLoading: boolean;
   error: Error | null;
@@ -47,7 +48,16 @@ export const useQueueDataCache = (contractAddress: string, chainId?: number) => 
   
   const storageCall = useStorageAt({
     address: contractAddress as `0x${string}`,
-    slot: "0x00",
+    slot: "0x00", // excess requests (fee numerator base)
+    chainId,
+    query: {
+      enabled: false, // We'll manually control when to fetch
+    }
+  });
+
+  const countStorageCall = useStorageAt({
+    address: contractAddress as `0x${string}`,
+    slot: "0x01", // requests added in the current block
     chainId,
     query: {
       enabled: false, // We'll manually control when to fetch
@@ -88,12 +98,17 @@ export const useQueueDataCache = (contractAddress: string, chainId?: number) => 
     fetchingContracts.add(cacheKey);
     
     try {
-      const result = await storageCall.refetch();
-      
+      const [result, countResult] = await Promise.all([
+        storageCall.refetch(),
+        countStorageCall.refetch(),
+      ]);
+
       if (result.data) {
         const queueLength = BigInt(result.data as string);
+        const blockCount = countResult.data ? BigInt(countResult.data as string) : 0n;
         const queueData: QueueData = {
           queueLength,
+          blockCount,
           lastFetch: Date.now(),
           isLoading: false,
           error: null,
@@ -110,6 +125,7 @@ export const useQueueDataCache = (contractAddress: string, chainId?: number) => 
     } catch (error) {
       const queueData: QueueData = {
         queueLength: 0n,
+        blockCount: 0n,
         lastFetch: Date.now(),
         isLoading: false,
         error: error as Error,
@@ -125,7 +141,7 @@ export const useQueueDataCache = (contractAddress: string, chainId?: number) => 
     } finally {
       fetchingContracts.delete(cacheKey);
     }
-  }, [cacheKey, storageCall]);
+  }, [cacheKey, storageCall, countStorageCall]);
 
   const fetchLogData = useCallback(async () => {
     if (!client || !blockNumber.data) return;
@@ -205,6 +221,7 @@ export const useQueueDataCache = (contractAddress: string, chainId?: number) => 
     if (fetchingContracts.has(cacheKey)) {
       return {
         queueLength: 0n,
+        blockCount: 0n,
         lastFetch: 0,
         isLoading: true,
         error: null,


### PR DESCRIPTION
## Problem

Builder deposit transactions submitted via the "Submit builder deposits" page reverted: Dora showed a queue fee of 1 wei while the contract's fee getter (empty-calldata call) returned 48 wei.

The builder deposit and builder exit system contracts (EIP-8282) charge request fees **per write path**, unlike EIP-7002/7251 where the fee only changes at end-of-block. Per the [sys-asm reference implementation](https://github.com/ethereum/sys-asm/blob/3bba94c696bc46beeecef05db6c2df0f18b4b239/src/builder_deposits/main.eas), the user subroutine computes the fee numerator as:

```
excess (slot 0) + max(0, current_block_count (slot 1) - TARGET_PER_BLOCK)
```

with `TARGET_PER_BLOCK = 8` for the builder deposit contract and `2` for the builder exit contract.

The submit forms only read storage slot 0, so during a burst of requests the displayed fee was far below what the contract actually charged (a fee numerator of 66 yields exactly the observed 48 wei, while slot 0 alone yielded 1 wei). The transaction's `msg.value` (stake + understated fee) then failed the contract's `callvalue - fee >= stake_wei` check and reverted.

The EIP-7002 withdrawal and EIP-7251 consolidation forms are unaffected — those contracts compute the user fee from the excess slot only.

## Fix

- `useQueueDataCache`: additionally read storage slot `0x01` (requests added in the current block) alongside slot `0x00`, exposed as `blockCount`.
- `BuilderDepositsTable` / `BuilderExitReview`: fold `max(0, blockCount - TARGET_PER_BLOCK)` into the fee numerator before running the fake-exponential, matching the contract's user-path logic. The "add extra fee" headroom is applied on top of the corrected numerator.

## Testing

- `npm run build` in `ui-package` compiles cleanly (only pre-existing warnings).
- Verified the fee formula against the sys-asm assembly: with the reported on-chain state the corrected computation reproduces the contract getter's 48 wei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEDNv2UuHsNxitpTUGZf55

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEDNv2UuHsNxitpTUGZf55)_