### PR TITLE
Update state transition for spec `v1.7.0-alpha.14`

### DIFF
--- a/db/slots.go
+++ b/db/slots.go
@@ -610,7 +610,6 @@ func GetFilteredSlots(ctx context.Context, filter *dbtypes.BlockFilter, firstSlo
 
 	fmt.Fprintf(&sql, `	ORDER BY slots.slot DESC `)
 	fmt.Fprintf(&sql, ` LIMIT $%v OFFSET $%v `, argIdx+1, argIdx+2)
-	argIdx += 2
 	args = append(args, limit)
 	args = append(args, offset)
 

--- a/indexer/beacon/statetransition/builder.go
+++ b/indexer/beacon/statetransition/builder.go
@@ -1,6 +1,8 @@
 package statetransition
 
 import (
+	"math"
+
 	"github.com/ethpandaops/go-eth2-client/spec"
 	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
@@ -16,6 +18,10 @@ const (
 	// preset/config), so this value is not network-configurable.
 	BuilderPaymentQuorumPercent = 100.0 * BuilderPaymentThresholdNumerator / BuilderPaymentThresholdDenominator
 )
+
+// BuilderIndexSelfBuild is BUILDER_INDEX_SELF_BUILD: the sentinel builder index marking a bid that
+// the proposer built itself rather than buying from a builder.
+const BuilderIndexSelfBuild = gloas.BuilderIndex(math.MaxUint64)
 
 // processBuilderPendingPayments implements process_builder_pending_payments (Gloas).
 // Evaluates the first SLOTS_PER_EPOCH entries of BuilderPendingPayments against

--- a/indexer/beacon/statetransition/fork.go
+++ b/indexer/beacon/statetransition/fork.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/capella"
+	"github.com/ethpandaops/go-eth2-client/spec/deneb"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
@@ -87,20 +88,29 @@ func upgradeToGloas(s *stateAccessor) []*electra.PendingDeposit {
 	s.BuilderPendingPayments = payments
 	s.BuilderPendingWithdrawals = make([]*gloas.BuilderPendingWithdrawal, 0)
 
-	// [New in Gloas:EIP7732] latest_execution_payload_bid seeded from the header, with the root of
-	// an empty ExecutionRequests. A HTR failure leaves a zero root (best effort; only affects the
-	// state root used to short-circuit later replays, never the extracted field values).
+	// [New in Gloas:EIP7732] latest_execution_payload_bid seeded from the pre-state's execution
+	// payload header and block header, marked as a self-build, with the root of an empty
+	// ExecutionRequests. A HTR failure leaves a zero root (best effort; only affects the state root
+	// used to short-circuit later replays, never the extracted field values).
 	var execRequestsRoot phase0.Root
 	if root, err := s.dynSsz.HashTreeRoot(&all.ExecutionRequests{Version: spec.DataVersionGloas}); err == nil {
 		execRequestsRoot = phase0.Root(root)
 	}
 	bid := &all.ExecutionPayloadBid{
 		Version:               spec.DataVersionGloas,
+		BuilderIndex:          BuilderIndexSelfBuild,
+		BlobKZGCommitments:    make([]deneb.KZGCommitment, 0),
 		ExecutionRequestsRoot: execRequestsRoot,
 	}
 	if header != nil {
+		bid.ParentBlockHash = header.ParentHash
 		bid.BlockHash = header.BlockHash
+		bid.PrevRandao = phase0.Root(header.PrevRandao)
 		bid.GasLimit = header.GasLimit
+	}
+	if s.LatestBlockHeader != nil {
+		bid.ParentBlockRoot = s.LatestBlockHeader.ParentRoot
+		bid.Slot = s.LatestBlockHeader.Slot
 	}
 	s.LatestExecutionPayloadBid = bid
 	s.PayloadExpectedWithdrawals = make([]*capella.Withdrawal, 0)

--- a/indexer/beacon/statetransition/operations.go
+++ b/indexer/beacon/statetransition/operations.go
@@ -443,6 +443,7 @@ func processAttestation(s *stateAccessor, att *all.Attestation, cc *committeeCac
 			continue
 		}
 
+		hadNoParticipation := participation[index] == 0
 		willSetNewFlag := false
 		for fi := 0; fi < 3; fi++ {
 			if !participationFlags[fi] {
@@ -456,10 +457,11 @@ func processAttestation(s *stateAccessor, att *all.Attestation, cc *committeeCac
 		}
 
 		// Gloas: each validator contributes its effective balance to the
-		// builder payment weight at most once per slot, when it first sets a
-		// new flag on a same-slot attestation. Only counted when the slot
-		// actually has a builder payment with non-zero amount.
-		if willSetNewFlag && sameSlot && builderPayment != nil &&
+		// builder payment weight at most once per slot, when it sets a new flag
+		// on a same-slot attestation while holding no prior flags for that
+		// epoch. Only counted when the slot actually has a builder payment with
+		// non-zero amount.
+		if willSetNewFlag && hadNoParticipation && sameSlot && builderPayment != nil &&
 			builderPayment.Withdrawal != nil && builderPayment.Withdrawal.Amount > 0 {
 			builderPayment.Weight += s.Validators[index].EffectiveBalance
 		}


### PR DESCRIPTION
Upgrades the state transition in `indexer/beacon/statetransition/` from consensus-specs `v1.7.0-alpha.13` to [`v1.7.0-alpha.14`](https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.14).

## Spec delta

The raw `alpha.13 → alpha.14` diff is ~5,900 lines, but nearly all of it is cosmetic: the spec now declares named SSZ type aliases (`Balances`, `Withdrawals`, `PTC`, `PTCWindow`, `ProposerIndices`, …) and containers reference those instead of inline `ProgressiveList[…]` / `Vector[…]`. Diffing the spec's Python blocks function-by-function across every fork shows **phase0 through fulu have zero functional changes**.

Only two changes affect the state transition, both Gloas.

### 1. `upgrade_to_gloas` populates the full `latest_execution_payload_bid`

Previously only `block_hash`, `gas_limit` and `execution_requests_root` were seeded. alpha.14 also sets `parent_block_hash` (from the pre-state payload header), `parent_block_root` and `slot` (from `pre.latest_block_header`), `prev_randao`, and `builder_index = BUILDER_INDEX_SELF_BUILD`.

This **changes the post-fork state root**, so it is required for correct replay across the Gloas fork boundary. Adds a `BuilderIndexSelfBuild` constant (`UINT64_MAX`).

### 2. Gloas `process_attestation` gains the `had_no_participation` gate

Builder payment weight now also requires that the validator held no participation flags for that epoch before the attestation was applied. alpha.13's `will_set_new_flag` check alone was insufficient: when two aggregates for the same slot each set a *different* new flag, the validator's effective balance was added to the payment weight twice.

## Not covered here (non-STF)

- `GAS_LIMIT_SCHEDULE` config and `get_scheduled_gas_limit` — block-building only, no state effect.
- `MAX_BYTES_PER_INCLUSION_LIST` → `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST` — not referenced by dora.
- New EIP8321 feature fork — not a scheduled fork.
- Heze `InclusionList.inclusion_list_committee_root` → `dependent_root` — needs a `go-eth2-client` rename first, then `handlers/slot.go` and `handlers/api/slot_inclusion_lists_v1.go` follow. SSZ shape is unchanged (`Root` → `Root`), so nothing breaks in the meantime.

## Verification

- Both changed functions checked field-by-field against the alpha.14 spec text.
- Confirmed every newly-set bid field actually reaches the hash tree root through the `all.ExecutionPayloadBid` wrapper — each field independently changes the root, and nil vs. empty `blob_kzg_commitments` hash identically.
- Audited dora's coverage of all 56 Gloas spec functions. The only gaps are assert-only or signature-verification helpers (`process_payload_attestation` mutates no state, `can_builder_cover_bid`, the two signature verifiers), which is consistent with replaying canonical blocks.
- Cross-checked `process_execution_payload_bid` against alpha.14 — state effects match (dora reads `s.Slot` / `block.ProposerIndex` where the spec reads `bid.slot` / `get_beacon_proposer_index`, equivalent under the spec's own asserts).
- `go build`, `go vet`, `gofmt` and `go test ./indexer/beacon/...` all clean.
- Pre-Gloas replay on `glamsterdam-devnet-8` (alpha.14, slots 45601–45617): every state root matched.

### Known gap

The new `upgrade_to_gloas` bid has **not** been validated against a real post-fork state root yet. `devnet-7` is still on alpha.13; `glamsterdam-devnet-8` is on alpha.14 but its `GLOAS_FORK_EPOCH` is 1536 and head was around epoch 1425 at the time of writing. The definitive check is to replay devnet-8 across slot 49152 with `cmd/statetransition-test` once it forks.
