### PR TITLE
fix(deposits): rework builder deposit tracking around the Gloas fork

### DIFF
--- a/clients/consensus/chainstate.go
+++ b/clients/consensus/chainstate.go
@@ -558,3 +558,30 @@ func (cs *ChainState) GetActivationExitChurnLimit(totalActiveBalance uint64) uin
 
 	return balanceChurnLimit
 }
+
+// GetActivationChurnLimit returns the per-epoch churn budget that deposits consume.
+//
+// Gloas (EIP-8061) splits this off from the shared activation/exit churn limit and gives it its
+// own quotient and cap, so deposits and exits no longer compete for the same budget.
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#new-get_activation_churn_limit
+func (cs *ChainState) GetActivationChurnLimit(epoch phase0.Epoch, totalActiveBalance uint64) uint64 {
+	if cs.specs == nil {
+		return 0
+	}
+
+	if !cs.IsEip7732Enabled(epoch) {
+		return cs.GetActivationExitChurnLimit(totalActiveBalance)
+	}
+
+	churn := totalActiveBalance / cs.specs.ChurnLimitQuotientGloas
+	if churn < cs.specs.MinPerEpochChurnLimitElectra {
+		churn = cs.specs.MinPerEpochChurnLimitElectra
+	}
+	churn -= churn % cs.specs.EffectiveBalanceIncrement
+
+	if churn > cs.specs.MaxPerEpochActivationChurnLimitGloas {
+		return cs.specs.MaxPerEpochActivationChurnLimitGloas
+	}
+
+	return churn
+}

--- a/db/builder_deposit_request_txs.go
+++ b/db/builder_deposit_request_txs.go
@@ -9,7 +9,19 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// builderDepositTxFieldCount is the number of columns written per row; it must match the column list
+// below and is what bounds the chunk size in InsertBuilderDepositTxs.
+const builderDepositTxFieldCount = 14
+
 func InsertBuilderDepositTxs(ctx context.Context, tx *sqlx.Tx, depositTxs []*dbtypes.BuilderDepositTx) error {
+	return insertChunks(depositTxs, builderDepositTxFieldCount, func(chunk []*dbtypes.BuilderDepositTx) error {
+		return insertBuilderDepositTxsChunk(ctx, tx, chunk)
+	})
+}
+
+// insertBuilderDepositTxsChunk inserts a single statement worth of rows; callers must go through
+// InsertBuilderDepositTxs so the bind-parameter limit is respected.
+func insertBuilderDepositTxsChunk(ctx context.Context, tx *sqlx.Tx, depositTxs []*dbtypes.BuilderDepositTx) error {
 	var sql strings.Builder
 	fmt.Fprint(&sql,
 		EngineQuery(map[dbtypes.DBEngineType]string{
@@ -20,7 +32,7 @@ func InsertBuilderDepositTxs(ctx context.Context, tx *sqlx.Tx, depositTxs []*dbt
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 14
+	fieldCount := builderDepositTxFieldCount
 
 	args := make([]any, len(depositTxs)*fieldCount)
 	for i, depositTx := range depositTxs {
@@ -145,9 +157,18 @@ func GetBuilderDepositTxsFiltered(ctx context.Context, offset uint64, limit uint
 
 	filterOp := "WHERE"
 	if filter.MinDequeue > 0 {
-		// dequeue block 0 = queued before dequeue activation, not determinable yet - still pending
+		// dequeue block 0 = queued before dequeue activation, so its real dequeue block is not
+		// determinable yet. Such a request counts as pending until it shows up as an included
+		// builder deposit on the consensus side: the dequeue block only gets rebased once the
+		// activation fork boundary is finalized, and until then a sentinel row would otherwise
+		// be listed as pending next to the very deposit it produced.
 		args = append(args, filter.MinDequeue)
-		fmt.Fprintf(&sql, " %v (dequeue_block >= $%v OR dequeue_block = 0)", filterOp, len(args))
+		fmt.Fprintf(&sql, ` %v (dequeue_block >= $%v OR (dequeue_block = 0 AND NOT EXISTS (
+			SELECT 1 FROM builder_deposits
+			WHERE builder_deposits.public_key = builder_deposit_request_txs.public_key
+			AND builder_deposits.amount = builder_deposit_request_txs.amount
+			AND builder_deposits.signature = builder_deposit_request_txs.signature
+		)))`, filterOp, len(args))
 		filterOp = "AND"
 	}
 	if filter.MaxDequeue > 0 {
@@ -218,4 +239,49 @@ func GetBuilderDepositTxsFiltered(ctx context.Context, offset uint64, limit uint
 	}
 
 	return depositTxs[1:], depositTxs[0].BlockNumber, nil
+}
+
+// GetBuilderDepositTxsWithSentinelDequeue returns the request txs of the given public keys that
+// are still stored with the dequeue-block sentinel (0).
+//
+// Requests enqueued before their activation fork have no determinable dequeue block until that
+// fork boundary is finalized, so the transaction matcher - which pairs consensus-side deposits
+// with request txs by dequeue block - cannot link them. Matching them to their deposit by
+// content is what surfaces their transaction in the meantime.
+func GetBuilderDepositTxsWithSentinelDequeue(ctx context.Context, publicKeys [][]byte) []*dbtypes.BuilderDepositTx {
+	depositTxs := []*dbtypes.BuilderDepositTx{}
+	if len(publicKeys) == 0 {
+		return depositTxs
+	}
+
+	err := insertChunks(publicKeys, 1, func(chunk [][]byte) error {
+		var sql strings.Builder
+		args := make([]any, 0, len(chunk))
+
+		fmt.Fprint(&sql, `SELECT builder_deposit_request_txs.*
+			FROM builder_deposit_request_txs
+			WHERE dequeue_block = 0 AND public_key IN (
+		`)
+
+		for _, publicKey := range chunk {
+			args = append(args, publicKey)
+		}
+		appendDollarPlaceholders(&sql, 1, len(chunk), ", ")
+		fmt.Fprint(&sql, ") ORDER BY block_number ASC, block_index ASC")
+
+		var chunkResult []*dbtypes.BuilderDepositTx
+		if err := ReaderDb.SelectContext(ctx, &chunkResult, sql.String(), args...); err != nil {
+			return err
+		}
+
+		depositTxs = append(depositTxs, chunkResult...)
+
+		return nil
+	})
+	if err != nil {
+		logger.Errorf("Error while fetching sentinel builder deposit txs: %v", err)
+		return nil
+	}
+
+	return depositTxs
 }

--- a/db/builder_deposits.go
+++ b/db/builder_deposits.go
@@ -9,7 +9,19 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// builderDepositFieldCount is the number of columns written per row; it must match the column list
+// below and is what bounds the chunk size in InsertBuilderDeposits.
+const builderDepositFieldCount = 13
+
 func InsertBuilderDeposits(ctx context.Context, tx *sqlx.Tx, deposits []*dbtypes.BuilderDeposit) error {
+	return insertChunks(deposits, builderDepositFieldCount, func(chunk []*dbtypes.BuilderDeposit) error {
+		return insertBuilderDepositsChunk(ctx, tx, chunk)
+	})
+}
+
+// insertBuilderDepositsChunk inserts a single statement worth of rows; callers must go through
+// InsertBuilderDeposits so the bind-parameter limit is respected.
+func insertBuilderDepositsChunk(ctx context.Context, tx *sqlx.Tx, deposits []*dbtypes.BuilderDeposit) error {
 	var sql strings.Builder
 	fmt.Fprint(&sql,
 		EngineQuery(map[dbtypes.DBEngineType]string{
@@ -20,7 +32,7 @@ func InsertBuilderDeposits(ctx context.Context, tx *sqlx.Tx, deposits []*dbtypes
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 13
+	fieldCount := builderDepositFieldCount
 
 	args := make([]interface{}, len(deposits)*fieldCount)
 	for i, deposit := range deposits {

--- a/db/builder_deposits_test.go
+++ b/db/builder_deposits_test.go
@@ -1,0 +1,132 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/ethpandaops/dora/dbtypes"
+)
+
+// TestInsertBuilderDepositsChunking inserts far more rows than a single statement can bind.
+// The one-time Gloas builder onboarding produces one row per queued builder deposit, which on
+// a spammed devnet was ~12k rows - 13 placeholders each, well past the 65535 parameters
+// postgres allows and the 32766 sqlite allows.
+func TestInsertBuilderDepositsChunking(t *testing.T) {
+	newTestDB(t)
+
+	const rowCount = 20000
+
+	deposits := make([]*dbtypes.BuilderDeposit, 0, rowCount)
+	for i := 0; i < rowCount; i++ {
+		slotRoot := make([]byte, 32)
+		slotRoot[0] = byte(i % 251)
+		pubkey := make([]byte, 48)
+		pubkey[0] = byte(i % 253)
+
+		deposits = append(deposits, &dbtypes.BuilderDeposit{
+			SlotNumber:            1000,
+			SlotRoot:              slotRoot,
+			SlotIndex:             uint64(i),
+			ForkId:                1,
+			PublicKey:             pubkey,
+			WithdrawalCredentials: make([]byte, 32),
+			Amount:                1_000_000_000,
+			Signature:             make([]byte, 96),
+			Result:                dbtypes.BuilderDepositRequestResultNewBuilder,
+		})
+	}
+
+	err := RunDBTransaction(func(tx *sqlx.Tx) error {
+		return InsertBuilderDeposits(context.Background(), tx, deposits)
+	})
+	if err != nil {
+		t.Fatalf("insert builder deposits: %v", err)
+	}
+
+	var count int
+	if err := ReaderDb.Get(&count, "SELECT count(*) FROM builder_deposits"); err != nil {
+		t.Fatalf("count builder deposits: %v", err)
+	}
+	if count != rowCount {
+		t.Errorf("stored %d builder deposits, want %d", count, rowCount)
+	}
+}
+
+// TestGetBuilderDepositTxsFilteredSentinelDequeue checks that a request tx stored with the
+// dequeue-block sentinel (0) only counts as pending while no builder deposit carrying the same
+// content has been included. Requests enqueued before the activation fork keep that sentinel
+// until the fork boundary finalizes, so without the check they would be listed as pending next
+// to the very deposit they produced.
+func TestGetBuilderDepositTxsFilteredSentinelDequeue(t *testing.T) {
+	newTestDB(t)
+
+	ctx := context.Background()
+	includedPubkey := make([]byte, 48)
+	includedPubkey[0] = 0x11
+	queuedPubkey := make([]byte, 48)
+	queuedPubkey[0] = 0x22
+	signature := make([]byte, 96)
+	signature[0] = 0x33
+
+	depositTx := func(pubkey []byte, blockIndex uint64) *dbtypes.BuilderDepositTx {
+		blockRoot := make([]byte, 32)
+		blockRoot[0] = byte(blockIndex)
+
+		return &dbtypes.BuilderDepositTx{
+			BlockNumber:           100,
+			BlockIndex:            blockIndex,
+			BlockTime:             1000,
+			BlockRoot:             blockRoot,
+			PublicKey:             pubkey,
+			WithdrawalCredentials: make([]byte, 32),
+			Amount:                1_000_000_000,
+			Signature:             signature,
+			TxSender:              make([]byte, 20),
+			TxTarget:              make([]byte, 20),
+			DequeueBlock:          0, // sentinel: activation block not resolved yet
+		}
+	}
+
+	err := RunDBTransaction(func(tx *sqlx.Tx) error {
+		if err := InsertBuilderDepositTxs(ctx, tx, []*dbtypes.BuilderDepositTx{
+			depositTx(includedPubkey, 1),
+			depositTx(queuedPubkey, 2),
+		}); err != nil {
+			return err
+		}
+
+		return InsertBuilderDeposits(ctx, tx, []*dbtypes.BuilderDeposit{{
+			SlotNumber:            2000,
+			SlotRoot:              make([]byte, 32),
+			SlotIndex:             0,
+			PublicKey:             includedPubkey,
+			WithdrawalCredentials: make([]byte, 32),
+			Amount:                1_000_000_000,
+			Signature:             signature,
+		}})
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rows, total, err := GetBuilderDepositTxsFiltered(ctx, 0, 10, &dbtypes.BuilderDepositTxFilter{MinDequeue: 500})
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("pending count = %d, want 1", total)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("returned %d rows, want 1", len(rows))
+	}
+	if rows[0].BlockIndex != 2 {
+		t.Errorf("pending row is block index %d, want 2 (the one without an included deposit)", rows[0].BlockIndex)
+	}
+
+	sentinel := GetBuilderDepositTxsWithSentinelDequeue(ctx, [][]byte{includedPubkey})
+	if len(sentinel) != 1 || sentinel[0].BlockIndex != 1 {
+		t.Errorf("sentinel lookup returned %d rows, want the included pubkey's request tx", len(sentinel))
+	}
+}

--- a/db/builder_exit_request_txs.go
+++ b/db/builder_exit_request_txs.go
@@ -9,7 +9,19 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// builderExitTxFieldCount is the number of columns written per row; it must match the column list
+// below and is what bounds the chunk size in InsertBuilderExitTxs.
+const builderExitTxFieldCount = 12
+
 func InsertBuilderExitTxs(ctx context.Context, tx *sqlx.Tx, exitTxs []*dbtypes.BuilderExitTx) error {
+	return insertChunks(exitTxs, builderExitTxFieldCount, func(chunk []*dbtypes.BuilderExitTx) error {
+		return insertBuilderExitTxsChunk(ctx, tx, chunk)
+	})
+}
+
+// insertBuilderExitTxsChunk inserts a single statement worth of rows; callers must go through
+// InsertBuilderExitTxs so the bind-parameter limit is respected.
+func insertBuilderExitTxsChunk(ctx context.Context, tx *sqlx.Tx, exitTxs []*dbtypes.BuilderExitTx) error {
 	var sql strings.Builder
 	fmt.Fprint(&sql,
 		EngineQuery(map[dbtypes.DBEngineType]string{
@@ -20,7 +32,7 @@ func InsertBuilderExitTxs(ctx context.Context, tx *sqlx.Tx, exitTxs []*dbtypes.B
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 12
+	fieldCount := builderExitTxFieldCount
 
 	args := make([]any, len(exitTxs)*fieldCount)
 	for i, exitTx := range exitTxs {

--- a/db/builder_exits.go
+++ b/db/builder_exits.go
@@ -9,7 +9,19 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// builderExitFieldCount is the number of columns written per row; it must match the column list
+// below and is what bounds the chunk size in InsertBuilderExits.
+const builderExitFieldCount = 11
+
 func InsertBuilderExits(ctx context.Context, tx *sqlx.Tx, exits []*dbtypes.BuilderExit) error {
+	return insertChunks(exits, builderExitFieldCount, func(chunk []*dbtypes.BuilderExit) error {
+		return insertBuilderExitsChunk(ctx, tx, chunk)
+	})
+}
+
+// insertBuilderExitsChunk inserts a single statement worth of rows; callers must go through
+// InsertBuilderExits so the bind-parameter limit is respected.
+func insertBuilderExitsChunk(ctx context.Context, tx *sqlx.Tx, exits []*dbtypes.BuilderExit) error {
 	var sql strings.Builder
 	fmt.Fprint(&sql,
 		EngineQuery(map[dbtypes.DBEngineType]string{
@@ -20,7 +32,7 @@ func InsertBuilderExits(ctx context.Context, tx *sqlx.Tx, exits []*dbtypes.Build
 		" VALUES ",
 	)
 	argIdx := 0
-	fieldCount := 11
+	fieldCount := builderExitFieldCount
 
 	args := make([]interface{}, len(exits)*fieldCount)
 	for i, exit := range exits {

--- a/db/execution_fork_ids.go
+++ b/db/execution_fork_ids.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// executionRequestTxTables are the tables holding execution-layer system contract requests. Each
+// row records the execution block it was seen in and the consensus fork that block belonged to at
+// the time it was indexed.
+//
+// The rows are keyed by block_root, which for these tables is the *execution* block hash
+// (log.BlockHash), not a consensus block root. That is the right key to re-tag by: an execution
+// block hash identifies exactly one block on exactly one chain, where a block number does not.
+var executionRequestTxTables = []string{
+	"deposit_txs",
+	"builder_deposit_request_txs",
+	"builder_exit_request_txs",
+	"withdrawal_request_txs",
+	"consolidation_request_txs",
+}
+
+// updateForkIdBatchSize bounds how many block hashes go into one UPDATE, keeping the statement
+// under the driver's bind-parameter limit (SQLite allows 32766, and older builds only 999).
+const updateForkIdBatchSize = 900
+
+// UpdateExecutionRequestTxsForkId re-tags the execution-layer request transactions of the given
+// execution blocks onto a fork.
+//
+// The consensus fork a block belongs to is not final when the block is first indexed: a fork id
+// handed out while the chain was still being resolved is superseded once the blocks are re-linked
+// onto their real fork. Consensus rows follow that move because the blocks are re-persisted, but
+// these are written once by the execution contract indexers and would otherwise keep the stale id
+// forever — which makes canonical transactions read as orphaned and stops them pairing with the
+// consensus requests they produced.
+func UpdateExecutionRequestTxsForkId(ctx context.Context, tx *sqlx.Tx, executionBlockHashes [][]byte, forkId uint64) error {
+	if len(executionBlockHashes) == 0 {
+		return nil
+	}
+
+	for start := 0; start < len(executionBlockHashes); start += updateForkIdBatchSize {
+		end := start + updateForkIdBatchSize
+		if end > len(executionBlockHashes) {
+			end = len(executionBlockHashes)
+		}
+
+		chunk := executionBlockHashes[start:end]
+
+		for _, table := range executionRequestTxTables {
+			var sql strings.Builder
+
+			args := make([]any, 0, len(chunk)+1)
+			args = append(args, forkId)
+
+			fmt.Fprintf(&sql, "UPDATE %v SET fork_id = $1 WHERE block_root IN (", table)
+
+			for i, blockHash := range chunk {
+				if i > 0 {
+					fmt.Fprint(&sql, ", ")
+				}
+
+				args = append(args, blockHash)
+				fmt.Fprintf(&sql, "$%v", len(args))
+			}
+
+			fmt.Fprint(&sql, ")")
+
+			if _, err := tx.ExecContext(ctx, sql.String(), args...); err != nil {
+				return fmt.Errorf("error updating %v fork ids: %w", table, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/db/execution_fork_ids_test.go
+++ b/db/execution_fork_ids_test.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecutionRequestTxTablesAreComplete guards that every execution-layer request table that
+// carries a fork_id is re-tagged. A table added later without being listed here would silently
+// keep stale fork ids, which reads as "canonical transaction shown as orphaned" long after the
+// fork it was indexed under is gone.
+func TestExecutionRequestTxTablesAreComplete(t *testing.T) {
+	require.ElementsMatch(t, []string{
+		"deposit_txs",
+		"builder_deposit_request_txs",
+		"builder_exit_request_txs",
+		"withdrawal_request_txs",
+		"consolidation_request_txs",
+	}, executionRequestTxTables)
+
+	for _, table := range executionRequestTxTables {
+		require.True(t, strings.HasSuffix(table, "_txs"),
+			"%v is not a request-transaction table; consensus rows follow their block instead", table)
+	}
+}
+
+func TestUpdateForkIdBatchStaysUnderBindLimits(t *testing.T) {
+	// one bind for the fork id plus one per block hash, against the 999-variable limit of older
+	// SQLite builds
+	require.LessOrEqual(t, updateForkIdBatchSize+1, 999)
+}

--- a/db/query_helpers.go
+++ b/db/query_helpers.go
@@ -67,3 +67,37 @@ func appendWithOrphanedFilter(sql *strings.Builder, args *[]any, filterOp *strin
 		*filterOp = "AND"
 	}
 }
+
+// maxBindParams bounds the placeholder count of a single INSERT statement. PostgreSQL's
+// extended protocol allows 65535 bind parameters per statement and SQLite's default
+// SQLITE_MAX_VARIABLE_NUMBER is 32766, so the lower of the two is applied to both engines.
+const maxBindParams = 32766
+
+// insertChunks splits items into slices small enough that fieldCount placeholders per item
+// stay below maxBindParams and runs insert for each of them. Bulk inserts whose size is
+// driven by chain data rather than by a per-block limit (e.g. the one-time Gloas builder
+// onboarding, which produces one row per queued builder deposit) exceed the limit in a
+// single statement and would fail the whole transaction.
+func insertChunks[T any](items []T, fieldCount int, insert func(chunk []T) error) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	chunkSize := maxBindParams / fieldCount
+	if chunkSize < 1 {
+		chunkSize = 1
+	}
+
+	for start := 0; start < len(items); start += chunkSize {
+		end := start + chunkSize
+		if end > len(items) {
+			end = len(items)
+		}
+
+		if err := insert(items[start:end]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/db/validators.go
+++ b/db/validators.go
@@ -390,3 +390,21 @@ func StreamValidatorsByIndexes(ctx context.Context, indexes []uint64, cb func(va
 
 	return nil
 }
+
+// DeleteValidators removes the given validator indexes. Real validators are never removed
+// from the registry, so this only exists to clean up rows that should not have been written
+// in the first place (see the projected-validator cleanup in the validator cache).
+func DeleteValidators(ctx context.Context, tx *sqlx.Tx, indexes []uint64) error {
+	return insertChunks(indexes, 1, func(chunk []uint64) error {
+		var sql strings.Builder
+		args := make([]any, 0, len(chunk))
+
+		fmt.Fprint(&sql, "DELETE FROM validators WHERE validator_index IN (")
+		appendUint64ListPlaceholders(&sql, &args, chunk, ", ")
+		fmt.Fprint(&sql, ")")
+
+		_, err := tx.ExecContext(ctx, sql.String(), args...)
+
+		return err
+	})
+}

--- a/handlers/api/deposits_queue_v1.go
+++ b/handlers/api/deposits_queue_v1.go
@@ -260,39 +260,43 @@ func APIDepositsQueueV1(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 
-					// Get validator information
+					// Get validator information. The index is only reported when the entry it
+					// points at can actually be loaded — GetValidatorIndexByPubkey also resolves
+					// validators that are merely projected from this very queue, and an index
+					// whose projection has gone away must not be reported as a real validator.
 					validatorIndex, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(queueEntry.PendingDeposit.Pubkey[:]))
-					if !found {
+					validator := (*v1.Validator)(nil)
+					if found {
+						validator = services.GlobalBeaconService.GetValidatorByIndex(validatorIndex, false)
+					}
+
+					if validator == nil {
 						depositInfo.ValidatorIndex = -1
 						depositInfo.ValidatorStatus = "Deposited"
 					} else {
 						depositInfo.ValidatorIndex = int64(validatorIndex)
 						depositInfo.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIndex))
 
-						// Get validator status and liveness
-						validator := services.GlobalBeaconService.GetValidatorByIndex(phase0.ValidatorIndex(validatorIndex), false)
-						if validator != nil {
-							if strings.HasPrefix(validator.Status.String(), "pending") {
-								depositInfo.ValidatorStatus = "Pending"
-							} else if validator.Status == v1.ValidatorStateActiveOngoing {
-								depositInfo.ValidatorStatus = "Active"
-								depositInfo.ValidatorLiveness = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
-								depositInfo.ValidatorLivenessMax = 3
-							} else if validator.Status == v1.ValidatorStateActiveExiting {
-								depositInfo.ValidatorStatus = "Exiting"
-								depositInfo.ValidatorLiveness = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
-								depositInfo.ValidatorLivenessMax = 3
-							} else if validator.Status == v1.ValidatorStateActiveSlashed {
-								depositInfo.ValidatorStatus = "Slashed"
-								depositInfo.ValidatorLiveness = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
-								depositInfo.ValidatorLivenessMax = 3
-							} else if validator.Status == v1.ValidatorStateExitedUnslashed {
-								depositInfo.ValidatorStatus = "Exited"
-							} else if validator.Status == v1.ValidatorStateExitedSlashed {
-								depositInfo.ValidatorStatus = "Slashed"
-							} else {
-								depositInfo.ValidatorStatus = validator.Status.String()
-							}
+						if strings.HasPrefix(validator.Status.String(), "pending") {
+							depositInfo.ValidatorStatus = "Pending"
+						} else if validator.Status == v1.ValidatorStateActiveOngoing {
+							depositInfo.ValidatorStatus = "Active"
+							depositInfo.ValidatorLiveness = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+							depositInfo.ValidatorLivenessMax = 3
+						} else if validator.Status == v1.ValidatorStateActiveExiting {
+							depositInfo.ValidatorStatus = "Exiting"
+							depositInfo.ValidatorLiveness = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+							depositInfo.ValidatorLivenessMax = 3
+						} else if validator.Status == v1.ValidatorStateActiveSlashed {
+							depositInfo.ValidatorStatus = "Slashed"
+							depositInfo.ValidatorLiveness = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+							depositInfo.ValidatorLivenessMax = 3
+						} else if validator.Status == v1.ValidatorStateExitedUnslashed {
+							depositInfo.ValidatorStatus = "Exited"
+						} else if validator.Status == v1.ValidatorStateExitedSlashed {
+							depositInfo.ValidatorStatus = "Slashed"
+						} else {
+							depositInfo.ValidatorStatus = validator.Status.String()
 						}
 					}
 

--- a/handlers/builder_deposits.go
+++ b/handlers/builder_deposits.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"time"
 
@@ -295,6 +296,12 @@ func buildBuilderDepositsPageData(ctx context.Context, pageIdx uint64, pageSize 
 	return pageData
 }
 
+// queuedRegularFetchCap bounds how many queued builder-contract request txs the pre-Gloas
+// projection page enumerates. The whole set is needed at once: the projected builder index of
+// each deposit depends on its position in the contract queue, so the list cannot be paginated
+// at the db level.
+const queuedRegularFetchCap = 10000
+
 // buildBuilderDepositsProjectionPageData builds the pre-Gloas projection view of the builder
 // deposits page: the builders projected to be onboarded from the pending deposit queue at the Gloas
 // fork transition, plus the "is it safe to deposit right now" indicator. It applies the slot, pubkey
@@ -365,10 +372,9 @@ func buildBuilderDepositsProjectionPageData(ctx context.Context, pageIdx uint64,
 
 	// Regular builder deposits already queued in the builder deposit contract: they can be
 	// submitted before the fork, but stay locked in the queue until dequeuing starts with the
-	// first Gloas payload, so no builder index is assigned yet (builders onboarded at the fork
-	// transition are registered first). Listed before the projected onboarding deposits, like
-	// pending request txs on the post-fork page.
-	pageOffset := (pageIdx - 1) * pageSize
+	// first Gloas payload. The fork transition onboards the validator-contract deposits first,
+	// so these continue the builder index sequence behind them - which is also why they are
+	// listed after the onboarding group.
 	queuedFilter := &dbtypes.BuilderDepositTxFilter{
 		PublicKey: common.FromHex(pubkey),
 	}
@@ -379,22 +385,45 @@ func buildBuilderDepositsProjectionPageData(ctx context.Context, pageIdx uint64,
 		queuedFilter.MaxAmount = &maxAmount
 	}
 
-	queuedTxs, totalTxRows := services.GlobalBeaconService.GetQueuedBuilderDepositTxs(ctx, queuedFilter, pageOffset, uint32(pageSize))
+	queuedTxs, totalTxRows := services.GlobalBeaconService.GetQueuedBuilderDepositTxs(ctx, queuedFilter, 0, queuedRegularFetchCap)
 	pageData.QueuedRegularCount = totalTxRows
+	if totalTxRows > queuedRegularFetchCap {
+		pageData.ProjectionTruncated = true
+		logrus.Warnf("builder deposits projection truncated: %v of %v queued builder contract deposits enumerated", queuedRegularFetchCap, totalTxRows)
+	}
 
+	// GetQueuedBuilderDepositTxs returns newest first; the contract dequeues in enqueue order,
+	// so the builder index sequence is assigned over the reversed (oldest first) list.
 	queuedRows := make([]*models.BuilderDepositsPageDataDeposit, 0, len(queuedTxs))
-	for _, queuedTx := range queuedTxs {
+	nextBuilderIndex := uint64(0)
+	if projection != nil {
+		nextBuilderIndex = projection.NextBuilderIndex
+	}
+	queuedBuilderIndexes := make(map[string]uint64, len(queuedTxs))
+
+	for i := len(queuedTxs) - 1; i >= 0; i-- {
+		queuedTx := queuedTxs[i]
 		depositTx := queuedTx.Transaction
+
+		builderIndex, isKnown := queuedBuilderIndexes[string(depositTx.PublicKey)]
+		if !isKnown {
+			builderIndex = nextBuilderIndex
+			queuedBuilderIndexes[string(depositTx.PublicKey)] = builderIndex
+			nextBuilderIndex++
+		}
+
 		queuedRows = append(queuedRows, &models.BuilderDepositsPageDataDeposit{
-			IsQueuedRegular:       true,
-			Time:                  time.Unix(int64(depositTx.BlockTime), 0),
-			PublicKey:             depositTx.PublicKey,
-			WithdrawalCredentials: depositTx.WithdrawalCredentials,
-			Amount:                depositTx.Amount,
-			BlockNumber:           depositTx.BlockNumber,
-			HasTransaction:        true,
-			TransactionHash:       depositTx.TxHash,
-			TransactionOrphaned:   queuedTx.TransactionOrphaned,
+			IsQueuedRegular:          true,
+			HasProjectedBuilderIndex: projection != nil,
+			ProjectedBuilderIndex:    builderIndex,
+			Time:                     time.Unix(int64(depositTx.BlockTime), 0),
+			PublicKey:                depositTx.PublicKey,
+			WithdrawalCredentials:    depositTx.WithdrawalCredentials,
+			Amount:                   depositTx.Amount,
+			BlockNumber:              depositTx.BlockNumber,
+			HasTransaction:           true,
+			TransactionHash:          depositTx.TxHash,
+			TransactionOrphaned:      queuedTx.TransactionOrphaned,
 			TransactionDetails: &models.BuilderPageDataDepositTxDetails{
 				BlockNumber: depositTx.BlockNumber,
 				BlockHash:   fmt.Sprintf("%#x", depositTx.BlockRoot),
@@ -405,6 +434,9 @@ func buildBuilderDepositsProjectionPageData(ctx context.Context, pageIdx uint64,
 			},
 		})
 	}
+
+	// back to newest first for display
+	slices.Reverse(queuedRows)
 
 	// Map and filter the projected deposits (slot / pubkey / amount; builder-index filter ignored).
 	pubkeyFilter := common.FromHex(pubkey)
@@ -444,6 +476,8 @@ func buildBuilderDepositsProjectionPageData(ctx context.Context, pageIdx uint64,
 				Result:                    pd.Result,
 				IsQueued:                  pd.IsQueued,
 				QueuePosition:             pd.QueuePos,
+				HasProjectedBuilderIndex:  pd.HasProjectedBuilderIndex,
+				ProjectedBuilderIndex:     pd.ProjectedBuilderIndex,
 				ProjectedOnboarded:        pd.Onboarded(),
 				ProjectedTooEarly:         pd.TooEarly,
 				ProjectedAlreadyProcessed: pd.AlreadyProcessed,
@@ -485,28 +519,29 @@ func buildBuilderDepositsProjectionPageData(ctx context.Context, pageIdx uint64,
 		}
 	}
 
-	// combined pagination: queued request txs first, then the projected onboarding deposits
-	totalRows := totalTxRows + uint64(len(matched))
+	// The onboarding deposits are classified in ascending deposit-index order (the order the
+	// chain onboards them in) but displayed newest first, like every other deposit list.
+	slices.Reverse(matched)
 
-	deposits := queuedRows
-	if uint64(len(deposits)) < pageSize {
-		matchedOffset := uint64(0)
-		if pageOffset > totalTxRows {
-			matchedOffset = pageOffset - totalTxRows
-		}
-		if matchedOffset > uint64(len(matched)) {
-			matchedOffset = uint64(len(matched))
-		}
+	// The fork onboards the validator-contract deposits before the builder deposit contract
+	// queue is dequeued, so the onboarding group comes first and the queued regular deposits
+	// follow it - mirroring the builder index order both groups end up with.
+	combined := make([]*models.BuilderDepositsPageDataDeposit, 0, len(matched)+len(queuedRows))
+	combined = append(combined, matched...)
+	combined = append(combined, queuedRows...)
 
-		matchedEnd := matchedOffset + pageSize - uint64(len(deposits))
-		if matchedEnd > uint64(len(matched)) {
-			matchedEnd = uint64(len(matched))
-		}
+	totalRows := uint64(len(combined))
 
-		deposits = append(deposits, matched[matchedOffset:matchedEnd]...)
+	pageOffset := (pageIdx - 1) * pageSize
+	pageEnd := pageOffset + pageSize
+	if pageOffset > totalRows {
+		pageOffset = totalRows
+	}
+	if pageEnd > totalRows {
+		pageEnd = totalRows
 	}
 
-	pageData.Deposits = deposits
+	pageData.Deposits = combined[pageOffset:pageEnd]
 	pageData.DepositCount = uint64(len(pageData.Deposits))
 
 	if pageData.DepositCount > 0 {

--- a/handlers/builders.go
+++ b/handlers/builders.go
@@ -118,9 +118,14 @@ func buildBuildersPageData(ctx context.Context, pageNumber uint64, pageSize uint
 
 	chainState := services.GlobalBeaconService.GetChainState()
 
+	pageOffset := uint64(0)
+	if pageNumber > 1 {
+		pageOffset = (pageNumber - 1) * pageSize
+	}
+
 	builderFilter := dbtypes.BuilderFilter{
 		Limit:  pageSize,
-		Offset: (pageNumber - 1) * pageSize,
+		Offset: pageOffset,
 	}
 
 	filterArgs := url.Values{}
@@ -275,7 +280,9 @@ func buildBuildersPageData(ctx context.Context, pageNumber uint64, pageSize uint
 		pageData.Builders = append(pageData.Builders, builderData)
 	}
 	pageData.BuilderCount = builderSetLen
-	pageData.FirstBuilder = pageNumber * pageSize
+	// the label describes the rows actually fetched, so it follows the query offset rather
+	// than the (possibly clamped) page number
+	pageData.FirstBuilder = pageOffset
 	pageData.LastBuilder = pageData.FirstBuilder + uint64(len(pageData.Builders))
 
 	ensAddrs := make([][]byte, 0, len(pageData.Builders))

--- a/handlers/deposit_identity.go
+++ b/handlers/deposit_identity.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"strings"
+
+	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+
+	"github.com/ethpandaops/dora/services"
+)
+
+// depositPubkeyOwner is the on-chain entity a deposit's public key belongs to. At most one of
+// the two is set; both are nil while the deposit has not been applied to anything yet.
+type depositPubkeyOwner struct {
+	Validator      *v1.Validator
+	ValidatorIndex phase0.ValidatorIndex
+	IsProjected    bool
+
+	Builder      *gloas.Builder
+	BuilderIndex gloas.BuilderIndex
+}
+
+// resolveDepositPubkeyOwner resolves a deposit's public key to the validator - or, failing
+// that, the builder - it belongs to, for rendering the "Validator" column of the deposit pages.
+//
+// A pubkey only counts as a validator when the entry it points at can actually be loaded:
+// GetValidatorIndexByPubkey also resolves validators that are merely projected from the
+// pending deposit queue, and an index whose projection has gone away must not be rendered as
+// a link to a validator page that cannot be opened.
+//
+// Builders share the validator deposit contract's pubkey space - a builder-credential deposit
+// made before the Gloas fork onboards a builder rather than a validator - so a pubkey that is
+// no validator is looked up in the builder registry before giving up.
+func resolveDepositPubkeyOwner(pubkey phase0.BLSPubKey) depositPubkeyOwner {
+	owner := depositPubkeyOwner{}
+
+	if index, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(pubkey); found {
+		if validator := services.GlobalBeaconService.GetValidatorByIndex(index, false); validator != nil {
+			owner.Validator = validator
+			owner.ValidatorIndex = index
+			owner.IsProjected = services.GlobalBeaconService.IsProjectedValidatorIndex(index)
+
+			return owner
+		}
+	}
+
+	if index, found := services.GlobalBeaconService.GetBuilderIndexByPubkey(pubkey); found {
+		if builder := services.GlobalBeaconService.GetBuilderByIndex(index); builder != nil {
+			owner.Builder = builder
+			owner.BuilderIndex = index
+		}
+	}
+
+	return owner
+}
+
+// depositValidatorStatus maps a validator state to the label the deposit pages show, together
+// with whether the row should render the liveness (upcheck) indicator.
+func depositValidatorStatus(validator *v1.Validator) (status string, showUpcheck bool) {
+	switch {
+	case strings.HasPrefix(validator.Status.String(), "pending"):
+		return "Pending", false
+	case validator.Status == v1.ValidatorStateActiveOngoing:
+		return "Active", true
+	case validator.Status == v1.ValidatorStateActiveExiting:
+		return "Exiting", true
+	case validator.Status == v1.ValidatorStateActiveSlashed:
+		return "Slashed", true
+	case validator.Status == v1.ValidatorStateExitedUnslashed:
+		return "Exited", false
+	case validator.Status == v1.ValidatorStateExitedSlashed:
+		return "Slashed", false
+	default:
+		return validator.Status.String(), false
+	}
+}
+
+// depositBuilderStatus maps a builder's state to the label the deposit pages show.
+func depositBuilderStatus(builder *gloas.Builder, currentEpoch phase0.Epoch) string {
+	if builder.WithdrawableEpoch <= currentEpoch {
+		return "Exited"
+	}
+
+	return "Active"
+}

--- a/handlers/deposits.go
+++ b/handlers/deposits.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,8 +15,6 @@ import (
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/templates"
 	"github.com/ethpandaops/dora/types/models"
-	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
-	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 )
@@ -177,60 +174,27 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 				IsBuilder:             isBuilder,
 			}
 
-			validatorIndex, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(depositTx.PublicKey))
-			if !found {
-				depositTxData.ValidatorStatus = "Deposited"
-				depositTxData.ValidatorExists = false
-			} else if uint64(validatorIndex)&services.BuilderIndexFlag != 0 {
-				builderIndex := uint64(validatorIndex) &^ services.BuilderIndexFlag
-				depositTxData.IsBuilder = true
+			owner := resolveDepositPubkeyOwner(phase0.BLSPubKey(depositTx.PublicKey))
+			switch {
+			case owner.Validator != nil:
 				depositTxData.ValidatorExists = true
-				depositTxData.ValidatorIndex = builderIndex
-				depositTxData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIndex))
-
-				builder := services.GlobalBeaconService.GetBuilderByIndex(gloas.BuilderIndex(builderIndex))
-				if builder == nil {
-					depositTxData.ValidatorStatus = "Deposited"
-				} else {
-					currentEpoch := chainState.CurrentEpoch()
-					if builder.WithdrawableEpoch <= currentEpoch {
-						depositTxData.ValidatorStatus = "Exited"
-					} else {
-						depositTxData.ValidatorStatus = "Active"
-					}
-				}
-			} else {
-				depositTxData.ValidatorExists = true
-				depositTxData.ValidatorIndex = uint64(validatorIndex)
-				depositTxData.ProjectedIndex = services.GlobalBeaconService.IsProjectedValidatorIndex(validatorIndex)
+				depositTxData.ValidatorIndex = uint64(owner.ValidatorIndex)
+				depositTxData.ProjectedIndex = owner.IsProjected
 				depositTxData.IsBuilder = false
-				depositTxData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAtTime(uint64(validatorIndex), int64(depositTx.BlockTime))
-
-				validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIndex, false)
-				if validator == nil {
-					depositTxData.ValidatorStatus = "Deposited"
-				} else if strings.HasPrefix(validator.Status.String(), "pending") {
-					depositTxData.ValidatorStatus = "Pending"
-				} else if validator.Status == v1.ValidatorStateActiveOngoing {
-					depositTxData.ShowUpcheck = true
-				} else if validator.Status == v1.ValidatorStateActiveExiting {
-					depositTxData.ValidatorStatus = "Exiting"
-					depositTxData.ShowUpcheck = true
-				} else if validator.Status == v1.ValidatorStateActiveSlashed {
-					depositTxData.ValidatorStatus = "Slashed"
-					depositTxData.ShowUpcheck = true
-				} else if validator.Status == v1.ValidatorStateExitedUnslashed {
-					depositTxData.ValidatorStatus = "Exited"
-				} else if validator.Status == v1.ValidatorStateExitedSlashed {
-					depositTxData.ValidatorStatus = "Slashed"
-				} else {
-					depositTxData.ValidatorStatus = validator.Status.String()
-				}
+				depositTxData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAtTime(uint64(owner.ValidatorIndex), int64(depositTx.BlockTime))
+				depositTxData.ValidatorStatus, depositTxData.ShowUpcheck = depositValidatorStatus(owner.Validator)
 
 				if depositTxData.ShowUpcheck {
-					depositTxData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+					depositTxData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(owner.Validator.Index, 3))
 					depositTxData.UpcheckMaximum = uint8(3)
 				}
+			case owner.Builder != nil:
+				depositTxData.IsBuilder = true
+				depositTxData.ValidatorExists = true
+				depositTxData.ValidatorIndex = uint64(owner.BuilderIndex)
+				depositTxData.ValidatorStatus = depositBuilderStatus(owner.Builder, chainState.CurrentEpoch())
+			default:
+				depositTxData.ValidatorStatus = "Deposited"
 			}
 
 			pageData.InitiatedDeposits = append(pageData.InitiatedDeposits, depositTxData)
@@ -293,60 +257,27 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 				}
 			}
 
-			validatorIndex, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(deposit.PublicKey()))
-			if !found {
-				depositData.ValidatorStatus = "Deposited"
-			} else if uint64(validatorIndex)&services.BuilderIndexFlag != 0 {
-				builderIndex := uint64(validatorIndex) &^ services.BuilderIndexFlag
-				depositData.IsBuilder = true
+			owner := resolveDepositPubkeyOwner(phase0.BLSPubKey(deposit.PublicKey()))
+			switch {
+			case owner.Validator != nil:
 				depositData.ValidatorExists = true
-				depositData.ValidatorIndex = builderIndex
-				depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIndex))
-
-				builder := services.GlobalBeaconService.GetBuilderByIndex(gloas.BuilderIndex(builderIndex))
-				if builder == nil {
-					depositData.ValidatorStatus = "Deposited"
-				} else {
-					currentEpoch := chainState.CurrentEpoch()
-					if builder.WithdrawableEpoch <= currentEpoch {
-						depositData.ValidatorStatus = "Exited"
-					} else {
-						depositData.ValidatorStatus = "Active"
-					}
-				}
-			} else {
-				depositData.ValidatorExists = true
-				depositData.ValidatorIndex = uint64(validatorIndex)
-				depositData.ProjectedIndex = services.GlobalBeaconService.IsProjectedValidatorIndex(validatorIndex)
+				depositData.ValidatorIndex = uint64(owner.ValidatorIndex)
+				depositData.ProjectedIndex = owner.IsProjected
 				depositData.IsBuilder = false
-				depositData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAt(uint64(validatorIndex), phase0.Slot(deposit.Request.SlotNumber))
-
-				validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIndex, false)
-				if validator == nil {
-					depositData.ValidatorStatus = "Deposited"
-				} else if strings.HasPrefix(validator.Status.String(), "pending") {
-					depositData.ValidatorStatus = "Pending"
-				} else if validator.Status == v1.ValidatorStateActiveOngoing {
-					depositData.ValidatorStatus = "Active"
-					depositData.ShowUpcheck = true
-				} else if validator.Status == v1.ValidatorStateActiveExiting {
-					depositData.ValidatorStatus = "Exiting"
-					depositData.ShowUpcheck = true
-				} else if validator.Status == v1.ValidatorStateActiveSlashed {
-					depositData.ValidatorStatus = "Slashed"
-					depositData.ShowUpcheck = true
-				} else if validator.Status == v1.ValidatorStateExitedUnslashed {
-					depositData.ValidatorStatus = "Exited"
-				} else if validator.Status == v1.ValidatorStateExitedSlashed {
-					depositData.ValidatorStatus = "Slashed"
-				} else {
-					depositData.ValidatorStatus = validator.Status.String()
-				}
+				depositData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAt(uint64(owner.ValidatorIndex), phase0.Slot(deposit.Request.SlotNumber))
+				depositData.ValidatorStatus, depositData.ShowUpcheck = depositValidatorStatus(owner.Validator)
 
 				if depositData.ShowUpcheck {
-					depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+					depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(owner.Validator.Index, 3))
 					depositData.UpcheckMaximum = uint8(3)
 				}
+			case owner.Builder != nil:
+				depositData.IsBuilder = true
+				depositData.ValidatorExists = true
+				depositData.ValidatorIndex = uint64(owner.BuilderIndex)
+				depositData.ValidatorStatus = depositBuilderStatus(owner.Builder, chainState.CurrentEpoch())
+			default:
+				depositData.ValidatorStatus = "Deposited"
 			}
 
 			pageData.IncludedDeposits = append(pageData.IncludedDeposits, depositData)
@@ -397,59 +328,27 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 					Postponed:             queueEntry.Postponed,
 				}
 
-				if validatorIdx, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(depositData.PublicKey)); !found {
-					depositData.ValidatorStatus = "Deposited"
-				} else if uint64(validatorIdx)&services.BuilderIndexFlag != 0 {
-					builderIndex := uint64(validatorIdx) &^ services.BuilderIndexFlag
-					depositData.IsBuilder = true
+				owner := resolveDepositPubkeyOwner(phase0.BLSPubKey(depositData.PublicKey))
+				switch {
+				case owner.Validator != nil:
 					depositData.ValidatorExists = true
-					depositData.ValidatorIndex = builderIndex
-					depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
-
-					builder := services.GlobalBeaconService.GetBuilderByIndex(gloas.BuilderIndex(builderIndex))
-					if builder == nil {
-						depositData.ValidatorStatus = "Deposited"
-					} else {
-						currentEpoch := chainState.CurrentEpoch()
-						if builder.WithdrawableEpoch <= currentEpoch {
-							depositData.ValidatorStatus = "Exited"
-						} else {
-							depositData.ValidatorStatus = "Active"
-						}
-					}
-				} else {
-					depositData.ValidatorExists = true
-					depositData.ValidatorIndex = uint64(validatorIdx)
-					depositData.ProjectedIndex = services.GlobalBeaconService.IsProjectedValidatorIndex(validatorIdx)
+					depositData.ValidatorIndex = uint64(owner.ValidatorIndex)
+					depositData.ProjectedIndex = owner.IsProjected
 					depositData.IsBuilder = false
-					depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
-
-					validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-					if validator == nil {
-						depositData.ValidatorStatus = "Deposited"
-					} else if strings.HasPrefix(validator.Status.String(), "pending") {
-						depositData.ValidatorStatus = "Pending"
-					} else if validator.Status == v1.ValidatorStateActiveOngoing {
-						depositData.ValidatorStatus = "Active"
-						depositData.ShowUpcheck = true
-					} else if validator.Status == v1.ValidatorStateActiveExiting {
-						depositData.ValidatorStatus = "Exiting"
-						depositData.ShowUpcheck = true
-					} else if validator.Status == v1.ValidatorStateActiveSlashed {
-						depositData.ValidatorStatus = "Slashed"
-						depositData.ShowUpcheck = true
-					} else if validator.Status == v1.ValidatorStateExitedUnslashed {
-						depositData.ValidatorStatus = "Exited"
-					} else if validator.Status == v1.ValidatorStateExitedSlashed {
-						depositData.ValidatorStatus = "Slashed"
-					} else {
-						depositData.ValidatorStatus = validator.Status.String()
-					}
+					depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(owner.ValidatorIndex))
+					depositData.ValidatorStatus, depositData.ShowUpcheck = depositValidatorStatus(owner.Validator)
 
 					if depositData.ShowUpcheck {
-						depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+						depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(owner.Validator.Index, 3))
 						depositData.UpcheckMaximum = uint8(3)
 					}
+				case owner.Builder != nil:
+					depositData.IsBuilder = true
+					depositData.ValidatorExists = true
+					depositData.ValidatorIndex = uint64(owner.BuilderIndex)
+					depositData.ValidatorStatus = depositBuilderStatus(owner.Builder, chainState.CurrentEpoch())
+				default:
+					depositData.ValidatorStatus = "Deposited"
 				}
 
 				if queueEntry.DepositIndex != nil {

--- a/handlers/included_deposits.go
+++ b/handlers/included_deposits.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -15,8 +14,6 @@ import (
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/templates"
 	"github.com/ethpandaops/dora/types/models"
-	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
-	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 )
@@ -253,57 +250,27 @@ func buildFilteredIncludedDepositsPageData(ctx context.Context, pageIdx uint64, 
 		}
 
 		// Add validator status
-		if validatorIdx, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(deposit.PublicKey())); !found {
-			depositData.ValidatorStatus = "Deposited"
-			depositData.ValidatorExists = false
-		} else if uint64(validatorIdx)&services.BuilderIndexFlag != 0 {
-			builderIndex := uint64(validatorIdx) &^ services.BuilderIndexFlag
-			depositData.IsBuilder = true
+		owner := resolveDepositPubkeyOwner(phase0.BLSPubKey(deposit.PublicKey()))
+		switch {
+		case owner.Validator != nil:
 			depositData.ValidatorExists = true
-			depositData.ValidatorIndex = builderIndex
-			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
-
-			builder := services.GlobalBeaconService.GetBuilderByIndex(gloas.BuilderIndex(builderIndex))
-			if builder == nil {
-				depositData.ValidatorStatus = "Deposited"
-			} else if builder.WithdrawableEpoch <= chainState.CurrentEpoch() {
-				depositData.ValidatorStatus = "Exited"
-			} else {
-				depositData.ValidatorStatus = "Active"
-			}
-		} else {
-			depositData.ValidatorExists = true
-			depositData.ValidatorIndex = uint64(validatorIdx)
-			depositData.ProjectedIndex = services.GlobalBeaconService.IsProjectedValidatorIndex(validatorIdx)
+			depositData.ValidatorIndex = uint64(owner.ValidatorIndex)
+			depositData.ProjectedIndex = owner.IsProjected
 			depositData.IsBuilder = false
-			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAt(uint64(validatorIdx), phase0.Slot(deposit.Request.SlotNumber))
-
-			validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-			if validator == nil {
-				depositData.ValidatorStatus = "Deposited"
-			} else if strings.HasPrefix(validator.Status.String(), "pending") {
-				depositData.ValidatorStatus = "Pending"
-			} else if validator.Status == v1.ValidatorStateActiveOngoing {
-				depositData.ValidatorStatus = "Active"
-				depositData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateActiveExiting {
-				depositData.ValidatorStatus = "Exiting"
-				depositData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateActiveSlashed {
-				depositData.ValidatorStatus = "Slashed"
-				depositData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateExitedUnslashed {
-				depositData.ValidatorStatus = "Exited"
-			} else if validator.Status == v1.ValidatorStateExitedSlashed {
-				depositData.ValidatorStatus = "Slashed"
-			} else {
-				depositData.ValidatorStatus = validator.Status.String()
-			}
+			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAt(uint64(owner.ValidatorIndex), phase0.Slot(deposit.Request.SlotNumber))
+			depositData.ValidatorStatus, depositData.ShowUpcheck = depositValidatorStatus(owner.Validator)
 
 			if depositData.ShowUpcheck {
-				depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+				depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(owner.Validator.Index, 3))
 				depositData.UpcheckMaximum = uint8(3)
 			}
+		case owner.Builder != nil:
+			depositData.IsBuilder = true
+			depositData.ValidatorExists = true
+			depositData.ValidatorIndex = uint64(owner.BuilderIndex)
+			depositData.ValidatorStatus = depositBuilderStatus(owner.Builder, chainState.CurrentEpoch())
+		default:
+			depositData.ValidatorStatus = "Deposited"
 		}
 
 		// Add transaction details if available

--- a/handlers/initiated_deposits.go
+++ b/handlers/initiated_deposits.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -15,8 +14,6 @@ import (
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/templates"
 	"github.com/ethpandaops/dora/types/models"
-	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
-	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 )
@@ -199,57 +196,27 @@ func buildFilteredInitiatedDepositsPageData(ctx context.Context, pageIdx uint64,
 			IsBuilder:             isBuilder,
 		}
 
-		if validatorIdx, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(depositTx.PublicKey)); !found {
-			depositTxData.ValidatorStatus = "Deposited"
-			depositTxData.ValidatorExists = false
-		} else if uint64(validatorIdx)&services.BuilderIndexFlag != 0 {
-			builderIndex := uint64(validatorIdx) &^ services.BuilderIndexFlag
-			depositTxData.IsBuilder = true
+		owner := resolveDepositPubkeyOwner(phase0.BLSPubKey(depositTx.PublicKey))
+		switch {
+		case owner.Validator != nil:
 			depositTxData.ValidatorExists = true
-			depositTxData.ValidatorIndex = builderIndex
-			depositTxData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
-
-			builder := services.GlobalBeaconService.GetBuilderByIndex(gloas.BuilderIndex(builderIndex))
-			if builder == nil {
-				depositTxData.ValidatorStatus = "Deposited"
-			} else if builder.WithdrawableEpoch <= services.GlobalBeaconService.GetChainState().CurrentEpoch() {
-				depositTxData.ValidatorStatus = "Exited"
-			} else {
-				depositTxData.ValidatorStatus = "Active"
-			}
-		} else {
-			depositTxData.ValidatorExists = true
-			depositTxData.ValidatorIndex = uint64(validatorIdx)
-			depositTxData.ProjectedIndex = services.GlobalBeaconService.IsProjectedValidatorIndex(validatorIdx)
+			depositTxData.ValidatorIndex = uint64(owner.ValidatorIndex)
+			depositTxData.ProjectedIndex = owner.IsProjected
 			depositTxData.IsBuilder = false
-			depositTxData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAtTime(uint64(validatorIdx), int64(depositTx.BlockTime))
-
-			validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-			if validator == nil {
-				depositTxData.ValidatorStatus = "Deposited"
-			} else if strings.HasPrefix(validator.Status.String(), "pending") {
-				depositTxData.ValidatorStatus = "Pending"
-			} else if validator.Status == v1.ValidatorStateActiveOngoing {
-				depositTxData.ValidatorStatus = "Active"
-				depositTxData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateActiveExiting {
-				depositTxData.ValidatorStatus = "Exiting"
-				depositTxData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateActiveSlashed {
-				depositTxData.ValidatorStatus = "Slashed"
-				depositTxData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateExitedUnslashed {
-				depositTxData.ValidatorStatus = "Exited"
-			} else if validator.Status == v1.ValidatorStateExitedSlashed {
-				depositTxData.ValidatorStatus = "Slashed"
-			} else {
-				depositTxData.ValidatorStatus = validator.Status.String()
-			}
+			depositTxData.ValidatorName = services.GlobalBeaconService.GetValidatorNameAtTime(uint64(owner.ValidatorIndex), int64(depositTx.BlockTime))
+			depositTxData.ValidatorStatus, depositTxData.ShowUpcheck = depositValidatorStatus(owner.Validator)
 
 			if depositTxData.ShowUpcheck {
-				depositTxData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+				depositTxData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(owner.Validator.Index, 3))
 				depositTxData.UpcheckMaximum = uint8(3)
 			}
+		case owner.Builder != nil:
+			depositTxData.IsBuilder = true
+			depositTxData.ValidatorExists = true
+			depositTxData.ValidatorIndex = uint64(owner.BuilderIndex)
+			depositTxData.ValidatorStatus = depositBuilderStatus(owner.Builder, services.GlobalBeaconService.GetChainState().CurrentEpoch())
+		default:
+			depositTxData.ValidatorStatus = "Deposited"
 		}
 
 		pageData.Deposits = append(pageData.Deposits, depositTxData)

--- a/handlers/queued_deposits.go
+++ b/handlers/queued_deposits.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,8 +15,6 @@ import (
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/templates"
 	"github.com/ethpandaops/dora/types/models"
-	v1 "github.com/ethpandaops/go-eth2-client/api/v1"
-	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 )
 
@@ -233,56 +230,27 @@ func buildQueuedDepositsPageData(ctx context.Context, pageIdx uint64, pageSize u
 		}
 
 		// Get validator status if exists
-		if validatorIdx, found := services.GlobalBeaconService.GetValidatorIndexByPubkey(phase0.BLSPubKey(depositData.PublicKey)); !found {
-			depositData.ValidatorStatus = "Deposited"
-		} else if uint64(validatorIdx)&services.BuilderIndexFlag != 0 {
-			builderIndex := uint64(validatorIdx) &^ services.BuilderIndexFlag
-			depositData.IsBuilder = true
+		owner := resolveDepositPubkeyOwner(phase0.BLSPubKey(depositData.PublicKey))
+		switch {
+		case owner.Validator != nil:
 			depositData.ValidatorExists = true
-			depositData.ValidatorIndex = builderIndex
-			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
-
-			builder := services.GlobalBeaconService.GetBuilderByIndex(gloas.BuilderIndex(builderIndex))
-			if builder == nil {
-				depositData.ValidatorStatus = "Deposited"
-			} else if builder.WithdrawableEpoch <= chainState.CurrentEpoch() {
-				depositData.ValidatorStatus = "Exited"
-			} else {
-				depositData.ValidatorStatus = "Active"
-			}
-		} else {
-			depositData.ValidatorExists = true
-			depositData.ValidatorIndex = uint64(validatorIdx)
-			depositData.ProjectedIndex = services.GlobalBeaconService.IsProjectedValidatorIndex(validatorIdx)
+			depositData.ValidatorIndex = uint64(owner.ValidatorIndex)
+			depositData.ProjectedIndex = owner.IsProjected
 			depositData.IsBuilder = false
-			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(validatorIdx))
-
-			validator := services.GlobalBeaconService.GetValidatorByIndex(validatorIdx, false)
-			if validator == nil {
-				depositData.ValidatorStatus = "Deposited"
-			} else if strings.HasPrefix(validator.Status.String(), "pending") {
-				depositData.ValidatorStatus = "Pending"
-			} else if validator.Status == v1.ValidatorStateActiveOngoing {
-				depositData.ValidatorStatus = "Active"
-				depositData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateActiveExiting {
-				depositData.ValidatorStatus = "Exiting"
-				depositData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateActiveSlashed {
-				depositData.ValidatorStatus = "Slashed"
-				depositData.ShowUpcheck = true
-			} else if validator.Status == v1.ValidatorStateExitedUnslashed {
-				depositData.ValidatorStatus = "Exited"
-			} else if validator.Status == v1.ValidatorStateExitedSlashed {
-				depositData.ValidatorStatus = "Slashed"
-			} else {
-				depositData.ValidatorStatus = validator.Status.String()
-			}
+			depositData.ValidatorName = services.GlobalBeaconService.GetValidatorName(uint64(owner.ValidatorIndex))
+			depositData.ValidatorStatus, depositData.ShowUpcheck = depositValidatorStatus(owner.Validator)
 
 			if depositData.ShowUpcheck {
-				depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(validator.Index, 3))
+				depositData.UpcheckActivity = uint8(services.GlobalBeaconService.GetValidatorLiveness(owner.Validator.Index, 3))
 				depositData.UpcheckMaximum = uint8(3)
 			}
+		case owner.Builder != nil:
+			depositData.IsBuilder = true
+			depositData.ValidatorExists = true
+			depositData.ValidatorIndex = uint64(owner.BuilderIndex)
+			depositData.ValidatorStatus = depositBuilderStatus(owner.Builder, chainState.CurrentEpoch())
+		default:
+			depositData.ValidatorStatus = "Deposited"
 		}
 
 		if queueEntry.DepositIndex != nil {

--- a/indexer/beacon/block.go
+++ b/indexer/beacon/block.go
@@ -775,7 +775,7 @@ func (block *Block) GetDbBuilderDeposits(indexer *Indexer, isCanonical bool) []*
 		return nil
 	}
 
-	return indexer.dbWriter.buildDbBuilderDeposits(block, !isCanonical, nil)
+	return indexer.dbWriter.buildDbBuilderDeposits(block, !isCanonical, nil, nil)
 }
 
 // GetDbBuilderExits returns the database representation of the builder exit requests in this block.

--- a/indexer/beacon/depositsig/depositsig.go
+++ b/indexer/beacon/depositsig/depositsig.go
@@ -91,12 +91,11 @@ type Input struct {
 // validity in input order.
 //
 // It uses random-coefficient batch verification
-// (https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407): in the
-// common case where every signature is valid, the whole batch is confirmed with a
-// single aggregate check regardless of size. Because that check is all-or-nothing,
-// a failing batch is bisected to isolate the invalid inputs (O(log n) extra checks
-// per invalid signature). Inputs with a malformed pubkey or signature are rejected
-// up front without entering the batch.
+// (https://ethresear.ch/t/fast-verification-of-multiple-bls-signatures/5407): an
+// aggregate check confirms a whole group at roughly half the cost of verifying its
+// signatures one by one. The check is all-or-nothing, so a group that fails is
+// re-verified individually. Inputs with a malformed pubkey or signature are
+// rejected up front without entering a group.
 func VerifyBatch(inputs []Input, domain zrnt_common.BLSDomain) []bool {
 	results := make([]bool, len(inputs))
 
@@ -131,37 +130,76 @@ type batchItem struct {
 	signature *blsu.Signature
 }
 
-// verifyBatchItems aggregate-verifies items, marking results[idx]=true for each
-// valid one. On batch failure it bisects until single items remain, which are then
-// verified individually.
+// batchGroupSize bounds how many signatures share one aggregate check. The group is
+// the unit of wasted work when a check fails, so it trades the best case (fewer, larger
+// aggregate checks) against the cost of an invalid signature (re-verifying its group).
+const batchGroupSize = 128
+
+// maxAggregateFailures is how many groups may fail before aggregate checking is given
+// up for the rest of the batch. Invalid deposit signatures arrive in runs — a spammer
+// repeating the same bad proof-of-possession — and once they are this dense the
+// aggregate check is pure overhead on top of verifying individually.
+const maxAggregateFailures = 3
+
+// verifyBatchItems verifies items in groups, marking results[idx]=true for each valid
+// one.
+//
+// A failing group is verified item by item rather than bisected. Bisecting sounds
+// cheaper — O(log n) checks to isolate one bad signature — but every level re-runs an
+// aggregate check over half the remaining items, so the constant is large: measured
+// against verifying one by one, bisection is ~2.6x slower at 1% invalid and ~7x slower
+// when most signatures are bad. Verifying a failed group directly bounds the worst case
+// at roughly 1.5x the one-by-one cost while keeping the ~0.5x best case.
 func verifyBatchItems(items []batchItem, results []bool) {
-	if len(items) == 0 {
-		return
+	useAggregate := true
+	failures := 0
+
+	for start := 0; start < len(items); start += batchGroupSize {
+		end := start + batchGroupSize
+		if end > len(items) {
+			end = len(items)
+		}
+
+		group := items[start:end]
+
+		if useAggregate && aggregateVerify(group) {
+			for _, it := range group {
+				results[it.idx] = true
+			}
+
+			continue
+		}
+
+		if useAggregate {
+			failures++
+			if failures >= maxAggregateFailures {
+				useAggregate = false
+			}
+		}
+
+		for _, it := range group {
+			results[it.idx] = blsu.Verify(it.pubkey, it.message, it.signature)
+		}
+	}
+}
+
+// aggregateVerify reports whether every signature in the group is valid.
+func aggregateVerify(group []batchItem) bool {
+	if len(group) == 0 {
+		return true
 	}
 
-	pubkeys := make([]*blsu.Pubkey, len(items))
-	messages := make([][]byte, len(items))
-	signatures := make([]*blsu.Signature, len(items))
-	for i, it := range items {
+	pubkeys := make([]*blsu.Pubkey, len(group))
+	messages := make([][]byte, len(group))
+	signatures := make([]*blsu.Signature, len(group))
+
+	for i, it := range group {
 		pubkeys[i] = it.pubkey
 		messages[i] = it.message
 		signatures[i] = it.signature
 	}
 
-	if ok, err := blsu.SignatureSetVerify(pubkeys, messages, signatures); err == nil && ok {
-		for _, it := range items {
-			results[it.idx] = true
-		}
-		return
-	}
+	ok, err := blsu.SignatureSetVerify(pubkeys, messages, signatures)
 
-	if len(items) == 1 {
-		it := items[0]
-		results[it.idx] = blsu.Verify(it.pubkey, it.message, it.signature)
-		return
-	}
-
-	mid := len(items) / 2
-	verifyBatchItems(items[:mid], results)
-	verifyBatchItems(items[mid:], results)
+	return err == nil && ok
 }

--- a/indexer/beacon/depositsig/depositsig_test.go
+++ b/indexer/beacon/depositsig/depositsig_test.go
@@ -136,3 +136,93 @@ func TestVerifyBatch(t *testing.T) {
 		t.Errorf("VerifyBatch(nil) = %v, want empty", got)
 	}
 }
+
+// TestVerifyBatchSpansGroups covers the paths that only appear beyond a single group:
+// results must stay correct across group boundaries, and once enough groups fail the
+// verifier gives up on aggregate checking for the rest of the batch and must still
+// return the same verdicts.
+func TestVerifyBatchSpansGroups(t *testing.T) {
+	domain := Domain(phase0.Version{})
+	wc := make([]byte, 32)
+	wc[0] = 0x01
+
+	// enough items that more than maxAggregateFailures groups contain an invalid
+	// signature, so the give-up path is exercised
+	n := batchGroupSize * (maxAggregateFailures + 2)
+
+	skWrong, _ := keyPair(t, 0xfe)
+
+	inputs := make([]Input, 0, n)
+	want := make([]bool, 0, n)
+
+	for i := range n {
+		sk, pubkey := keyPair(t, byte(i%251)+1)
+		amount := phase0.Gwei(32_000_000_000 + uint64(i))
+
+		// one bad signature in every group, plus a run of them at the end
+		bad := i%batchGroupSize == 7 || i >= n-batchGroupSize
+
+		signer := sk
+		if bad {
+			signer = skWrong
+		}
+
+		inputs = append(inputs, Input{
+			Pubkey:                pubkey,
+			WithdrawalCredentials: wc,
+			Amount:                amount,
+			Signature:             signDeposit(signer, pubkey, wc, amount, domain),
+		})
+		want = append(want, !bad)
+	}
+
+	got := VerifyBatch(inputs, domain)
+	if len(got) != len(want) {
+		t.Fatalf("VerifyBatch returned %d results, want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("result[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestVerifyBatchIsolatesASingleFailure guards the case a batch verifier is easiest to
+// get wrong: one bad signature must not condemn the rest of its group.
+func TestVerifyBatchIsolatesASingleFailure(t *testing.T) {
+	domain := Domain(phase0.Version{})
+	wc := make([]byte, 32)
+	wc[0] = 0x01
+	amount := phase0.Gwei(32_000_000_000)
+
+	n := batchGroupSize + 10
+	badIndex := batchGroupSize / 2
+
+	skWrong, _ := keyPair(t, 0xfd)
+
+	inputs := make([]Input, 0, n)
+	for i := range n {
+		sk, pubkey := keyPair(t, byte(i%251)+1)
+
+		signer := sk
+		if i == badIndex {
+			signer = skWrong
+		}
+
+		inputs = append(inputs, Input{
+			Pubkey:                pubkey,
+			WithdrawalCredentials: wc,
+			Amount:                amount,
+			Signature:             signDeposit(signer, pubkey, wc, amount, domain),
+		})
+	}
+
+	got := VerifyBatch(inputs, domain)
+	for i := range inputs {
+		want := i != badIndex
+		if got[i] != want {
+			t.Fatalf("result[%d] = %v, want %v", i, got[i], want)
+		}
+	}
+}

--- a/indexer/beacon/epochstate.go
+++ b/indexer/beacon/epochstate.go
@@ -248,13 +248,17 @@ func (s *epochState) processState(state *all.BeaconState, cache *epochCache) err
 				e := phase0.Epoch(*specs.GloasForkEpoch)
 				gloasForkEpoch = &e
 			}
+			stateEpoch := chainState.EpochOfSlot(state.Slot)
 			projectedValidators, projectedBalances := cache.indexer.pendingValidators.project(state.Validators, state.PendingDeposits, pendingProjectionInput{
 				genesisForkVersion:         specs.GenesisForkVersion,
-				currentEpoch:               chainState.EpochOfSlot(state.Slot),
+				currentEpoch:               stateEpoch,
 				depositBalanceToConsume:    state.DepositBalanceToConsume,
 				maxPendingDepositsPerEpoch: specs.MaxPendingDepositsPerEpoch,
 				gloasForkEpoch:             gloasForkEpoch,
-				churnLimit:                 chainState.GetActivationExitChurnLimit,
+				churnLimit: func(totalActiveBalance uint64) uint64 {
+					// Deposits consume the activation-only churn budget from Gloas on (EIP-8061).
+					return chainState.GetActivationChurnLimit(stateEpoch, totalActiveBalance)
+				},
 			})
 			if len(projectedValidators) > 0 {
 				validators = make([]*phase0.Validator, 0, realValidatorCount+len(projectedValidators))
@@ -269,7 +273,7 @@ func (s *epochState) processState(state *all.BeaconState, cache *epochCache) err
 	}
 
 	if cache != nil {
-		cache.indexer.validatorCache.updateValidatorSet(state.Slot, dependentRoot, validators)
+		cache.indexer.validatorCache.updateValidatorSet(state.Slot, dependentRoot, validators, realValidatorCount)
 	}
 
 	// Process builder set for Gloas+

--- a/indexer/beacon/epochstats.go
+++ b/indexer/beacon/epochstats.go
@@ -30,12 +30,17 @@ type EpochStats struct {
 
 	requestedMutex  sync.Mutex
 	requestedBy     []*Client
-	ready           bool
 	readyChanMutex  sync.Mutex
 	readyChan       chan bool
 	processingMutex sync.Mutex
+	ready           bool
 	processing      bool
 	isInDb          bool
+
+	// gloasOnboardingStored records that the builder deposits onboarded by the
+	// upgrade_to_gloas fork transition have been copied into the builder deposit tables for
+	// this dependent root, so repeated processState runs don't rewrite thousands of rows.
+	gloasOnboardingStored bool
 
 	precalcBaseRoot phase0.Root
 	precalcValues   *EpochStatsValues
@@ -584,19 +589,31 @@ func (es *EpochStats) processState(indexer *Indexer, validatorSet []*phase0.Vali
 	}
 
 	err = db.RunDBTransaction(func(tx *sqlx.Tx) error {
-		if err := db.InsertUnfinalizedDuty(indexer.ctx, tx, dbDuty); err != nil {
-			return err
-		}
-		if len(onboardedDeposits) > 0 {
-			return indexer.dbWriter.persistGloasOnboardedBuilderDeposits(tx, es.epoch, es.dependentRoot, onboardedForkId, onboardedDeposits)
-		}
-		return nil
+		return db.InsertUnfinalizedDuty(indexer.ctx, tx, dbDuty)
 	})
 	if err != nil {
 		indexer.logger.WithError(err).Errorf("failed storing epoch %v stats (%v / %v) to unfinalized duties", es.epoch, es.dependentRoot.String(), dependentState.stateRoot.String())
+	} else {
+		// Only mark the stats as readable from the db once the row is actually there;
+		// otherwise loadValuesFromDb would keep looking for a row that was never written.
+		es.isInDb = true
 	}
 
-	es.isInDb = true
+	// The onboarding copy is written in its own transaction: it is an order of magnitude
+	// larger than the duty row (one row per queued builder deposit) and a failure there must
+	// not take the epoch stats down with it. The write is an upsert, so a retry on a later
+	// processState run repairs a previous failure.
+	if len(onboardedDeposits) > 0 && !es.gloasOnboardingStored {
+		err = db.RunDBTransaction(func(tx *sqlx.Tx) error {
+			return indexer.dbWriter.persistGloasOnboardedBuilderDeposits(tx, es.epoch, es.dependentRoot, onboardedForkId, onboardedDeposits)
+		})
+		if err != nil {
+			indexer.logger.WithError(err).Errorf("failed storing %v onboarded builder deposits for epoch %v (%v)", len(onboardedDeposits), es.epoch, es.dependentRoot.String())
+		} else {
+			es.gloasOnboardingStored = true
+			indexer.logger.Infof("stored %v builder deposits onboarded at the gloas fork (epoch %v, root %v)", len(onboardedDeposits), es.epoch, es.dependentRoot.String())
+		}
+	}
 
 	indexer.logger.Infof(
 		"processed epoch %v stats (root: %v / state: %v, validators: %v/%v, load: %v ms, process: %v ms), %v bytes",

--- a/indexer/beacon/forkdetection.go
+++ b/indexer/beacon/forkdetection.go
@@ -280,6 +280,34 @@ func (cache *forkCache) processBlock(block *Block) error {
 				return nil
 			}
 
+			// helper function to move the execution layer request txs of the same blocks onto the
+			// fork as well. Those rows are keyed by execution block hash, so the consensus roots
+			// are resolved through the block index; a block whose payload is not known yet
+			// (Gloas reveals it a slot later) is skipped and re-tagged when it is.
+			updateExecutionRequestForkIds := func(updateRoots [][]byte, forkId ForkKey) error {
+				blockHashes := make([][]byte, 0, len(updateRoots))
+
+				for _, root := range updateRoots {
+					if len(root) != len(phase0.Root{}) {
+						continue
+					}
+
+					block := cache.indexer.GetBlockByRoot(phase0.Root(root))
+					if block == nil {
+						continue
+					}
+
+					blockIndex := block.GetBlockIndex(cache.indexer.ctx)
+					if blockIndex == nil || blockIndex.ExecutionHash == (phase0.Hash32{}) {
+						continue
+					}
+
+					blockHashes = append(blockHashes, blockIndex.ExecutionHash[:])
+				}
+
+				return db.UpdateExecutionRequestTxsForkId(cache.indexer.ctx, tx, blockHashes, uint64(forkId))
+			}
+
 			// add new forks
 			for _, newFork := range newForks {
 				err := db.InsertFork(cache.indexer.ctx, tx, newFork.fork.toDbFork())
@@ -292,12 +320,22 @@ func (cache *forkCache) processBlock(block *Block) error {
 					if err != nil {
 						return err
 					}
+
+					err = updateExecutionRequestForkIds(newFork.updateRoots, newFork.fork.forkId)
+					if err != nil {
+						return err
+					}
 				}
 			}
 
 			// update blocks building on top of current block
 			if len(updatedBlocks) > 0 {
 				err := updateUnfinalizedBlockForkIds(updatedBlocks, currentForkId)
+				if err != nil {
+					return err
+				}
+
+				err = updateExecutionRequestForkIds(updatedBlocks, currentForkId)
 				if err != nil {
 					return err
 				}

--- a/indexer/beacon/indexer_getter.go
+++ b/indexer/beacon/indexer_getter.go
@@ -385,8 +385,16 @@ func (indexer *Indexer) GetActivationExitQueueLengths(epoch phase0.Epoch, overri
 // GetValidatorIndexByPubkey returns the validator index for a given pubkey.
 // Builders live in a separate index space (see GetBuilderIndexByPubkey) and are
 // never returned here, even if they share a pubkey with a validator.
+//
+// Validators projected from the pending_deposits queue resolve too, from a separate
+// in-memory map: their index is an estimate that changes as the queue drains, so it must
+// never be written to the persistent pubkey cache.
 func (indexer *Indexer) GetValidatorIndexByPubkey(pubkey phase0.BLSPubKey) (phase0.ValidatorIndex, bool) {
-	return indexer.pubkeyCache.Get(pubkey)
+	if index, found := indexer.pubkeyCache.Get(pubkey); found {
+		return index, true
+	}
+
+	return indexer.validatorCache.getProjectedIndexByPubkey(pubkey)
 }
 
 // GetBuilderIndexByPubkey returns the builder index for a given pubkey (EIP-8282).

--- a/indexer/beacon/pendingvalidators.go
+++ b/indexer/beacon/pendingvalidators.go
@@ -113,7 +113,7 @@ type pendingProjectionInput struct {
 	depositBalanceToConsume    phase0.Gwei
 	maxPendingDepositsPerEpoch uint64
 	gloasForkEpoch             *phase0.Epoch                          // nil if no Gloas fork is scheduled
-	churnLimit                 func(totalActiveBalance uint64) uint64 // activation/exit churn limit for a given active balance
+	churnLimit                 func(totalActiveBalance uint64) uint64 // per-epoch churn budget deposits consume at currentEpoch
 }
 
 // isActiveAtEpoch reports whether a validator is active at the given epoch.
@@ -148,6 +148,11 @@ type depositProcessingEstimator struct {
 	maxPendingDepositsPerEpoch uint64
 	countInEpoch               uint64
 	gloasForkEpoch             *phase0.Epoch
+
+	// gloasActive records that the one-time onboarding already happened, so no queue entry can
+	// still be removed by it: a builder-credential deposit that is in the queue after the fork
+	// was kept by onboarding and is applied as a normal validator deposit.
+	gloasActive bool
 }
 
 func newDepositProcessingEstimator(currentEpoch phase0.Epoch, depositBalanceToConsume phase0.Gwei, churnLimit phase0.Gwei, maxPendingDepositsPerEpoch uint64, gloasForkEpoch *phase0.Epoch) *depositProcessingEstimator {
@@ -160,6 +165,7 @@ func newDepositProcessingEstimator(currentEpoch phase0.Epoch, depositBalanceToCo
 		churnLimit:                 churnLimit,
 		maxPendingDepositsPerEpoch: maxPendingDepositsPerEpoch,
 		gloasForkEpoch:             gloasForkEpoch,
+		gloasActive:                gloasForkEpoch != nil && currentEpoch >= *gloasForkEpoch,
 	}
 }
 
@@ -184,7 +190,7 @@ func (e *depositProcessingEstimator) next(amount phase0.Gwei, isBuilder bool) (e
 		e.balance += e.churnLimit
 		e.countInEpoch = 0
 	}
-	if isBuilder && e.gloasForkEpoch != nil && e.epoch >= *e.gloasForkEpoch {
+	if isBuilder && e.gloasForkEpoch != nil && !e.gloasActive && e.epoch >= *e.gloasForkEpoch {
 		// onboarded as a builder at the fork; removed from the queue, consumes no churn
 		return e.epoch, true
 	}

--- a/indexer/beacon/pubkeycache.go
+++ b/indexer/beacon/pubkeycache.go
@@ -84,6 +84,22 @@ func (c *pubkeyCache) Add(pubkey phase0.BLSPubKey, index phase0.ValidatorIndex) 
 	return nil
 }
 
+// Remove drops a pubkey mapping. The cache is persistent, so an entry that was written by
+// mistake (e.g. a projected validator restored from a stale db row) survives restarts and
+// keeps resolving to an index that does not exist; Remove is how such an entry is cleaned up.
+func (c *pubkeyCache) Remove(pubkey phase0.BLSPubKey) error {
+	c.pubkeyMutex.Lock()
+	defer c.pubkeyMutex.Unlock()
+
+	if c.pubkeyDb != nil {
+		return c.pubkeyDb.Delete(c.dbKey(pubkey), nil)
+	}
+
+	delete(c.pubkeyMap, pubkey)
+
+	return nil
+}
+
 func (c *pubkeyCache) Get(pubkey phase0.BLSPubKey) (phase0.ValidatorIndex, bool) {
 	if c.pubkeyDb != nil {
 		data, err := c.pubkeyDb.Get(c.dbKey(pubkey), nil)

--- a/indexer/beacon/state_sim.go
+++ b/indexer/beacon/state_sim.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/dora/indexer/beacon/depositsig"
 	"github.com/ethpandaops/dora/utils"
 	"github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/electra"
@@ -54,6 +55,12 @@ type stateSimulatorState struct {
 	pendingConsolidationCount uint64
 	validatorMap              map[phase0.ValidatorIndex]*phase0.Validator
 	blockResults              [][]uint8
+
+	// registeredBuilders holds the pubkeys that builder deposit requests registered during this
+	// replay. The builder set the replay starts from is read from the cache, but builders added
+	// within the replayed epoch only exist here, and they turn every later deposit for the same
+	// pubkey into a top-up.
+	registeredBuilders map[phase0.BLSPubKey]bool
 }
 
 func newStateSimulator(indexer *Indexer, epochStats *EpochStats) *stateSimulator {
@@ -897,18 +904,20 @@ func (sim *stateSimulator) applyBlock(block *Block, applyPayload bool) [][]uint8
 	return results
 }
 
-// applyExecutionRequests simulates the withdrawal and consolidation requests of a block and
-// returns the per-request results ([0] = withdrawal requests, [1] = consolidation requests).
-// When process is false the requests are not applied to the simulated state (their results
-// stay unknown), but the result slices are still sized so callers can index them per request.
+// applyExecutionRequests simulates the execution requests of a block and returns the
+// per-request results ([0] = withdrawal requests, [1] = consolidation requests,
+// [2] = builder deposit requests). When process is false the requests are not applied to the
+// simulated state (their results stay unknown), but the result slices are still sized so
+// callers can index them per request.
 func (sim *stateSimulator) applyExecutionRequests(requests *all.ExecutionRequests, process bool) [][]uint8 {
 	if requests == nil {
 		return nil
 	}
 
-	results := make([][]uint8, 2)
+	results := make([][]uint8, 3)
 	results[0] = make([]uint8, len(requests.Withdrawals))
 	results[1] = make([]uint8, len(requests.Consolidations))
+	results[2] = make([]uint8, len(requests.BuilderDeposits))
 
 	if !process {
 		return results
@@ -922,7 +931,99 @@ func (sim *stateSimulator) applyExecutionRequests(requests *all.ExecutionRequest
 		results[1][i] = sim.applyConsolidation(consolidation)
 	}
 
+	sim.applyBuilderDeposits(requests.BuilderDeposits, results[2])
+
 	return results
+}
+
+// applyBuilderDeposits classifies the builder deposit requests of a block, mirroring
+// process_builder_deposit_request (Gloas/EIP-8282): a deposit for a pubkey that already owns a
+// builder slot tops up its balance, a deposit for a new pubkey registers a builder only if it
+// carries a valid proof-of-possession under DOMAIN_BUILDER_DEPOSIT, and is dropped otherwise.
+//
+// The signatures of the registration candidates are verified as one aggregated batch, which
+// resolves in a single check while they are all valid - a block can carry up to
+// MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD of them.
+func (sim *stateSimulator) applyBuilderDeposits(deposits []*gloas.BuilderDepositRequest, results []uint8) {
+	if len(deposits) == 0 {
+		return
+	}
+
+	if sim.prevState.registeredBuilders == nil {
+		sim.prevState.registeredBuilders = make(map[phase0.BLSPubKey]bool)
+	}
+
+	isTopUp := make([]bool, len(deposits))
+	toVerify := make([]depositsig.Input, 0, len(deposits))
+	toVerifyIdx := make([]int, 0, len(deposits))
+
+	for i, deposit := range deposits {
+		if deposit == nil {
+			continue
+		}
+
+		if sim.prevState.registeredBuilders[deposit.Pubkey] || sim.isRegisteredBuilder(deposit.Pubkey) {
+			isTopUp[i] = true
+			continue
+		}
+
+		toVerify = append(toVerify, depositsig.Input{
+			Pubkey:                deposit.Pubkey,
+			WithdrawalCredentials: deposit.WithdrawalCredentials,
+			Amount:                deposit.Amount,
+			Signature:             deposit.Signature,
+		})
+		toVerifyIdx = append(toVerifyIdx, i)
+	}
+
+	sigValid := make([]bool, len(deposits))
+	if len(toVerify) > 0 {
+		chainSpec := sim.indexer.consensusPool.GetChainState().GetSpecs()
+		domain := depositsig.BuilderDomain(chainSpec.GenesisForkVersion)
+		for j, valid := range depositsig.VerifyBatch(toVerify, domain) {
+			sigValid[toVerifyIdx[j]] = valid
+		}
+	}
+
+	// Sequential pass: a registration mutates the builder set, so a later deposit for the same
+	// pubkey in the same block is a top-up - and a dropped invalid-signature deposit leaves the
+	// pubkey unregistered, so a later one can still register it.
+	for i, deposit := range deposits {
+		if deposit == nil {
+			continue
+		}
+
+		switch {
+		case isTopUp[i] || sim.prevState.registeredBuilders[deposit.Pubkey]:
+			results[i] = dbtypes.BuilderDepositRequestResultTopUp
+		case !sigValid[i]:
+			results[i] = dbtypes.BuilderDepositRequestResultInvalidSignature
+		default:
+			results[i] = dbtypes.BuilderDepositRequestResultNewBuilder
+			sim.prevState.registeredBuilders[deposit.Pubkey] = true
+		}
+	}
+}
+
+// isRegisteredBuilder reports whether the pubkey already owns a builder slot in the builder set
+// the replay starts from.
+//
+// Builders registered within the epoch being replayed are deliberately excluded: the cached set
+// tracks the chain head, so it would already contain a builder that one of the requests in this
+// very replay creates, and that deposit would be misread as a top-up.
+func (sim *stateSimulator) isRegisteredBuilder(pubkey phase0.BLSPubKey) bool {
+	index, found := sim.indexer.builderPubkeyCache.Get(pubkey)
+	if !found {
+		return false
+	}
+
+	builder := sim.indexer.builderCache.getBuilderByIndexAndRoot(gloas.BuilderIndex(index), sim.epochStats.dependentRoot)
+	if builder == nil || builder.PublicKey != pubkey {
+		// no builder at that index on this branch, or the index was reused by another pubkey
+		return false
+	}
+
+	return builder.DepositEpoch < sim.epochStats.epoch
 }
 
 func (sim *stateSimulator) replayBlockResults(block *Block) [][]uint8 {

--- a/indexer/beacon/statetransition/pending.go
+++ b/indexer/beacon/statetransition/pending.go
@@ -9,9 +9,10 @@ import (
 
 // processPendingDeposits implements the Electra+ version of process_pending_deposits.
 // New in Electra: https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_pending_deposits
+// [Modified in Gloas:EIP8061] deposits consume the activation-only churn budget.
 func processPendingDeposits(s *stateAccessor) error {
 	nextEpoch := s.currentEpoch() + 1
-	availableForProcessing := s.DepositBalanceToConsume + s.getActivationExitChurnLimit()
+	availableForProcessing := s.DepositBalanceToConsume + s.getActivationChurnLimit()
 	processedAmount := phase0.Gwei(0)
 	nextDepositIndex := uint64(0)
 	var depositsToPostpone []*electra.PendingDeposit

--- a/indexer/beacon/statetransition/state.go
+++ b/indexer/beacon/statetransition/state.go
@@ -379,3 +379,25 @@ func (s *stateAccessor) getActivationExitChurnLimit() phase0.Gwei {
 	}
 	return churn
 }
+
+// getActivationChurnLimit returns the per-epoch churn budget that deposits consume.
+// New in Gloas (EIP-8061), which gives activations their own quotient and cap so deposits no
+// longer share the budget with exits; before Gloas it is the activation/exit churn limit.
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#new-get_activation_churn_limit
+func (s *stateAccessor) getActivationChurnLimit() phase0.Gwei {
+	if s.Version < spec.DataVersionGloas {
+		return s.getActivationExitChurnLimit()
+	}
+
+	churn := uint64(s.getTotalActiveBalance()) / s.specs.ChurnLimitQuotientGloas
+	if s.specs.MinPerEpochChurnLimitElectra > churn {
+		churn = s.specs.MinPerEpochChurnLimitElectra
+	}
+	churn -= churn % s.specs.EffectiveBalanceIncrement
+
+	if s.specs.MaxPerEpochActivationChurnLimitGloas < churn {
+		return phase0.Gwei(s.specs.MaxPerEpochActivationChurnLimitGloas)
+	}
+
+	return phase0.Gwei(churn)
+}

--- a/indexer/beacon/validatorcache.go
+++ b/indexer/beacon/validatorcache.go
@@ -37,7 +37,22 @@ type validatorCache struct {
 	lastFinalized            phase0.Epoch      // last finalized epoch
 	lastFinalizedActiveCount uint64
 	triggerDbUpdate          chan bool
+
+	// projectedPubkeys maps the pubkeys of the validators projected from the pending_deposits
+	// queue to their estimated index. It is replaced wholesale on every set update, so a
+	// projection that disappears (or moves) can never leave a stale mapping behind — unlike
+	// the persistent pubkeyCache, which projections must never be written to.
+	projectedPubkeys map[phase0.BLSPubKey]phase0.ValidatorIndex
 }
+
+// validatorEntryProjected marks an entry whose finalValidator is a placeholder for a validator
+// the chain has not created yet, derived from the pending_deposits queue. Such entries
+// deliberately carry no diffs, must never be promoted by setFinalizedEpoch and must never reach
+// the validators table: their index is an estimate that shifts as the queue drains.
+//
+// The flag rides in the padding after statusFlags rather than in a second validator pointer -
+// the cache holds one entry per validator, so an extra word costs megabytes on a large chain.
+const validatorEntryProjected uint8 = 1 << 0
 
 // validatorEntry represents a single validator's state in the cache
 type validatorEntry struct {
@@ -46,6 +61,13 @@ type validatorEntry struct {
 	finalValidator *phase0.Validator
 	activeData     *ValidatorData
 	statusFlags    uint16
+	entryFlags     uint8
+}
+
+// isProjected reports whether finalValidator holds a projection rather than a finalized
+// on-chain validator.
+func (e *validatorEntry) isProjected() bool {
+	return e.entryFlags&validatorEntryProjected != 0
 }
 
 // latestPubkey returns the pubkey of the most recently known state for this entry
@@ -100,7 +122,10 @@ func (v *ValidatorData) EffectiveBalance() phase0.Gwei {
 //   - validators: Full validator set for this epoch, optionally extended with
 //     validators projected from the pending_deposits queue (those carry a zero
 //     effective balance and unset activation-eligibility epoch)
-func (cache *validatorCache) updateValidatorSet(slot phase0.Slot, dependentRoot phase0.Root, validators []*phase0.Validator) {
+//   - realCount: number of entries in validators that are actually on chain; everything
+//     from this index on is a projection and is cached separately (never diffed, never
+//     finalized, never persisted, never written to the pubkey cache)
+func (cache *validatorCache) updateValidatorSet(slot phase0.Slot, dependentRoot phase0.Root, validators []*phase0.Validator, realCount int) {
 	chainState := cache.indexer.consensusPool.GetChainState()
 	epoch := chainState.EpochOfSlot(slot)
 	currentEpoch := chainState.CurrentEpoch()
@@ -146,25 +171,45 @@ func (cache *validatorCache) updateValidatorSet(slot phase0.Slot, dependentRoot 
 			cache.valsetCache = cache.valsetCache[:len(validators)]
 		}
 	} else if len(cache.valsetCache) > len(validators) {
-		// The validator set shrank. Real validators only ever grow, so every entry
-		// beyond the new length is a projected (pending-deposit) validator that is no
-		// longer projected — e.g. builder deposits that get onboarded as builders at
-		// the Gloas fork, or a projection that simply produced fewer entries than a
-		// previous one. Drop the excess so stale projected validators don't linger in
-		// the set (and point past the balances array). Their pubkey-cache entries are
-		// left dangling but resolve to nil via the index bound check in
-		// getValidatorByIndex.
+		// The validator set shrank. Real validators only ever grow, so every entry beyond
+		// the new length is a projected (pending-deposit) validator that is no longer
+		// projected — e.g. builder deposits that get onboarded as builders at the Gloas
+		// fork, or a projection that simply produced fewer entries than a previous one.
+		// Drop the excess so stale projected validators don't linger in the set (and point
+		// past the balances array); their pubkey mappings live in projectedPubkeys, which
+		// is replaced below, so nothing dangles.
 		for i := len(validators); i < len(cache.valsetCache); i++ {
 			cache.valsetCache[i] = nil
 		}
 		cache.valsetCache = cache.valsetCache[:len(validators)]
 	}
 
+	// Rebuilt from scratch on every update: a projected index is an estimate that shifts as
+	// the queue ahead of it drains, so a mapping must never outlive the update that made it.
+	projectedPubkeys := make(map[phase0.BLSPubKey]phase0.ValidatorIndex, len(validators)-min(realCount, len(validators)))
+
 	isParentMap := map[phase0.Root]bool{}
 	isAheadMap := map[phase0.Root]bool{}
 	updatedCount := uint64(0)
 
 	for i := range validators {
+		if i >= realCount {
+			// Projected validator: cached for display only, kept out of the diff/finalization
+			// machinery entirely.
+			cachedValidator := cache.valsetCache[i]
+			if cachedValidator == nil {
+				cachedValidator = &validatorEntry{}
+				cache.valsetCache[i] = cachedValidator
+			}
+
+			cachedValidator.finalValidator = validators[i]
+			cachedValidator.entryFlags |= validatorEntryProjected
+			cachedValidator.statusFlags = GetValidatorStatusFlags(validators[i])
+			projectedPubkeys[validators[i].PublicKey] = phase0.ValidatorIndex(i)
+
+			continue
+		}
+
 		var parentChecksum uint64
 		var parentValidator *phase0.Validator
 		parentEpoch := phase0.Epoch(0)
@@ -180,15 +225,26 @@ func (cache *validatorCache) updateValidatorSet(slot phase0.Slot, dependentRoot 
 
 			cache.indexer.pubkeyCache.Add(validators[i].PublicKey, phase0.ValidatorIndex(i))
 		} else {
+			if cachedValidator.isProjected() {
+				// The chain caught up with a projection: this index is now occupied by a real
+				// validator, so the placeholder goes away (and with it the checksum derived from
+				// it, which must not be mistaken for a finalized parent state) and the pubkey
+				// becomes a permanent mapping. Losing that mapping here would leave the validator
+				// unresolvable by pubkey until the next restart, so the failure is worth reporting.
+				cachedValidator.entryFlags &^= validatorEntryProjected
+				cachedValidator.finalValidator = nil
+				cachedValidator.finalChecksum = 0
+				if err := cache.indexer.pubkeyCache.Add(validators[i].PublicKey, phase0.ValidatorIndex(i)); err != nil {
+					cache.indexer.logger.WithError(err).Warnf("could not add pubkey cache entry for validator %v", i)
+				}
+			}
+
 			parentValidator = cachedValidator.finalValidator
 			parentChecksum = cachedValidator.finalChecksum
 
 			// Reconcile the pubkey→index map when the pubkey occupying this index changes.
-			// Real validators never change pubkey, but a projected (pending-deposit)
-			// validator's estimated index shifts as the queue ahead of it is processed or
-			// builder deposits are dropped at the Gloas fork. Without this the pubkey cache
-			// keeps a stale mapping and GetValidatorIndexByPubkey misses the validator, so
-			// it appears "not projected".
+			// Real validators never change pubkey, so this only guards against a cache entry
+			// left over from an earlier, differently-shaped set.
 			if existingPubkey, ok := cachedValidator.latestPubkey(); ok && existingPubkey != validators[i].PublicKey {
 				cache.indexer.pubkeyCache.Add(validators[i].PublicKey, phase0.ValidatorIndex(i))
 			}
@@ -304,6 +360,8 @@ func (cache *validatorCache) updateValidatorSet(slot phase0.Slot, dependentRoot 
 		}
 	}
 
+	cache.projectedPubkeys = projectedPubkeys
+
 	if updatedCount > 0 {
 		select {
 		case cache.triggerDbUpdate <- true:
@@ -370,6 +428,17 @@ func (cache *validatorCache) getValidatorSetSize() uint64 {
 	return uint64(len(cache.valsetCache))
 }
 
+// getProjectedIndexByPubkey resolves a pubkey to the index its validator is projected to
+// get once the chain processes its pending deposit.
+func (cache *validatorCache) getProjectedIndexByPubkey(pubkey phase0.BLSPubKey) (phase0.ValidatorIndex, bool) {
+	cache.cacheMutex.RLock()
+	defer cache.cacheMutex.RUnlock()
+
+	index, found := cache.projectedPubkeys[pubkey]
+
+	return index, found
+}
+
 // getValidatorFlags returns the status flags for a specific validator
 // Returns 0 if validator index is invalid or not found
 func (cache *validatorCache) getValidatorFlags(validatorIndex phase0.ValidatorIndex) uint16 {
@@ -395,6 +464,12 @@ func (cache *validatorCache) setFinalizedEpoch(epoch phase0.Epoch, dependentRoot
 
 	for _, cachedValidator := range cache.valsetCache {
 		if cachedValidator == nil {
+			continue
+		}
+
+		if cachedValidator.isProjected() {
+			// A projection has no on-chain state to finalize; promoting a diff onto it would
+			// turn the placeholder into a row persistValidators writes to the db.
 			continue
 		}
 
@@ -468,6 +543,26 @@ func (cache *validatorCache) streamValidatorSetForRoot(blockRoot phase0.Root, on
 
 	for index, cachedValidator := range cache.valsetCache {
 		if cachedValidator == nil {
+			continue
+		}
+
+		if cachedValidator.isProjected() {
+			projected := cachedValidator.finalValidator
+			// Projected entries carry no diffs and no finalized state; stream the placeholder
+			// itself so the validator set stays contiguous.
+			projectedData := &ValidatorData{
+				ActivationEligibilityEpoch: projected.ActivationEligibilityEpoch,
+				ActivationEpoch:            projected.ActivationEpoch,
+				ExitEpoch:                  projected.ExitEpoch,
+				EffectiveBalanceEth:        uint32(projected.EffectiveBalance / EtherGweiFactor),
+			}
+			if onlyActive && (epoch != nil && (projectedData.ActivationEpoch > *epoch || projectedData.ExitEpoch < *epoch)) {
+				continue
+			}
+			if err := cb(phase0.ValidatorIndex(index), GetValidatorStatusFlags(projected), projectedData, projected); err != nil {
+				return err
+			}
+
 			continue
 		}
 
@@ -649,6 +744,12 @@ func (cache *validatorCache) getValidatorByIndexAndRoot(index phase0.ValidatorIn
 		return nil
 	}
 
+	if cachedValidator.isProjected() {
+		// copied like the cached values below, so callers can't mutate the cache entry
+		projectedCopy := *cachedValidator.finalValidator
+		return &projectedCopy
+	}
+
 	validator := cachedValidator.finalValidator
 	validatorEpoch := cache.lastFinalized
 
@@ -730,10 +831,18 @@ func (cache *validatorCache) prepopulateFromDB() (uint64, error) {
 	activeCount := uint64(0)
 	restoreCount := uint64(0)
 
-	// Load validators in batches
+	// Projected validators were persisted by earlier versions (setFinalizedEpoch promoted their
+	// cache diffs like any other). Restoring them would recreate a validator that does not exist
+	// on chain and re-register its pubkey in the persistent cache, so they are dropped here and
+	// removed from the db instead.
+	staleProjections := make([]uint64, 0)
+	staleProjectionPubkeys := make([]phase0.BLSPubKey, 0)
+
+	// Load validators in batches. The range query is inclusive on both ends, so the end index
+	// must stop one short of the next batch's start.
 	batchSize := uint64(10000)
 	for start := uint64(0); start <= maxIndex; start += batchSize {
-		end := start + batchSize
+		end := start + batchSize - 1
 		if end > maxIndex {
 			end = maxIndex
 		}
@@ -742,6 +851,13 @@ func (cache *validatorCache) prepopulateFromDB() (uint64, error) {
 		for _, dbVal := range validators {
 			// Convert db validator to phase0.Validator
 			val := UnwrapDbValidator(dbVal)
+			if IsProjectedValidator(val) {
+				staleProjections = append(staleProjections, dbVal.ValidatorIndex)
+				staleProjectionPubkeys = append(staleProjectionPubkeys, val.PublicKey)
+
+				continue
+			}
+
 			valEntry := &validatorEntry{
 				finalChecksum: calculateValidatorChecksum(val),
 			}
@@ -768,6 +884,23 @@ func (cache *validatorCache) prepopulateFromDB() (uint64, error) {
 	}
 
 	cache.lastFinalizedActiveCount = activeCount
+
+	if len(staleProjections) > 0 {
+		for _, pubkey := range staleProjectionPubkeys {
+			if err := cache.indexer.pubkeyCache.Remove(pubkey); err != nil {
+				cache.indexer.logger.WithError(err).Warnf("could not drop pubkey cache entry of stale projected validator")
+			}
+		}
+
+		err := db.RunDBTransaction(func(tx *sqlx.Tx) error {
+			return db.DeleteValidators(cache.indexer.ctx, tx, staleProjections)
+		})
+		if err != nil {
+			cache.indexer.logger.WithError(err).Errorf("error deleting %v stale projected validators from db", len(staleProjections))
+		} else {
+			cache.indexer.logger.Infof("dropped %v stale projected validators from db (indexes %v-%v)", len(staleProjections), staleProjections[0], staleProjections[len(staleProjections)-1])
+		}
+	}
 
 	return restoreCount, nil
 }
@@ -815,7 +948,7 @@ func (cache *validatorCache) persistValidators(tx *sqlx.Tx) (bool, error) {
 	hasMore := false
 
 	for index, entry := range cache.valsetCache {
-		if entry == nil || entry.finalValidator == nil {
+		if entry == nil || entry.finalValidator == nil || entry.isProjected() {
 			continue
 		}
 

--- a/indexer/beacon/writedb.go
+++ b/indexer/beacon/writedb.go
@@ -171,7 +171,7 @@ func (dbw *dbWriter) persistBlockChildObjects(tx *sqlx.Tx, block *Block, deposit
 	}
 
 	// insert builder deposit requests (gloas)
-	err = dbw.persistBlockBuilderDeposits(tx, block, orphaned, overrideForkId)
+	err = dbw.persistBlockBuilderDeposits(tx, block, orphaned, overrideForkId, sim)
 	if err != nil {
 		return err
 	}
@@ -965,8 +965,8 @@ func (dbw *dbWriter) buildDbDepositRequests(block *Block, orphaned bool, overrid
 
 // persistBlockBuilderDeposits persists the block's builder deposit requests
 // (Gloas/EIP-8282) to the builder_deposits table. Pre-Gloas blocks carry none.
-func (dbw *dbWriter) persistBlockBuilderDeposits(tx *sqlx.Tx, block *Block, orphaned bool, overrideForkId *ForkKey) error {
-	dbDeposits := dbw.buildDbBuilderDeposits(block, orphaned, overrideForkId)
+func (dbw *dbWriter) persistBlockBuilderDeposits(tx *sqlx.Tx, block *Block, orphaned bool, overrideForkId *ForkKey, sim *stateSimulator) error {
+	dbDeposits := dbw.buildDbBuilderDeposits(block, orphaned, overrideForkId, sim)
 	if len(dbDeposits) > 0 {
 		err := db.InsertBuilderDeposits(dbw.indexer.ctx, tx, dbDeposits)
 		if err != nil {
@@ -977,10 +977,15 @@ func (dbw *dbWriter) persistBlockBuilderDeposits(tx *sqlx.Tx, block *Block, orph
 	return nil
 }
 
-func (dbw *dbWriter) buildDbBuilderDeposits(block *Block, orphaned bool, overrideForkId *ForkKey) []*dbtypes.BuilderDeposit {
+func (dbw *dbWriter) buildDbBuilderDeposits(block *Block, orphaned bool, overrideForkId *ForkKey, sim *stateSimulator) []*dbtypes.BuilderDeposit {
 	requests, blockNumber := dbw.getProcessedExecutionRequests(block)
 	if requests == nil || len(requests.BuilderDeposits) == 0 {
 		return []*dbtypes.BuilderDeposit{}
+	}
+
+	var blockResults [][]uint8
+	if sim != nil {
+		blockResults = sim.replayBlockResults(block)
 	}
 
 	dbDeposits := make([]*dbtypes.BuilderDeposit, len(requests.BuilderDeposits))
@@ -1003,6 +1008,9 @@ func (dbw *dbWriter) buildDbBuilderDeposits(block *Block, orphaned bool, overrid
 		}
 		if overrideForkId != nil {
 			dbDeposit.ForkId = uint64(*overrideForkId)
+		}
+		if len(blockResults) > 2 && idx < len(blockResults[2]) {
+			dbDeposit.Result = blockResults[2][idx]
 		}
 
 		dbDeposits[idx] = dbDeposit

--- a/services/chainservice.go
+++ b/services/chainservice.go
@@ -50,6 +50,8 @@ type ChainService struct {
 	txIndexer             *txindexer.TxIndexer
 	ensResolver           *EnsResolver
 	started               bool
+
+	depositQueueIndexes depositQueueIndexCache
 }
 
 var GlobalBeaconService *ChainService

--- a/services/chainservice_builder_onboarding.go
+++ b/services/chainservice_builder_onboarding.go
@@ -21,9 +21,14 @@ func isBuilderCredential(wc []byte) bool {
 	return len(wc) > 0 && wc[0] == builderWithdrawalCredType
 }
 
-// projectionFetchCap bounds how many builder-credential deposits the projection enumerates. It is
-// far above any realistic count of pre-fork builder deposits; hitting it sets Truncated.
-const projectionFetchCap = 10000
+// projectionFetchCap bounds how many builder-credential deposits the projection enumerates.
+//
+// The onboarding simulation is sequential and only produces the right new-builder/top-up
+// classification if it starts at the very first builder deposit, so the window is anchored at
+// the OLDEST deposit and the newest ones are dropped when the cap is hit (which sets
+// Truncated). Anchoring at the newest instead starts the simulation mid-stream and shifts the
+// whole list by one on every new deposit.
+const projectionFetchCap = 100000
 
 // ProjectedBuilderDeposit is one builder-credential (0xB0) deposit on chain together with its
 // projected fate at the upcoming Gloas fork transition. When none of the fate flags is set the
@@ -37,6 +42,13 @@ type ProjectedBuilderDeposit struct {
 
 	// EstimateEpoch is the projected epoch the deposit is processed (0 = unknown).
 	EstimateEpoch phase0.Epoch
+
+	// ProjectedBuilderIndex is the builder index this deposit registers or tops up at the fork.
+	// Onboarding assigns indexes in queue order starting at 0, before the builder deposit
+	// contract queue is dequeued, so these are the lowest indexes on the chain. Unset for
+	// deposits that never become a builder.
+	ProjectedBuilderIndex    uint64
+	HasProjectedBuilderIndex bool
 
 	// Fate flags (at most one set; none set => onboarded as a builder):
 	TooEarly         bool // processed before the fork -> becomes a regular validator, not a builder
@@ -68,8 +80,13 @@ type BuilderOnboardingProjection struct {
 	// each annotated with its projected fate.
 	Deposits []*ProjectedBuilderDeposit
 
-	OnboardedNewCount     uint64
-	OnboardedTopUpCount   uint64
+	OnboardedNewCount   uint64
+	OnboardedTopUpCount uint64
+
+	// NextBuilderIndex is the first builder index that onboarding does NOT take, i.e. where the
+	// builder deposit contract queue continues once it starts dequeuing after the fork.
+	NextBuilderIndex uint64
+
 	TooEarlyCount         uint64
 	InvalidSignatureCount uint64
 	KeptAsValidatorCount  uint64
@@ -171,10 +188,17 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 		WithValid:           1, // no signature-validity filter — invalid sigs are a classified outcome
 		WithdrawalCredTypes: []uint8{builderWithdrawalCredType},
 	}
-	deposits, _ := bs.GetDepositOperationsByFilter(ctx, depositFilter, txFilter, 0, projectionFetchCap)
-	if len(deposits) >= projectionFetchCap {
+	// The result set is ordered newest-first, so the oldest deposits sit at the end: resolve the
+	// total first and page to the tail, keeping the simulation anchored at the first deposit.
+	_, totalDeposits := bs.GetDepositOperationsByFilter(ctx, depositFilter, txFilter, 0, 1)
+	fetchOffset := uint64(0)
+	if totalDeposits > projectionFetchCap {
+		fetchOffset = totalDeposits - projectionFetchCap
 		proj.Truncated = true
+		bs.logger.Warnf("builder onboarding projection truncated: %v of %v builder deposits enumerated", projectionFetchCap, totalDeposits)
 	}
+
+	deposits, _ := bs.GetDepositOperationsByFilter(ctx, depositFilter, txFilter, fetchOffset, projectionFetchCap)
 
 	// Process in deposit-index order (= queue / processing order); unresolved-index deposits (very
 	// recent) sort last.
@@ -187,8 +211,10 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 		return found && !bs.IsProjectedValidatorIndex(idx)
 	}
 
-	acceptedBuilderPubkeys := make(map[phase0.BLSPubKey]bool) // pubkeys onboarded as new builders so far
-	validatorFromDeposit := make(map[phase0.BLSPubKey]bool)   // pubkeys turned into validators by an earlier too-early deposit
+	// pubkeys onboarded as new builders so far, mapped to the builder index they took
+	acceptedBuilderIndexes := make(map[phase0.BLSPubKey]uint64)
+	nextBuilderIndex := uint64(0)
+	validatorFromDeposit := make(map[phase0.BLSPubKey]bool) // pubkeys turned into validators by an earlier too-early deposit
 	for _, dep := range deposits {
 		if dep.Orphaned || !isBuilderCredential(dep.WithdrawalCredentials) {
 			continue
@@ -239,9 +265,13 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 			validSig = *dep.ValidSignature == 1 || *dep.ValidSignature == 2
 		}
 
+		builderIndex, isAcceptedBuilder := acceptedBuilderIndexes[pubkey]
+
 		switch {
-		case acceptedBuilderPubkeys[pubkey]:
+		case isAcceptedBuilder:
 			pd.Result = dbtypes.BuilderDepositRequestResultTopUp
+			pd.ProjectedBuilderIndex = builderIndex
+			pd.HasProjectedBuilderIndex = true
 			proj.OnboardedTopUpCount++
 		case isExistingValidator(pubkey) || validatorFromDeposit[pubkey] || queueNonBuilderPubkeys[pubkey]:
 			pd.KeptAsValidator = true
@@ -252,12 +282,17 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 			proj.InvalidSignatureCount++
 		default:
 			pd.Result = dbtypes.BuilderDepositRequestResultNewBuilder
-			acceptedBuilderPubkeys[pubkey] = true
+			pd.ProjectedBuilderIndex = nextBuilderIndex
+			pd.HasProjectedBuilderIndex = true
+			acceptedBuilderIndexes[pubkey] = nextBuilderIndex
+			nextBuilderIndex++
 			proj.OnboardedNewCount++
 		}
 
 		proj.Deposits = append(proj.Deposits, pd)
 	}
+
+	proj.NextBuilderIndex = nextBuilderIndex
 
 	if tailEstimate > 0 {
 		proj.HasSafetyEstimate = true

--- a/services/chainservice_builder_onboarding.go
+++ b/services/chainservice_builder_onboarding.go
@@ -148,11 +148,10 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 		return epoch == 0 || epoch >= gloasForkEpoch
 	}
 
-	// Queue cross-check map + secondary stats. queueNonBuilderPubkeys collects pubkeys with a pending
-	// non-builder deposit remaining at the fork, so a same-pubkey builder deposit is kept as a
-	// validator deposit rather than onboarded.
+	// Queue cross-check map + secondary stats, and the validator deposits that keep a same-pubkey
+	// builder deposit out of the builder registry (see validatorDepositsInQueue).
 	pendingByIndex := make(map[uint64]*IndexedDepositQueueEntry, len(indexedQueue.Queue))
-	queueNonBuilderPubkeys := make(map[phase0.BLSPubKey]bool)
+	validatorDeposits := newValidatorDepositsInQueue()
 	for _, entry := range indexedQueue.Queue {
 		if entry.DepositIndex != nil {
 			pendingByIndex[*entry.DepositIndex] = entry
@@ -161,9 +160,7 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 		if !remains {
 			proj.TotalQueueProcessedBeforeFork++
 		}
-		if remains && !isBuilderCredential(entry.PendingDeposit.WithdrawalCredentials) {
-			queueNonBuilderPubkeys[entry.PendingDeposit.Pubkey] = true
-		}
+		validatorDeposits.add(entry, remains)
 	}
 
 	anchorIndex, hasAnchor := uint64(0), indexedQueue.LastIncludedDepositIndex != nil
@@ -273,7 +270,7 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 			pd.ProjectedBuilderIndex = builderIndex
 			pd.HasProjectedBuilderIndex = true
 			proj.OnboardedTopUpCount++
-		case isExistingValidator(pubkey) || validatorFromDeposit[pubkey] || queueNonBuilderPubkeys[pubkey]:
+		case isExistingValidator(pubkey) || validatorFromDeposit[pubkey] || validatorDeposits.keeps(pd):
 			pd.KeptAsValidator = true
 			proj.KeptAsValidatorCount++
 		case !validSig:
@@ -311,4 +308,76 @@ func depositIndexOrMax(dep *dbtypes.DepositWithTx) uint64 {
 		return *dep.Index
 	}
 	return math.MaxUint64
+}
+
+// validatorDepositsInQueue tracks the pending validator (non-builder) deposits that stop a
+// same-pubkey builder deposit from being onboarded at the fork. There are two ways that happens,
+// and they behave differently:
+//
+//   - The validator deposit is applied *before* the fork. It registers the pubkey as a validator,
+//     so onboarding finds it in state.validators and keeps every builder deposit for that pubkey,
+//     whatever their order in the queue.
+//   - The validator deposit is still queued *at* the fork. Onboarding walks the queue in order and
+//     keeps it, which only affects builder deposits that sit behind it — a builder deposit ahead of
+//     it is onboarded normally, and the validator deposit is applied to that validator later.
+//
+// Mirrors onboard_builders_from_pending_deposits (state.validators and the keptPubkeys set).
+type validatorDepositsInQueue struct {
+	// appliedBeforeFork are pubkeys that become validators before the fork.
+	appliedBeforeFork map[phase0.BLSPubKey]bool
+
+	// firstKeptPos is the queue position of the earliest validator deposit that is still queued at
+	// the fork, per pubkey.
+	firstKeptPos map[phase0.BLSPubKey]uint64
+}
+
+func newValidatorDepositsInQueue() *validatorDepositsInQueue {
+	return &validatorDepositsInQueue{
+		appliedBeforeFork: make(map[phase0.BLSPubKey]bool),
+		firstKeptPos:      make(map[phase0.BLSPubKey]uint64),
+	}
+}
+
+// add records a queue entry. remains says whether it survives process_pending_deposits up to the
+// fork epoch. Builder-credential deposits are not validator deposits and are ignored here.
+func (v *validatorDepositsInQueue) add(entry *IndexedDepositQueueEntry, remains bool) {
+	if isBuilderCredential(entry.PendingDeposit.WithdrawalCredentials) {
+		return
+	}
+
+	pubkey := entry.PendingDeposit.Pubkey
+
+	if !remains {
+		// applied before the fork: the pubkey is a validator by the time onboarding runs.
+		// Whether the deposit's own signature is valid is not modelled here; an invalid
+		// proof-of-possession would leave the pubkey unregistered and the builder deposit
+		// onboardable after all.
+		v.appliedBeforeFork[pubkey] = true
+
+		return
+	}
+
+	if pos, seen := v.firstKeptPos[pubkey]; !seen || entry.QueuePos < pos {
+		v.firstKeptPos[pubkey] = entry.QueuePos
+	}
+}
+
+// keeps reports whether a validator deposit keeps this builder deposit in the pending queue
+// instead of onboarding it as a builder.
+func (v *validatorDepositsInQueue) keeps(deposit *ProjectedBuilderDeposit) bool {
+	pubkey := phase0.BLSPubKey{}
+	copy(pubkey[:], deposit.Deposit.PublicKey)
+
+	if v.appliedBeforeFork[pubkey] {
+		return true
+	}
+
+	pos, queued := v.firstKeptPos[pubkey]
+	if !queued {
+		return false
+	}
+
+	// a deposit that is not in the queue snapshot was included after it, so it sits behind
+	// everything the snapshot holds
+	return !deposit.IsQueued || pos < deposit.QueuePos
 }

--- a/services/chainservice_builder_onboarding.go
+++ b/services/chainservice_builder_onboarding.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 
+	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
 )
 
@@ -148,19 +149,14 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 		return epoch == 0 || epoch >= gloasForkEpoch
 	}
 
-	// Queue cross-check map + secondary stats, and the validator deposits that keep a same-pubkey
-	// builder deposit out of the builder registry (see validatorDepositsInQueue).
 	pendingByIndex := make(map[uint64]*IndexedDepositQueueEntry, len(indexedQueue.Queue))
-	validatorDeposits := newValidatorDepositsInQueue()
 	for _, entry := range indexedQueue.Queue {
 		if entry.DepositIndex != nil {
 			pendingByIndex[*entry.DepositIndex] = entry
 		}
-		remains := remainsAtFork(entry.EpochEstimate)
-		if !remains {
+		if !remainsAtFork(entry.EpochEstimate) {
 			proj.TotalQueueProcessedBeforeFork++
 		}
-		validatorDeposits.add(entry, remains)
 	}
 
 	anchorIndex, hasAnchor := uint64(0), indexedQueue.LastIncludedDepositIndex != nil
@@ -202,6 +198,11 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 	sort.SliceStable(deposits, func(i, j int) bool {
 		return depositIndexOrMax(deposits[i]) < depositIndexOrMax(deposits[j])
 	})
+
+	// The validator deposits that keep a same-pubkey builder deposit out of the registry can only
+	// be judged once the builder pubkeys are known, since resolving whether a pre-fork deposit
+	// actually registers a validator needs a signature lookup (see validatorDepositsInQueue).
+	validatorDeposits := bs.collectValidatorDepositsInQueue(ctx, indexedQueue, deposits, remainsAtFork)
 
 	isExistingValidator := func(pubkey phase0.BLSPubKey) bool {
 		idx, found := bs.beaconIndexer.GetValidatorIndexByPubkey(pubkey)
@@ -248,20 +249,21 @@ func (bs *ChainService) GetBuilderOnboardingProjection(ctx context.Context) *Bui
 			remains = false
 		}
 
+		validSig := depositSignatureIsValid(dep.ValidSignature)
+
 		if !remains {
 			pd.TooEarly = true
 			proj.TooEarlyCount++
-			validatorFromDeposit[pubkey] = true
+			// only a deposit with a valid proof-of-possession registers the validator; an
+			// invalid one is dropped by apply_pending_deposit and leaves the pubkey free
+			if validSig {
+				validatorFromDeposit[pubkey] = true
+			}
 			proj.Deposits = append(proj.Deposits, pd)
 			continue
 		}
 
 		// Remains at the fork — onboarding selection (sequential, mirrors onboarding).
-		validSig := true
-		if dep.ValidSignature != nil {
-			validSig = *dep.ValidSignature == 1 || *dep.ValidSignature == 2
-		}
-
 		builderIndex, isAcceptedBuilder := acceptedBuilderIndexes[pubkey]
 
 		switch {
@@ -339,8 +341,10 @@ func newValidatorDepositsInQueue() *validatorDepositsInQueue {
 }
 
 // add records a queue entry. remains says whether it survives process_pending_deposits up to the
-// fork epoch. Builder-credential deposits are not validator deposits and are ignored here.
-func (v *validatorDepositsInQueue) add(entry *IndexedDepositQueueEntry, remains bool) {
+// fork epoch, and registersValidator whether an entry applied before the fork actually creates the
+// validator (it does not if its proof-of-possession is invalid). Builder-credential deposits are
+// not validator deposits and are ignored here.
+func (v *validatorDepositsInQueue) add(entry *IndexedDepositQueueEntry, remains, registersValidator bool) {
 	if isBuilderCredential(entry.PendingDeposit.WithdrawalCredentials) {
 		return
 	}
@@ -348,18 +352,82 @@ func (v *validatorDepositsInQueue) add(entry *IndexedDepositQueueEntry, remains 
 	pubkey := entry.PendingDeposit.Pubkey
 
 	if !remains {
-		// applied before the fork: the pubkey is a validator by the time onboarding runs.
-		// Whether the deposit's own signature is valid is not modelled here; an invalid
-		// proof-of-possession would leave the pubkey unregistered and the builder deposit
-		// onboardable after all.
-		v.appliedBeforeFork[pubkey] = true
+		// Applied before the fork. It only makes the pubkey a validator if its signature is
+		// valid: apply_pending_deposit drops an invalid proof-of-possession for a new pubkey
+		// without registering anything, leaving the builder deposit onboardable after all.
+		if registersValidator {
+			v.appliedBeforeFork[pubkey] = true
+		}
 
 		return
 	}
 
+	// A deposit that is still queued at the fork is kept regardless of its signature —
+	// onboard_builders_from_pending_deposits keeps every non-builder deposit it walks past,
+	// and only later does apply_pending_deposit judge the signature.
 	if pos, seen := v.firstKeptPos[pubkey]; !seen || entry.QueuePos < pos {
 		v.firstKeptPos[pubkey] = entry.QueuePos
 	}
+}
+
+// depositSignatureIsValid reads the indexer's proof-of-possession verdict: 1 is a verified
+// signature and 2 a top-up of a pubkey that already had one. Anything else — including an
+// unknown verdict, for a deposit whose contract transaction has not been indexed yet — is
+// treated as not registering anything, matching what onboarding does with a bad signature.
+func depositSignatureIsValid(validSignature *uint8) bool {
+	return validSignature != nil && (*validSignature == 1 || *validSignature == 2)
+}
+
+// collectValidatorDepositsInQueue builds the tracker for a projection run. Deciding whether a
+// pre-fork validator deposit registers anything needs its signature verdict, which the queue
+// entries do not carry, so it is looked up from the deposit transactions — restricted to the
+// pubkeys that actually have a builder deposit, since no other pubkey can change an outcome.
+func (bs *ChainService) collectValidatorDepositsInQueue(
+	ctx context.Context,
+	indexedQueue *IndexedDepositQueue,
+	builderDeposits []*dbtypes.DepositWithTx,
+	remainsAtFork func(phase0.Epoch) bool,
+) *validatorDepositsInQueue {
+	builderPubkeys := make(map[phase0.BLSPubKey]bool, len(builderDeposits))
+	for _, dep := range builderDeposits {
+		pubkey := phase0.BLSPubKey{}
+		copy(pubkey[:], dep.PublicKey)
+		builderPubkeys[pubkey] = true
+	}
+
+	// pre-fork validator deposits of those pubkeys are the only ones whose signature matters
+	lookup := make([]uint64, 0)
+	for _, entry := range indexedQueue.Queue {
+		if entry.DepositIndex == nil || remainsAtFork(entry.EpochEstimate) {
+			continue
+		}
+		if isBuilderCredential(entry.PendingDeposit.WithdrawalCredentials) {
+			continue
+		}
+		if builderPubkeys[entry.PendingDeposit.Pubkey] {
+			lookup = append(lookup, *entry.DepositIndex)
+		}
+	}
+
+	validity := make(map[uint64]bool, len(lookup))
+	for _, depositTx := range db.GetDepositTxsByIndexes(ctx, lookup) {
+		validSignature := depositTx.ValidSignature
+		validity[depositTx.Index] = depositSignatureIsValid(&validSignature)
+	}
+
+	validatorDeposits := newValidatorDepositsInQueue()
+	for _, entry := range indexedQueue.Queue {
+		remains := remainsAtFork(entry.EpochEstimate)
+
+		registersValidator := false
+		if !remains && entry.DepositIndex != nil {
+			registersValidator = validity[*entry.DepositIndex]
+		}
+
+		validatorDeposits.add(entry, remains, registersValidator)
+	}
+
+	return validatorDeposits
 }
 
 // keeps reports whether a validator deposit keeps this builder deposit in the pending queue

--- a/services/chainservice_builder_onboarding_test.go
+++ b/services/chainservice_builder_onboarding_test.go
@@ -59,7 +59,7 @@ func TestValidatorDepositAppliedBeforeForkKeepsBuilderDeposit(t *testing.T) {
 	pubkey := testPubkey(0x11)
 
 	validatorDeposits := newValidatorDepositsInQueue()
-	validatorDeposits.add(queueEntry(0, pubkey, validatorCredentials()), false)
+	validatorDeposits.add(queueEntry(0, pubkey, validatorCredentials()), false, true)
 
 	// order is irrelevant once the validator exists: both a later and an earlier builder deposit
 	// are kept
@@ -75,7 +75,7 @@ func TestQueuedValidatorDepositKeepsOnlyLaterBuilderDeposits(t *testing.T) {
 	pubkey := testPubkey(0x22)
 
 	validatorDeposits := newValidatorDepositsInQueue()
-	validatorDeposits.add(queueEntry(10, pubkey, validatorCredentials()), true)
+	validatorDeposits.add(queueEntry(10, pubkey, validatorCredentials()), true, false)
 
 	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 11)),
 		"a builder deposit behind the kept validator deposit is kept too")
@@ -89,8 +89,8 @@ func TestValidatorDepositsInQueueTracksTheEarliestKeptPosition(t *testing.T) {
 	pubkey := testPubkey(0x33)
 
 	validatorDeposits := newValidatorDepositsInQueue()
-	validatorDeposits.add(queueEntry(20, pubkey, validatorCredentials()), true)
-	validatorDeposits.add(queueEntry(5, pubkey, validatorCredentials()), true)
+	validatorDeposits.add(queueEntry(20, pubkey, validatorCredentials()), true, false)
+	validatorDeposits.add(queueEntry(5, pubkey, validatorCredentials()), true, false)
 
 	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 10)),
 		"the earliest kept validator deposit decides, not the last one seen")
@@ -100,8 +100,8 @@ func TestBuilderDepositsAreNotValidatorDeposits(t *testing.T) {
 	pubkey := testPubkey(0x44)
 
 	validatorDeposits := newValidatorDepositsInQueue()
-	validatorDeposits.add(queueEntry(0, pubkey, builderCredentials()), false)
-	validatorDeposits.add(queueEntry(1, pubkey, builderCredentials()), true)
+	validatorDeposits.add(queueEntry(0, pubkey, builderCredentials()), false, true)
+	validatorDeposits.add(queueEntry(1, pubkey, builderCredentials()), true, false)
 
 	require.False(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 5)),
 		"builder deposits are onboarded, so they never keep a later builder deposit as a validator")
@@ -109,8 +109,47 @@ func TestBuilderDepositsAreNotValidatorDeposits(t *testing.T) {
 
 func TestUnrelatedPubkeysAreUnaffected(t *testing.T) {
 	validatorDeposits := newValidatorDepositsInQueue()
-	validatorDeposits.add(queueEntry(0, testPubkey(0x55), validatorCredentials()), false)
-	validatorDeposits.add(queueEntry(1, testPubkey(0x66), validatorCredentials()), true)
+	validatorDeposits.add(queueEntry(0, testPubkey(0x55), validatorCredentials()), false, true)
+	validatorDeposits.add(queueEntry(1, testPubkey(0x66), validatorCredentials()), true, false)
 
 	require.False(t, validatorDeposits.keeps(builderDeposit(testPubkey(0x77), true, 9)))
+}
+
+// TestInvalidValidatorDepositDoesNotBlockOnboarding is the case that made the projection hide a
+// real builder: a pubkey with thousands of invalid validator deposits drained before the fork.
+// None of them registers anything, so onboarding still sees a free pubkey and registers the
+// builder from its one valid builder deposit.
+func TestInvalidValidatorDepositDoesNotBlockOnboarding(t *testing.T) {
+	pubkey := testPubkey(0x88)
+
+	validatorDeposits := newValidatorDepositsInQueue()
+	for pos := uint64(0); pos < 5; pos++ {
+		validatorDeposits.add(queueEntry(pos, pubkey, validatorCredentials()), false, false)
+	}
+
+	require.False(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 10)),
+		"deposits that register nothing must not keep the builder deposit out of the registry")
+}
+
+// TestQueuedValidatorDepositKeepsRegardlessOfSignature guards the asymmetry: onboarding keeps every
+// non-builder deposit it walks past without looking at the signature, and only apply_pending_deposit
+// judges it later. So a still-queued validator deposit keeps the builder deposit even when its own
+// proof-of-possession is invalid.
+func TestQueuedValidatorDepositKeepsRegardlessOfSignature(t *testing.T) {
+	pubkey := testPubkey(0x99)
+
+	validatorDeposits := newValidatorDepositsInQueue()
+	validatorDeposits.add(queueEntry(3, pubkey, validatorCredentials()), true, false)
+
+	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 4)))
+}
+
+func TestDepositSignatureVerdicts(t *testing.T) {
+	verdict := func(v uint8) *uint8 { return &v }
+
+	require.True(t, depositSignatureIsValid(verdict(1)), "a verified signature registers")
+	require.True(t, depositSignatureIsValid(verdict(2)), "a top-up implies an earlier valid signature")
+	require.False(t, depositSignatureIsValid(verdict(0)), "an invalid proof-of-possession registers nothing")
+	require.False(t, depositSignatureIsValid(nil),
+		"an unindexed deposit transaction leaves the verdict unknown, which must not be read as valid")
 }

--- a/services/chainservice_builder_onboarding_test.go
+++ b/services/chainservice_builder_onboarding_test.go
@@ -1,0 +1,116 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/ethpandaops/go-eth2-client/spec/electra"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+)
+
+func testPubkey(seed byte) phase0.BLSPubKey {
+	pubkey := phase0.BLSPubKey{}
+	for i := range pubkey {
+		pubkey[i] = seed
+	}
+
+	return pubkey
+}
+
+func validatorCredentials() []byte {
+	credentials := make([]byte, 32)
+	credentials[0] = 0x02
+
+	return credentials
+}
+
+func builderCredentials() []byte {
+	credentials := make([]byte, 32)
+	credentials[0] = builderWithdrawalCredType
+
+	return credentials
+}
+
+func queueEntry(pos uint64, pubkey phase0.BLSPubKey, credentials []byte) *IndexedDepositQueueEntry {
+	return &IndexedDepositQueueEntry{
+		QueuePos: pos,
+		PendingDeposit: &electra.PendingDeposit{
+			Pubkey:                pubkey,
+			WithdrawalCredentials: credentials,
+		},
+	}
+}
+
+func builderDeposit(pubkey phase0.BLSPubKey, queued bool, pos uint64) *ProjectedBuilderDeposit {
+	return &ProjectedBuilderDeposit{
+		Deposit:  &dbtypes.DepositWithTx{Deposit: dbtypes.Deposit{PublicKey: pubkey[:]}},
+		IsQueued: queued,
+		QueuePos: pos,
+	}
+}
+
+// TestValidatorDepositAppliedBeforeForkKeepsBuilderDeposit covers the case that made the projection
+// diverge from the chain: a validator deposit at the front of the queue is applied well before the
+// fork, so it registers the pubkey as a validator, and onboarding then keeps every builder deposit
+// for it. Being processed before the fork is exactly what makes it invisible to a check that only
+// looks at deposits still queued at the fork.
+func TestValidatorDepositAppliedBeforeForkKeepsBuilderDeposit(t *testing.T) {
+	pubkey := testPubkey(0x11)
+
+	validatorDeposits := newValidatorDepositsInQueue()
+	validatorDeposits.add(queueEntry(0, pubkey, validatorCredentials()), false)
+
+	// order is irrelevant once the validator exists: both a later and an earlier builder deposit
+	// are kept
+	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 17)))
+	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 0)))
+	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, false, 0)))
+}
+
+// TestQueuedValidatorDepositKeepsOnlyLaterBuilderDeposits covers the other half: a validator
+// deposit that is still queued at the fork is kept as onboarding walks the queue, so it only
+// affects builder deposits behind it.
+func TestQueuedValidatorDepositKeepsOnlyLaterBuilderDeposits(t *testing.T) {
+	pubkey := testPubkey(0x22)
+
+	validatorDeposits := newValidatorDepositsInQueue()
+	validatorDeposits.add(queueEntry(10, pubkey, validatorCredentials()), true)
+
+	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 11)),
+		"a builder deposit behind the kept validator deposit is kept too")
+	require.False(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 9)),
+		"a builder deposit ahead of it is onboarded before onboarding ever sees it")
+	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, false, 0)),
+		"a deposit included after the queue snapshot sits behind everything in it")
+}
+
+func TestValidatorDepositsInQueueTracksTheEarliestKeptPosition(t *testing.T) {
+	pubkey := testPubkey(0x33)
+
+	validatorDeposits := newValidatorDepositsInQueue()
+	validatorDeposits.add(queueEntry(20, pubkey, validatorCredentials()), true)
+	validatorDeposits.add(queueEntry(5, pubkey, validatorCredentials()), true)
+
+	require.True(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 10)),
+		"the earliest kept validator deposit decides, not the last one seen")
+}
+
+func TestBuilderDepositsAreNotValidatorDeposits(t *testing.T) {
+	pubkey := testPubkey(0x44)
+
+	validatorDeposits := newValidatorDepositsInQueue()
+	validatorDeposits.add(queueEntry(0, pubkey, builderCredentials()), false)
+	validatorDeposits.add(queueEntry(1, pubkey, builderCredentials()), true)
+
+	require.False(t, validatorDeposits.keeps(builderDeposit(pubkey, true, 5)),
+		"builder deposits are onboarded, so they never keep a later builder deposit as a validator")
+}
+
+func TestUnrelatedPubkeysAreUnaffected(t *testing.T) {
+	validatorDeposits := newValidatorDepositsInQueue()
+	validatorDeposits.add(queueEntry(0, testPubkey(0x55), validatorCredentials()), false)
+	validatorDeposits.add(queueEntry(1, testPubkey(0x66), validatorCredentials()), true)
+
+	require.False(t, validatorDeposits.keeps(builderDeposit(testPubkey(0x77), true, 9)))
+}

--- a/services/chainservice_builder_requests.go
+++ b/services/chainservice_builder_requests.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/dbtypes"
@@ -98,7 +99,54 @@ func (bs *ChainService) GetBuilderDepositsByFilter(ctx context.Context, filter *
 		}
 	}
 
+	bs.matchSentinelBuilderDepositTxs(ctx, combinedResults, canonicalForkIds)
+
 	return combinedResults, totalPendingTxResults, totalReqResults
+}
+
+// matchSentinelBuilderDepositTxs links included builder deposits to request txs that are still
+// stored with the dequeue-block sentinel (0).
+//
+// Requests enqueued before the activation fork keep that sentinel until the fork boundary is
+// finalized and the dequeue rebase runs, and the transaction matcher pairs rows by dequeue
+// block - so on a chain that has not finalized past the fork yet, those deposits would show no
+// transaction at all. They are matched by content instead (pubkey, amount, signature is unique
+// per deposit), consumed in queue order so repeated identical top-ups pair one to one.
+func (bs *ChainService) matchSentinelBuilderDepositTxs(ctx context.Context, results []*CombinedBuilderDeposit, canonicalForkIds []uint64) {
+	pubkeys := make([][]byte, 0, len(results))
+	for _, result := range results {
+		if result.Request != nil && result.Transaction == nil {
+			pubkeys = append(pubkeys, result.Request.PublicKey)
+		}
+	}
+	if len(pubkeys) == 0 {
+		return
+	}
+
+	sentinelTxs := make(map[string][]*dbtypes.BuilderDepositTx)
+	for _, depositTx := range db.GetBuilderDepositTxsWithSentinelDequeue(ctx, pubkeys) {
+		key := fmt.Sprintf("%x-%d-%x", depositTx.PublicKey, depositTx.Amount, depositTx.Signature)
+		sentinelTxs[key] = append(sentinelTxs[key], depositTx)
+	}
+	if len(sentinelTxs) == 0 {
+		return
+	}
+
+	for _, result := range results {
+		if result.Request == nil || result.Transaction != nil {
+			continue
+		}
+
+		key := fmt.Sprintf("%x-%d-%x", result.Request.PublicKey, result.Request.Amount, result.Request.Signature)
+		candidates := sentinelTxs[key]
+		if len(candidates) == 0 {
+			continue
+		}
+
+		result.Transaction = candidates[0]
+		result.TransactionOrphaned = !bs.isCanonicalForkId(candidates[0].ForkId, canonicalForkIds)
+		sentinelTxs[key] = candidates[1:]
+	}
 }
 
 // GetQueuedBuilderDepositTxs returns builder deposit request txs that are still queued in the

--- a/services/chainservice_builder_requests.go
+++ b/services/chainservice_builder_requests.go
@@ -99,36 +99,75 @@ func (bs *ChainService) GetBuilderDepositsByFilter(ctx context.Context, filter *
 		}
 	}
 
-	bs.matchSentinelBuilderDepositTxs(ctx, combinedResults, canonicalForkIds)
+	bs.matchBuilderDepositTxsByContent(ctx, combinedResults, canonicalForkIds)
 
 	return combinedResults, totalPendingTxResults, totalReqResults
 }
 
-// matchSentinelBuilderDepositTxs links included builder deposits to request txs that are still
-// stored with the dequeue-block sentinel (0).
+// builderDepositContentKey identifies a builder deposit by what it contains rather than where it
+// sits. Pubkey, amount and signature together are unique per deposit, so the same key can be
+// derived from the consensus request and from the execution transaction that produced it.
+func builderDepositContentKey(pubkey []byte, amount uint64, signature []byte) string {
+	return fmt.Sprintf("%x-%d-%x", pubkey, amount, signature)
+}
+
+// matchBuilderDepositTxsByContent links included builder deposits to the request txs they came
+// from, pairing them by content rather than by position in the block.
 //
-// Requests enqueued before the activation fork keep that sentinel until the fork boundary is
-// finalized and the dequeue rebase runs, and the transaction matcher pairs rows by dequeue
-// block - so on a chain that has not finalized past the fork yet, those deposits would show no
-// transaction at all. They are matched by content instead (pubkey, amount, signature is unique
-// per deposit), consumed in queue order so repeated identical top-ups pair one to one.
-func (bs *ChainService) matchSentinelBuilderDepositTxs(ctx context.Context, results []*CombinedBuilderDeposit, canonicalForkIds []uint64) {
+// It covers two cases the dequeue-block pairing cannot:
+//
+//   - Requests enqueued before the activation fork keep the dequeue-block sentinel (0) until the
+//     fork boundary is finalized and the dequeue rebase runs, so there is no dequeue block to
+//     pair on at all.
+//   - A block that mixes those sentinel requests with normally dequeued ones breaks positional
+//     pairing outright: the deposit's SlotIndex counts every request in the block, while the
+//     dequeued transactions are only the subset enqueued after the fork. The first blocks after
+//     activation are exactly that mix.
+//
+// Candidates are consumed in queue order, so repeated identical top-ups pair one to one.
+func (bs *ChainService) matchBuilderDepositTxsByContent(ctx context.Context, results []*CombinedBuilderDeposit, canonicalForkIds []uint64) {
 	pubkeys := make([][]byte, 0, len(results))
+	minBlock, maxBlock, haveBlocks := uint64(0), uint64(0), false
+
 	for _, result := range results {
-		if result.Request != nil && result.Transaction == nil {
-			pubkeys = append(pubkeys, result.Request.PublicKey)
+		if result.Request == nil || result.Transaction != nil {
+			continue
+		}
+
+		pubkeys = append(pubkeys, result.Request.PublicKey)
+
+		if blockNumber := result.Request.BlockNumber; blockNumber > 0 {
+			if !haveBlocks || blockNumber < minBlock {
+				minBlock = blockNumber
+			}
+			if !haveBlocks || blockNumber > maxBlock {
+				maxBlock = blockNumber
+			}
+			haveBlocks = true
 		}
 	}
+
 	if len(pubkeys) == 0 {
 		return
 	}
 
-	sentinelTxs := make(map[string][]*dbtypes.BuilderDepositTx)
-	for _, depositTx := range db.GetBuilderDepositTxsWithSentinelDequeue(ctx, pubkeys) {
-		key := fmt.Sprintf("%x-%d-%x", depositTx.PublicKey, depositTx.Amount, depositTx.Signature)
-		sentinelTxs[key] = append(sentinelTxs[key], depositTx)
+	candidates := make(map[string][]*dbtypes.BuilderDepositTx)
+	addCandidate := func(depositTx *dbtypes.BuilderDepositTx) {
+		key := builderDepositContentKey(depositTx.PublicKey, depositTx.Amount, depositTx.Signature)
+		candidates[key] = append(candidates[key], depositTx)
 	}
-	if len(sentinelTxs) == 0 {
+
+	for _, depositTx := range db.GetBuilderDepositTxsWithSentinelDequeue(ctx, pubkeys) {
+		addCandidate(depositTx)
+	}
+
+	if haveBlocks {
+		for _, depositTx := range db.GetBuilderDepositTxsByDequeueRange(ctx, minBlock, maxBlock) {
+			addCandidate(depositTx)
+		}
+	}
+
+	if len(candidates) == 0 {
 		return
 	}
 
@@ -137,15 +176,16 @@ func (bs *ChainService) matchSentinelBuilderDepositTxs(ctx context.Context, resu
 			continue
 		}
 
-		key := fmt.Sprintf("%x-%d-%x", result.Request.PublicKey, result.Request.Amount, result.Request.Signature)
-		candidates := sentinelTxs[key]
-		if len(candidates) == 0 {
+		key := builderDepositContentKey(result.Request.PublicKey, result.Request.Amount, result.Request.Signature)
+
+		matches := candidates[key]
+		if len(matches) == 0 {
 			continue
 		}
 
-		result.Transaction = candidates[0]
-		result.TransactionOrphaned = !bs.isCanonicalForkId(candidates[0].ForkId, canonicalForkIds)
-		sentinelTxs[key] = candidates[1:]
+		result.Transaction = matches[0]
+		result.TransactionOrphaned = !bs.isCanonicalForkId(matches[0].ForkId, canonicalForkIds)
+		candidates[key] = matches[1:]
 	}
 }
 
@@ -170,11 +210,33 @@ func (bs *ChainService) GetQueuedBuilderDepositTxs(ctx context.Context, filter *
 	return results, totalRows
 }
 
+// matchBuilderDepositTxOnTheFly pairs a single included deposit with the request tx dequeued at
+// its execution block, for deposits the persistent transaction matcher has not reached yet.
+//
+// The pairing is positional — the n-th request in the block is the n-th transaction dequeued at
+// that block — which only holds while every request in the block came through the dequeue. It
+// does not hold in the blocks right after activation, where requests enqueued before the fork are
+// mixed in carrying the dequeue-block sentinel instead. So the positional pick is only accepted
+// when the transaction it lands on actually contains this deposit; otherwise it is left for
+// matchBuilderDepositTxsByContent, which pairs by content and does not care about position.
+// Returning nothing is right here — returning the wrong transaction would be worse than showing
+// none at all.
 func (bs *ChainService) matchBuilderDepositTxOnTheFly(ctx context.Context, dbOperation *dbtypes.BuilderDeposit, canonicalForkIds []uint64) (*dbtypes.BuilderDepositTx, bool) {
+	depositKey := builderDepositContentKey(dbOperation.PublicKey, dbOperation.Amount, dbOperation.Signature)
+
+	accept := func(tx *dbtypes.BuilderDepositTx) (*dbtypes.BuilderDepositTx, bool) {
+		if builderDepositContentKey(tx.PublicKey, tx.Amount, tx.Signature) != depositKey {
+			return nil, false
+		}
+
+		return tx, !bs.isCanonicalForkId(tx.ForkId, canonicalForkIds)
+	}
+
 	requestTxs := db.GetBuilderDepositTxsByDequeueRange(ctx, dbOperation.BlockNumber, dbOperation.BlockNumber)
 	if len(requestTxs) == 1 {
-		return requestTxs[0], !bs.isCanonicalForkId(requestTxs[0].ForkId, canonicalForkIds)
+		return accept(requestTxs[0])
 	}
+
 	if len(requestTxs) > 1 {
 		forkIds := bs.GetParentForkIds(beacon.ForkKey(dbOperation.ForkId))
 		isParentFork := func(forkId uint64) bool {
@@ -194,8 +256,7 @@ func (bs *ChainService) matchBuilderDepositTxOnTheFly(ctx context.Context, dbOpe
 		}
 
 		if len(matchingTxs) >= int(dbOperation.SlotIndex)+1 {
-			tx := matchingTxs[dbOperation.SlotIndex]
-			return tx, !bs.isCanonicalForkId(tx.ForkId, canonicalForkIds)
+			return accept(matchingTxs[dbOperation.SlotIndex])
 		}
 	}
 

--- a/services/chainservice_builder_requests_test.go
+++ b/services/chainservice_builder_requests_test.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/dora/dbtypes"
+	"github.com/stretchr/testify/require"
+)
+
+func depositTx(pubkey byte, amount uint64, sig byte, dequeue uint64) *dbtypes.BuilderDepositTx {
+	return &dbtypes.BuilderDepositTx{
+		PublicKey:    []byte{pubkey},
+		Amount:       amount,
+		Signature:    []byte{sig},
+		DequeueBlock: dequeue,
+		TxHash:       []byte{pubkey, sig},
+	}
+}
+
+func includedDeposit(pubkey byte, amount uint64, sig byte, slotIndex uint64, blockNumber uint64) *CombinedBuilderDeposit {
+	return &CombinedBuilderDeposit{
+		Request: &dbtypes.BuilderDeposit{
+			PublicKey:   []byte{pubkey},
+			Amount:      amount,
+			Signature:   []byte{sig},
+			SlotIndex:   slotIndex,
+			BlockNumber: blockNumber,
+		},
+	}
+}
+
+// TestBuilderDepositContentKeyIdentifiesADeposit is the property the whole pairing rests on: the
+// key must be derivable identically from the consensus request and the execution transaction, and
+// must separate deposits that differ in any of the three fields.
+func TestBuilderDepositContentKeyIdentifiesADeposit(t *testing.T) {
+	tx := depositTx(0xaa, 50, 0x11, 48364)
+	request := includedDeposit(0xaa, 50, 0x11, 7, 48364).Request
+
+	require.Equal(t,
+		builderDepositContentKey(tx.PublicKey, tx.Amount, tx.Signature),
+		builderDepositContentKey(request.PublicKey, request.Amount, request.Signature),
+		"the same deposit must key the same from either side")
+
+	base := builderDepositContentKey([]byte{0xaa}, 50, []byte{0x11})
+	require.NotEqual(t, base, builderDepositContentKey([]byte{0xab}, 50, []byte{0x11}), "pubkey must matter")
+	require.NotEqual(t, base, builderDepositContentKey([]byte{0xaa}, 51, []byte{0x11}), "amount must matter")
+	require.NotEqual(t, base, builderDepositContentKey([]byte{0xaa}, 50, []byte{0x12}), "signature must matter")
+}
+
+// TestPositionalPickIsRejectedInAMixedBlock is the bug this fixes. In the blocks right after
+// activation a block holds both requests enqueued before the fork (dequeue-block sentinel) and
+// normally dequeued ones. SlotIndex counts every request in the block while the dequeued
+// transactions are only the post-fork subset, so the positional pick lands on the wrong
+// transaction — and must be refused rather than shown.
+func TestPositionalPickIsRejectedInAMixedBlock(t *testing.T) {
+	// block holds 4 requests; only the last two came through the dequeue
+	dequeued := []*dbtypes.BuilderDepositTx{
+		depositTx(0xc0, 50, 0x33, 48364),
+		depositTx(0xd0, 50, 0x44, 48364),
+	}
+
+	// the third request (SlotIndex 2) is the first dequeued one
+	request := includedDeposit(0xc0, 50, 0x33, 2, 48364).Request
+
+	// positional pick at SlotIndex 2 would need 3 candidates; with 2 it is out of range, and even
+	// at SlotIndex 1 it would land on 0xd0 rather than this deposit's own 0xc0
+	wrong := dequeued[1]
+	require.NotEqual(t,
+		builderDepositContentKey(wrong.PublicKey, wrong.Amount, wrong.Signature),
+		builderDepositContentKey(request.PublicKey, request.Amount, request.Signature),
+		"the positionally-picked transaction is not this deposit's")
+}
+
+// TestContentMatchPairsRepeatedTopUpsOneToOne guards the consumption behaviour: identical
+// top-ups share a content key, so each must take a distinct transaction rather than all
+// pointing at the first one.
+func TestContentMatchPairsRepeatedTopUpsOneToOne(t *testing.T) {
+	candidates := map[string][]*dbtypes.BuilderDepositTx{}
+	key := builderDepositContentKey([]byte{0xaa}, 50, []byte{0x11})
+	candidates[key] = []*dbtypes.BuilderDepositTx{
+		{PublicKey: []byte{0xaa}, Amount: 50, Signature: []byte{0x11}, TxHash: []byte{0x01}},
+		{PublicKey: []byte{0xaa}, Amount: 50, Signature: []byte{0x11}, TxHash: []byte{0x02}},
+	}
+
+	results := []*CombinedBuilderDeposit{
+		includedDeposit(0xaa, 50, 0x11, 0, 48364),
+		includedDeposit(0xaa, 50, 0x11, 1, 48364),
+	}
+
+	// mirrors the consumption in matchBuilderDepositTxsByContent
+	for _, result := range results {
+		k := builderDepositContentKey(result.Request.PublicKey, result.Request.Amount, result.Request.Signature)
+		matches := candidates[k]
+		require.NotEmpty(t, matches)
+		result.Transaction = matches[0]
+		candidates[k] = matches[1:]
+	}
+
+	require.Equal(t, []byte{0x01}, results[0].Transaction.TxHash)
+	require.Equal(t, []byte{0x02}, results[1].Transaction.TxHash,
+		"the second identical top-up must take the second transaction, not repeat the first")
+}

--- a/services/chainservice_deposits.go
+++ b/services/chainservice_deposits.go
@@ -459,6 +459,61 @@ func (q *IndexedDepositQueue) EstimateAppendedDepositEpoch(amount phase0.Gwei) p
 	return queueEpoch
 }
 
+// depositQueueIndexCache memoizes the EL deposit index resolution of pending-deposit queue
+// snapshots. Resolving costs a db round trip covering every slot present in the queue, while
+// the snapshot itself only changes once per epoch — without the cache every page render (and
+// every page of a paginated render) would repeat it. It also keeps a paginated walk
+// consistent, as all pages then resolve against the same snapshot.
+type depositQueueIndexCache struct {
+	mutex   sync.Mutex
+	entries map[phase0.Root]*resolvedDepositQueueIndexes
+	order   []phase0.Root
+}
+
+// resolvedDepositQueueIndexes is one snapshot's resolution result, keyed by the block root
+// the snapshot was taken at.
+type resolvedDepositQueueIndexes struct {
+	queueLen  int
+	indexes   []*uint64
+	postponed []bool
+}
+
+// depositQueueIndexCacheSize is the number of queue snapshots kept. A handful covers the
+// canonical chain plus the sibling forks that are live at any moment.
+const depositQueueIndexCacheSize = 4
+
+func (c *depositQueueIndexCache) get(root phase0.Root, queueLen int) *resolvedDepositQueueIndexes {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	cached := c.entries[root]
+	if cached == nil || cached.queueLen != queueLen {
+		// A different length means the snapshot advanced under the same root; recompute.
+		return nil
+	}
+
+	return cached
+}
+
+func (c *depositQueueIndexCache) put(root phase0.Root, resolved *resolvedDepositQueueIndexes) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.entries == nil {
+		c.entries = make(map[phase0.Root]*resolvedDepositQueueIndexes, depositQueueIndexCacheSize)
+	}
+
+	if _, exists := c.entries[root]; !exists {
+		c.order = append(c.order, root)
+		for len(c.order) > depositQueueIndexCacheSize {
+			delete(c.entries, c.order[0])
+			c.order = c.order[1:]
+		}
+	}
+
+	c.entries[root] = resolved
+}
+
 func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *beacon.Block) *IndexedDepositQueue {
 	if headBlock == nil {
 		return nil
@@ -486,19 +541,30 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 	// The churn-simulation residual below is still populated for an empty queue (so the
 	// safety estimate for a newly appended deposit works), hence no early return here.
 	if len(queue) > 0 {
-		// Assign EL deposit indexes by position, flagging postponed (reordered) entries
-		// that must instead be resolved by slot.
-		indexes, postponed := resolveQueueDepositIndexes(queue, lastIncludedDeposit)
-		for idx := range indexedQueue.Queue {
-			indexedQueue.Queue[idx].DepositIndex = indexes[idx]
+		resolved := bs.depositQueueIndexes.get(queueBlockRoot, len(queue))
+		if resolved == nil {
+			// The positional (anchor + backward count) shortcut is only valid while the queue is
+			// a contiguous suffix of the deposit stream. Gloas breaks that for good, so from the
+			// fork onwards every entry is resolved by slot.
+			chainState := bs.consensusPool.GetChainState()
+			allowPositional := !chainState.IsEip7732Enabled(chainState.EpochOfSlot(queueSlot))
+
+			indexes, postponed, resolveBySlot := resolveQueueDepositIndexes(queue, lastIncludedDeposit, allowPositional)
+
+			// Resolve the remaining entries by slot (one batched query).
+			for idx, depositIndex := range bs.resolveDepositIndexesBySlot(ctx, queue, resolveBySlot) {
+				if depositIndex != nil {
+					indexes[idx] = depositIndex
+				}
+			}
+
+			resolved = &resolvedDepositQueueIndexes{queueLen: len(queue), indexes: indexes, postponed: postponed}
+			bs.depositQueueIndexes.put(queueBlockRoot, resolved)
 		}
 
-		// Resolve postponed entries by slot (one batched query) and flag them for rendering.
-		bs.resolvePostponedDepositIndexes(ctx, queue, indexedQueue.Queue, postponed)
 		for idx := range indexedQueue.Queue {
-			if postponed[idx] {
-				indexedQueue.Queue[idx].Postponed = true
-			}
+			indexedQueue.Queue[idx].DepositIndex = resolved.indexes[idx]
+			indexedQueue.Queue[idx].Postponed = resolved.postponed[idx]
 		}
 	}
 
@@ -554,8 +620,9 @@ func (bs *ChainService) GetIndexedDepositQueue(ctx context.Context, headBlock *b
 	chainState := bs.consensusPool.GetChainState()
 	specs := chainState.GetSpecs()
 
-	activationExitChurnLimit := phase0.Gwei(chainState.GetActivationExitChurnLimit(uint64(totalActiveBalance)))
 	queueEpoch := chainState.EpochOfSlot(queueSlot)
+	// Deposits consume the activation-only churn budget from Gloas on (EIP-8061).
+	activationExitChurnLimit := phase0.Gwei(chainState.GetActivationChurnLimit(queueEpoch, uint64(totalActiveBalance)))
 
 	maxPendingDepositsPerEpoch := specs.MaxPendingDepositsPerEpoch
 	if maxPendingDepositsPerEpoch == 0 {
@@ -647,30 +714,36 @@ func (bs *ChainService) postponedDepositEpoch(pubkey phase0.BLSPubKey) phase0.Ep
 	return validator.Validator.WithdrawableEpoch
 }
 
-// resolveQueueDepositIndexes assigns an EL deposit index to each queue entry by position
-// and flags the postponed (reordered) entries. It returns, per entry, the resolved index
-// (nil where it must be resolved by slot) and whether the entry is postponed.
+// resolveQueueDepositIndexes assigns an EL deposit index to each queue entry and reports,
+// per entry, the resolved index (nil where it must be resolved by slot), whether the entry
+// is postponed, and whether it needs slot-based resolution.
 //
 // pending_deposits comes verbatim from the beacon state but carries no EL deposit index.
-// Regular deposits sit in the queue in strict slot<->index order, so their indexes are
-// derived by anchoring the tail to the last included deposit and counting backwards.
+// Before Gloas the queue is a contiguous suffix of the deposit stream, so indexes can be
+// derived by anchoring the tail to the last included deposit and counting backwards; this
+// is what allowPositional enables.
 //
-// process_pending_deposits moves deposits of an exiting validator to the back of the
-// queue, breaking that order. Such postponed entries surface as a slot that dips below
-// the running maximum; they are excluded from the backward count (left nil) and resolved
-// individually by slot afterwards. Detection is purely slot-based (independent of the
-// possibly-delayed validator set) so the assigned index is always correct.
+// Gloas breaks that assumption permanently, so allowPositional must be false once the fork
+// is active: onboard_builders_from_pending_deposits drops entries out of the middle of the
+// queue at the fork, and process_deposit_request applies builder deposits straight to the
+// builder registry without ever queueing them. Both leave gaps in the index sequence and
+// make the last included deposit an unreliable anchor.
 //
-// 0x01->0x02 compounding-switch deposits are synthesized in the queue with no EL deposit
-// at all; they are skipped entirely. Every other queue entry maps to a real EL deposit in
-// contiguous index order (post-Gloas builder deposits arrive via the separate builder
-// deposit contract and never appear in the regular deposit stream), so each non-postponed
-// entry simply takes the next index below the anchor.
-func resolveQueueDepositIndexes(queue []*electra.PendingDeposit, anchor *dbtypes.Deposit) (indexes []*uint64, postponed []bool) {
+// process_pending_deposits additionally moves deposits of an exiting validator to the back
+// of the queue. Such postponed entries surface as a slot that dips below the running
+// maximum. Being postponed is a chain fact (it changes how the deposit is processed and is
+// rendered as such), which is why it is reported separately from needing slot-based
+// resolution — a failed anchor check means only the latter.
+//
+// 0x01->0x02 compounding-switch deposits are synthesized in the queue with no EL deposit at
+// all; they are skipped entirely.
+func resolveQueueDepositIndexes(queue []*electra.PendingDeposit, anchor *dbtypes.Deposit, allowPositional bool) (indexes []*uint64, postponed, resolveBySlot []bool) {
 	indexes = make([]*uint64, len(queue))
 	postponed = make([]bool, len(queue))
+	resolveBySlot = make([]bool, len(queue))
 
-	// Forward pass: flag entries whose slot dips below the running maximum.
+	// Forward pass: flag entries whose slot dips below the running maximum. Postponed entries
+	// no longer follow the queue's slot<->index order, so they always need slot resolution.
 	prevRegularSlot := phase0.Slot(0)
 	for idx, deposit := range queue {
 		if isSyntheticPendingDeposit(deposit) {
@@ -678,9 +751,21 @@ func resolveQueueDepositIndexes(queue []*electra.PendingDeposit, anchor *dbtypes
 		}
 		if deposit.Slot < prevRegularSlot {
 			postponed[idx] = true
+			resolveBySlot[idx] = true
 			continue
 		}
 		prevRegularSlot = deposit.Slot
+	}
+
+	if !allowPositional {
+		for idx, deposit := range queue {
+			if isSyntheticPendingDeposit(deposit) {
+				continue
+			}
+			resolveBySlot[idx] = true
+		}
+
+		return indexes, postponed, resolveBySlot
 	}
 
 	// Backward pass: assign indexes to the regular (in-order) entries.
@@ -705,10 +790,10 @@ func resolveQueueDepositIndexes(queue []*electra.PendingDeposit, anchor *dbtypes
 	}
 
 	// Anchor verification. The tail-most regular entry must align with the anchor's slot.
-	// If it doesn't (a degenerate queue whose most recent deposits are all postponed or
-	// builder deposits, so the anchor is not the real tail), the positional assignment
-	// cannot be trusted and every non-synthetic entry is resolved by slot instead. This
-	// recovers the "queue is nothing but postponed deposits" case, which has no slot dip.
+	// If it doesn't (a degenerate queue whose most recent deposits are all postponed, so the
+	// anchor is not the real tail), the positional assignment cannot be trusted and every
+	// non-synthetic entry is resolved by slot instead. This recovers the "queue is nothing
+	// but postponed deposits" case, which has no slot dip.
 	anchorVerified := tailRegularIdx >= 0 && anchor != nil &&
 		queue[tailRegularIdx].Slot == phase0.Slot(anchor.SlotNumber)
 	if !anchorVerified {
@@ -716,30 +801,27 @@ func resolveQueueDepositIndexes(queue []*electra.PendingDeposit, anchor *dbtypes
 			if isSyntheticPendingDeposit(deposit) {
 				continue
 			}
-			postponed[idx] = true
+			resolveBySlot[idx] = true
 			indexes[idx] = nil
 		}
 	}
 
-	return indexes, postponed
+	return indexes, postponed, resolveBySlot
 }
 
-// resolvePostponedDepositIndexes fills in the EL deposit index of queue entries flagged
-// as postponed. These were reordered out of the queue's slot<->index sequence, so they
-// can't be aligned by position; instead they are looked up in a single batched query by
-// their slot (which equals the beacon state's PendingDeposit.slot) and matched on
-// (slot, pubkey, amount, withdrawal_credentials). Byte-identical deposits sharing a slot
-// are consumed in slot_index order, matching their queue order. Entries with no DB match
-// are left without an index rather than wrongly assigned.
-func (bs *ChainService) resolvePostponedDepositIndexes(ctx context.Context, queue []*electra.PendingDeposit, entries []*IndexedDepositQueueEntry, postponed []bool) {
+// resolveDepositIndexesBySlot resolves the EL deposit index of the queue entries that cannot
+// be aligned by position (postponed entries, and every entry once Gloas is active) with a
+// single batched query over the slots they were included in, and returns the indexes per
+// queue position (nil where nothing was resolved).
+func (bs *ChainService) resolveDepositIndexesBySlot(ctx context.Context, queue []*electra.PendingDeposit, resolveBySlot []bool) []*uint64 {
 	slotSet := make(map[uint64]struct{})
-	for idx, isPostponed := range postponed {
-		if isPostponed {
+	for idx, needsSlot := range resolveBySlot {
+		if needsSlot {
 			slotSet[uint64(queue[idx].Slot)] = struct{}{}
 		}
 	}
 	if len(slotSet) == 0 {
-		return
+		return nil
 	}
 
 	slots := make([]uint64, 0, len(slotSet))
@@ -749,16 +831,24 @@ func (bs *ChainService) resolvePostponedDepositIndexes(ctx context.Context, queu
 
 	rows, err := db.GetDepositRequestsBySlots(ctx, slots, bs.GetCanonicalForkIds())
 	if err != nil {
-		logrus.Warnf("ChainService.resolvePostponedDepositIndexes error: %v", err)
-		return
+		logrus.Warnf("ChainService.resolveDepositIndexesBySlot error: %v", err)
+		return nil
 	}
+
+	return assignDepositIndexesBySlot(queue, resolveBySlot, rows)
+}
+
+// assignDepositIndexesBySlot pairs the flagged queue entries with the deposits included in
+// their slot, matched on (slot, pubkey, amount, withdrawal_credentials). rows must be ordered
+// by (slot_number, slot_index), i.e. in inclusion order. Entries that are not flagged, or have
+// no matching deposit, get a nil index.
+func assignDepositIndexesBySlot(queue []*electra.PendingDeposit, resolveBySlot []bool, rows []*dbtypes.Deposit) []*uint64 {
+	indexes := make([]*uint64, len(queue))
 
 	depositKey := func(slot, amount uint64, pubkey, wdcreds []byte) string {
 		return fmt.Sprintf("%d-%x-%d-%x", slot, pubkey, amount, wdcreds)
 	}
 
-	// Rows arrive ordered by (slot_number, slot_index), so identical deposits keep their
-	// inclusion order within each key.
 	indexesByKey := make(map[string][]uint64, len(rows))
 	for _, row := range rows {
 		if row.Index == nil {
@@ -768,27 +858,44 @@ func (bs *ChainService) resolvePostponedDepositIndexes(ctx context.Context, queu
 		indexesByKey[key] = append(indexesByKey[key], *row.Index)
 	}
 
-	for idx, isPostponed := range postponed {
-		if !isPostponed {
+	// Walk back to front and hand out the highest index first: the chain drains the queue from
+	// the front in index order, so what a slot still has queued is its tail. Front-to-back
+	// assignment would give the queue's head slot - the only partially drained one - the
+	// indexes of deposits that were already applied, and with them the wrong transactions.
+	for idx := len(resolveBySlot) - 1; idx >= 0; idx-- {
+		if !resolveBySlot[idx] {
 			continue
 		}
+
 		deposit := queue[idx]
 		key := depositKey(uint64(deposit.Slot), uint64(deposit.Amount), deposit.Pubkey[:], deposit.WithdrawalCredentials)
-		indexes := indexesByKey[key]
-		if len(indexes) == 0 {
+		candidates := indexesByKey[key]
+		if len(candidates) == 0 {
 			continue
 		}
-		depositIndexCopy := indexes[0]
-		indexesByKey[key] = indexes[1:]
-		entries[idx].DepositIndex = &depositIndexCopy
+
+		depositIndexCopy := candidates[len(candidates)-1]
+		indexesByKey[key] = candidates[:len(candidates)-1]
+		indexes[idx] = &depositIndexCopy
 	}
+
+	return indexes
 }
 
 // isSyntheticPendingDeposit reports whether a pending deposit was synthesized during
 // state transition (queue_excess_active_balance, e.g. a 0x01->0x02 compounding switch)
-// rather than created from an EL deposit. Such deposits carry the G2 point-at-infinity
-// signature (0xc0 followed by zeros) and have no corresponding EL deposit index.
+// rather than created from an EL deposit. Such deposits have no corresponding EL deposit
+// index.
+//
+// The spec uses two markers together: the G2 point-at-infinity signature as a placeholder
+// "and GENESIS_SLOT to distinguish from a pending deposit request"
+// (specs/electra/beacon-chain.md, queue_excess_active_balance). Both are required — the
+// deposit contract happily accepts a real deposit carrying the point-at-infinity signature,
+// and treating those as synthetic would drop their EL index and transaction link.
 func isSyntheticPendingDeposit(deposit *electra.PendingDeposit) bool {
+	if deposit.Slot != 0 {
+		return false
+	}
 	if deposit.Signature[0] != 0xc0 {
 		return false
 	}

--- a/services/chainservice_deposits_test.go
+++ b/services/chainservice_deposits_test.go
@@ -16,9 +16,20 @@ func regularDeposit(slot phase0.Slot, pubkeyByte byte) *electra.PendingDeposit {
 	return d
 }
 
-// syntheticDeposit builds a synthesized (0x01->0x02 compounding switch) pending deposit
-// carrying the G2 point-at-infinity signature.
-func syntheticDeposit(slot phase0.Slot, pubkeyByte byte) *electra.PendingDeposit {
+// syntheticDeposit builds a synthesized (0x01->0x02 compounding switch) pending deposit:
+// the G2 point-at-infinity signature at GENESIS_SLOT, which is how queue_excess_active_balance
+// marks a deposit that has no EL counterpart.
+func syntheticDeposit(pubkeyByte byte) *electra.PendingDeposit {
+	d := &electra.PendingDeposit{Slot: 0}
+	d.Pubkey[0] = pubkeyByte
+	d.Signature[0] = 0xc0
+	return d
+}
+
+// infinitySigDeposit builds a real EL deposit that happens to carry the G2 point-at-infinity
+// signature. The deposit contract accepts any 96-byte signature, so these exist on chain and
+// must NOT be mistaken for synthesized deposits.
+func infinitySigDeposit(slot phase0.Slot, pubkeyByte byte) *electra.PendingDeposit {
 	d := &electra.PendingDeposit{Slot: slot}
 	d.Pubkey[0] = pubkeyByte
 	d.Signature[0] = 0xc0
@@ -52,7 +63,7 @@ func buildQueue(roles []queueRole) ([]*electra.PendingDeposit, []queueRole) {
 		pubkey := byte(i % 251)
 		switch role {
 		case roleSynthetic:
-			queue[i] = syntheticDeposit(nextRegularSlot, pubkey)
+			queue[i] = syntheticDeposit(pubkey)
 		case rolePostponed:
 			// far below any regular slot so it always dips below the running max
 			queue[i] = regularDeposit(10+phase0.Slot(i), pubkey)
@@ -98,6 +109,7 @@ func TestResolveQueueDepositIndexes(t *testing.T) {
 		anchor        *dbtypes.Deposit
 		wantIndexes   []*uint64
 		wantPostponed []bool
+		wantBySlot    []bool
 	}{
 		{
 			name:          "contiguous regular deposits",
@@ -105,6 +117,7 @@ func TestResolveQueueDepositIndexes(t *testing.T) {
 			anchor:        anchorAt(5, 12),
 			wantIndexes:   []*uint64{u64p(3), u64p(4), u64p(5)},
 			wantPostponed: []bool{false, false, false},
+			wantBySlot:    []bool{false, false, false},
 		},
 		{
 			name:          "postponed entry dips below running max slot",
@@ -112,13 +125,15 @@ func TestResolveQueueDepositIndexes(t *testing.T) {
 			anchor:        anchorAt(5, 11),
 			wantIndexes:   []*uint64{u64p(4), u64p(5), nil},
 			wantPostponed: []bool{false, false, true},
+			wantBySlot:    []bool{false, false, true},
 		},
 		{
 			name:          "synthetic compounding-switch deposit is skipped, not postponed",
-			queue:         []*electra.PendingDeposit{regularDeposit(10, 1), syntheticDeposit(10, 2), regularDeposit(11, 3)},
+			queue:         []*electra.PendingDeposit{regularDeposit(10, 1), syntheticDeposit(2), regularDeposit(11, 3)},
 			anchor:        anchorAt(5, 11),
 			wantIndexes:   []*uint64{u64p(4), nil, u64p(5)},
 			wantPostponed: []bool{false, false, false},
+			wantBySlot:    []bool{false, false, false},
 		},
 		{
 			name:          "0xB0 (builder-cred) regular deposit is indexed contiguously like any validator deposit",
@@ -126,26 +141,43 @@ func TestResolveQueueDepositIndexes(t *testing.T) {
 			anchor:        anchorAt(8, 11),
 			wantIndexes:   []*uint64{u64p(7), u64p(8)},
 			wantPostponed: []bool{false, false},
+			wantBySlot:    []bool{false, false},
 		},
 		{
-			name:          "anchor slot mismatch falls back to slot resolution for all entries",
+			name:          "anchor slot mismatch falls back to slot resolution without claiming the entry is postponed",
 			queue:         []*electra.PendingDeposit{regularDeposit(10, 1)},
 			anchor:        anchorAt(5, 20),
 			wantIndexes:   []*uint64{nil},
-			wantPostponed: []bool{true},
+			wantPostponed: []bool{false},
+			wantBySlot:    []bool{true},
 		},
 		{
 			name:          "nil anchor leaves every entry to slot resolution",
 			queue:         []*electra.PendingDeposit{regularDeposit(10, 1), regularDeposit(11, 2)},
 			anchor:        nil,
 			wantIndexes:   []*uint64{nil, nil},
-			wantPostponed: []bool{true, true},
+			wantPostponed: []bool{false, false},
+			wantBySlot:    []bool{true, true},
+		},
+		{
+			name:          "real deposit with a point-at-infinity signature is indexed like any other",
+			queue:         []*electra.PendingDeposit{regularDeposit(10, 1), infinitySigDeposit(11, 2), regularDeposit(12, 3)},
+			anchor:        anchorAt(9, 12),
+			wantIndexes:   []*uint64{u64p(7), u64p(8), u64p(9)},
+			wantPostponed: []bool{false, false, false},
+			wantBySlot:    []bool{false, false, false},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			indexes, postponed := resolveQueueDepositIndexes(tt.queue, tt.anchor)
+			indexes, postponed, bySlot := resolveQueueDepositIndexes(tt.queue, tt.anchor, true)
+
+			for i := range tt.wantBySlot {
+				if bySlot[i] != tt.wantBySlot[i] {
+					t.Errorf("resolveBySlot[%d] = %v, want %v", i, bySlot[i], tt.wantBySlot[i])
+				}
+			}
 
 			if len(postponed) != len(tt.wantPostponed) {
 				t.Fatalf("postponed length = %d, want %d", len(postponed), len(tt.wantPostponed))
@@ -263,7 +295,7 @@ func TestResolveQueueDepositIndexesRealistic(t *testing.T) {
 			anchor := anchorAt(tc.anchorIndex, uint64(1000+regCount-1))
 
 			wantIndexes, wantPostponed := expectedFor(roles, tc.anchorIndex)
-			gotIndexes, gotPostponed := resolveQueueDepositIndexes(queue, anchor)
+			gotIndexes, gotPostponed, _ := resolveQueueDepositIndexes(queue, anchor, true)
 
 			if len(gotIndexes) != len(queue) || len(gotPostponed) != len(queue) {
 				t.Fatalf("result lengths = (%d,%d), want %d", len(gotIndexes), len(gotPostponed), len(queue))
@@ -297,13 +329,135 @@ func TestResolveQueueDepositIndexesStuckDepositsFallback(t *testing.T) {
 	}
 	anchor := anchorAt(9_000_000, 5_000_000) // recent, unrelated deposit
 
-	indexes, postponed := resolveQueueDepositIndexes(queue, anchor)
+	indexes, postponed, bySlot := resolveQueueDepositIndexes(queue, anchor, true)
 	for i := range queue {
-		if !postponed[i] {
-			t.Errorf("postponed[%d] = false, want true (slot fallback)", i)
+		if !bySlot[i] {
+			t.Errorf("resolveBySlot[%d] = false, want true (slot fallback)", i)
+		}
+		if postponed[i] {
+			t.Errorf("postponed[%d] = true, want false (the entries are stuck, not reordered)", i)
 		}
 		if indexes[i] != nil {
 			t.Errorf("index[%d] = %d, want nil (slot fallback)", i, *indexes[i])
 		}
+	}
+}
+
+// TestResolveQueueDepositIndexesPostGloas checks that the positional shortcut is fully
+// disabled once Gloas is active: onboard_builders_from_pending_deposits and the builder
+// fast path in process_deposit_request both leave holes in the deposit index sequence, so
+// every non-synthetic entry must be resolved by slot even though the queue looks in-order.
+func TestResolveQueueDepositIndexesPostGloas(t *testing.T) {
+	queue := []*electra.PendingDeposit{
+		regularDeposit(1000, 1),
+		syntheticDeposit(2),
+		regularDeposit(1001, 3),
+	}
+	anchor := anchorAt(500, 1001) // would verify fine under the positional path
+
+	indexes, postponed, bySlot := resolveQueueDepositIndexes(queue, anchor, false)
+	wantBySlot := []bool{true, false, true}
+	for i := range queue {
+		if bySlot[i] != wantBySlot[i] {
+			t.Errorf("resolveBySlot[%d] = %v, want %v", i, bySlot[i], wantBySlot[i])
+		}
+		if postponed[i] {
+			t.Errorf("postponed[%d] = true, want false", i)
+		}
+		if indexes[i] != nil {
+			t.Errorf("index[%d] = %d, want nil (no positional assignment post-Gloas)", i, *indexes[i])
+		}
+	}
+}
+
+// depositRow builds a db deposit row as GetDepositRequestsBySlots returns them.
+func depositRow(index, slot uint64, pubkeyByte byte, amount uint64) *dbtypes.Deposit {
+	idx := index
+	pubkey := make([]byte, 48)
+	pubkey[0] = pubkeyByte
+
+	return &dbtypes.Deposit{
+		Index:                 &idx,
+		SlotNumber:            slot,
+		PublicKey:             pubkey,
+		WithdrawalCredentials: []byte{0x01},
+		Amount:                amount,
+	}
+}
+
+// queueEntryAt builds a pending deposit matching depositRow's identity fields.
+func queueEntryAt(slot phase0.Slot, pubkeyByte byte, amount phase0.Gwei) *electra.PendingDeposit {
+	d := &electra.PendingDeposit{Slot: slot, Amount: amount}
+	d.Pubkey[0] = pubkeyByte
+	d.WithdrawalCredentials = []byte{0x01}
+
+	return d
+}
+
+// TestAssignDepositIndexesBySlotUsesSlotTail covers the queue's head slot, which the chain has
+// normally already drained part of. Its remaining entries are the LAST deposits of that slot,
+// so they must get the highest indexes - handing out the slot's first indexes instead links
+// each row to a deposit transaction that was already applied.
+func TestAssignDepositIndexesBySlotUsesSlotTail(t *testing.T) {
+	// slot 100 included six identical deposits; only the last three are still queued
+	rows := []*dbtypes.Deposit{
+		depositRow(10, 100, 1, 1_000_000_000),
+		depositRow(11, 100, 1, 1_000_000_000),
+		depositRow(12, 100, 1, 1_000_000_000),
+		depositRow(13, 100, 1, 1_000_000_000),
+		depositRow(14, 100, 1, 1_000_000_000),
+		depositRow(15, 100, 1, 1_000_000_000),
+		// a later, fully queued slot
+		depositRow(20, 101, 2, 1_000_000_000),
+		depositRow(21, 101, 2, 1_000_000_000),
+	}
+
+	queue := []*electra.PendingDeposit{
+		queueEntryAt(100, 1, 1_000_000_000),
+		queueEntryAt(100, 1, 1_000_000_000),
+		queueEntryAt(100, 1, 1_000_000_000),
+		queueEntryAt(101, 2, 1_000_000_000),
+		queueEntryAt(101, 2, 1_000_000_000),
+	}
+	resolveBySlot := []bool{true, true, true, true, true}
+
+	want := []uint64{13, 14, 15, 20, 21}
+	got := assignDepositIndexesBySlot(queue, resolveBySlot, rows)
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d indexes, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] == nil {
+			t.Errorf("index[%d] = nil, want %d", i, want[i])
+			continue
+		}
+		if *got[i] != want[i] {
+			t.Errorf("index[%d] = %d, want %d", i, *got[i], want[i])
+		}
+	}
+}
+
+// TestAssignDepositIndexesBySlotSkipsUnflagged leaves entries that were already resolved
+// positionally untouched, and reports no index for a queue entry with no matching deposit.
+func TestAssignDepositIndexesBySlotSkipsUnflagged(t *testing.T) {
+	rows := []*dbtypes.Deposit{depositRow(7, 100, 1, 1_000_000_000)}
+
+	queue := []*electra.PendingDeposit{
+		queueEntryAt(100, 1, 1_000_000_000),
+		queueEntryAt(100, 1, 1_000_000_000),
+		queueEntryAt(100, 9, 1_000_000_000), // no matching deposit row
+	}
+	resolveBySlot := []bool{false, true, true}
+
+	got := assignDepositIndexesBySlot(queue, resolveBySlot, rows)
+	if got[0] != nil {
+		t.Errorf("index[0] = %d, want nil (not flagged for slot resolution)", *got[0])
+	}
+	if got[1] == nil || *got[1] != 7 {
+		t.Errorf("index[1] = %v, want 7", got[1])
+	}
+	if got[2] != nil {
+		t.Errorf("index[2] = %d, want nil (no matching deposit)", *got[2])
 	}
 }

--- a/templates/builder_deposits/builder_deposits.html
+++ b/templates/builder_deposits/builder_deposits.html
@@ -193,14 +193,14 @@
                       {{ end }}
                     </td>
                     <td>
-                      {{ if $deposit.IsQueuedRegular }}
-                        <span class="badge rounded-pill text-bg-secondary border" data-bs-toggle="tooltip" data-bs-title="Builder index not assigned yet — the deposit stays queued until Gloas activates, and builders onboarded at the fork transition are registered first"><i class="fas fa-hourglass-half mr-1"></i>no index yet</span>
-                      {{ else if $deposit.IsProjected }}
-                        {{ if $deposit.IsQueued }}
-                          <span class="badge rounded-pill text-bg-secondary border" data-bs-toggle="tooltip" data-bs-title="Found in the current pending deposit queue at position {{ $deposit.QueuePosition }}"><i class="fas fa-list-ol mr-1"></i>#{{ $deposit.QueuePosition }}</span>
+                      {{ if $deposit.HasProjectedBuilderIndex }}
+                        {{ if $deposit.IsQueuedRegular }}
+                          <span class="badge rounded-pill text-bg-secondary border" data-bs-toggle="tooltip" data-bs-title="Projected builder index. The deposit stays queued in the builder deposit contract until Gloas activates; the builders onboarded at the fork transition are registered first, so this index continues behind them."><i class="fas fa-hourglass-half mr-1"></i>#{{ $deposit.ProjectedBuilderIndex }}</span>
                         {{ else }}
-                          <span class="text-muted">-</span>
+                          <span class="badge rounded-pill text-bg-secondary border" data-bs-toggle="tooltip" data-bs-title="Projected builder index. Onboarding assigns indexes in deposit order at the Gloas fork transition, so this is an estimate that shifts if earlier deposits are processed before the fork."><i class="fas fa-hourglass-half mr-1"></i>#{{ $deposit.ProjectedBuilderIndex }}</span>
                         {{ end }}
+                      {{ else if or $deposit.IsQueuedRegular $deposit.IsProjected }}
+                        <span class="text-muted">-</span>
                       {{ else if $deposit.HasBuilderIndex }}
                         {{ formatBuilderWithIndex $deposit.BuilderIndex "" }}
                       {{ else if $deposit.IsInactiveBuilder }}
@@ -241,6 +241,12 @@
                         <span class="badge rounded-pill text-bg-secondary">Pending</span>
                       {{ else if $deposit.Orphaned }}
                         <span class="badge rounded-pill text-bg-info">Orphaned</span>
+                      {{ else if eq $deposit.Result 2 }}
+                        <span class="badge rounded-pill text-bg-success" data-bs-toggle="tooltip" data-bs-title="Registered a new builder">New builder</span>
+                      {{ else if eq $deposit.Result 3 }}
+                        <span class="badge rounded-pill text-bg-info" data-bs-toggle="tooltip" data-bs-title="Topped up the balance of an existing builder">Top-up</span>
+                      {{ else if eq $deposit.Result 20 }}
+                        <span class="badge rounded-pill text-bg-danger" data-bs-toggle="tooltip" data-bs-title="Invalid proof-of-possession — dropped without registering a builder">Invalid sig</span>
                       {{ else }}
                         <span class="badge rounded-pill text-bg-success">Included</span>
                       {{ end }}

--- a/types/models/builder_deposits.go
+++ b/types/models/builder_deposits.go
@@ -79,8 +79,10 @@ type BuilderDepositsPageDataDeposit struct {
 
 	// Pre-Gloas projection fields (set when the parent page is in projection mode).
 	IsProjected               bool      `json:"is_projected"`
-	IsQueuedRegular           bool      `json:"is_queued_regular"` // regular deposit queued in the builder deposit contract until the fork; no builder index assigned yet
-	HasDepositIndex           bool      `json:"has_deposit_index"` // EL deposit index of the deposit
+	IsQueuedRegular           bool      `json:"is_queued_regular"` // regular deposit queued in the builder deposit contract until the fork
+	HasProjectedBuilderIndex  bool      `json:"has_projected_builder_index"`
+	ProjectedBuilderIndex     uint64    `json:"projected_builder_index"` // builder index this deposit is projected to register or top up
+	HasDepositIndex           bool      `json:"has_deposit_index"`       // EL deposit index of the deposit
 	DepositIndex              uint64    `json:"deposit_index"`
 	EstimatedTime             time.Time `json:"estimated_time"`              // when the deposit is projected to be processed
 	IsQueued                  bool      `json:"is_queued"`                   // found in the current pending deposit queue snapshot


### PR DESCRIPTION
Reworks builder deposit tracking around the Gloas fork, plus the fixes found by replaying devnet-8's fork transition and diffing the projection against what the chain actually did.

## Base rework

`923a44b0` — the original rework: chunked inserts (the 65535 bind-parameter overflow), the dequeue-block sentinel and its rebase, pubkey-identity for builders whose index was reused, the pre-Gloas onboarding projection, and the state-sim extension for Gloas builder deposits.

## Fixes found by replaying the fork

Each of these was a measured divergence between the projected builder index and the index the pubkey actually got on chain.

**Validator deposits applied before the fork keep their builder deposit.** `onboard_builders_from_pending_deposits` keeps a builder deposit when the pubkey is in `state.validators` at the fork, or when an earlier deposit for it is still queued. The projection only modelled the second properly: the first was checked against the validator set *now*, but a validator deposit at the front of the queue is applied long before the fork and does register the pubkey — it just does not exist yet at projection time. Neither check saw it. Now tracked in `validatorDepositsInQueue`, mirroring the ordering the fork transition applies: applied-before-fork keeps every builder deposit for that pubkey, still-queued keeps only the ones behind it.

**Only deposits with a valid signature register anything.** Two places assumed a pre-fork deposit registers its pubkey without checking the proof-of-possession. `apply_pending_deposit` drops an invalid signature for a new pubkey without registering anything, so the pubkey is still free when onboarding runs. On devnet-8 this hid a real builder: a pubkey with 4000 invalid validator deposits and 1300 invalid builder deposits, all drained before the fork, plus one valid builder deposit — builder 9990 on chain, classified as kept-as-validator by the projection. An unknown verdict (contract tx not yet indexed) now counts as not registering, rather than being read as valid.

**Deposits pair with their transaction by content, not position.** The blocks right after activation mix requests enqueued before the fork (carrying the dequeue-block sentinel) with normally dequeued ones. Positional pairing indexes the transactions dequeued at a block by the deposit's `SlotIndex`, but `SlotIndex` counts every request in the block while those transactions are only the post-fork subset — two different lists. At devnet-8 slot 49158 that left 9 of 16 deposits with no transaction. The positional path survives as a fast path but its pick is now only accepted when the transaction it lands on actually contains that deposit; showing the wrong hash would be worse than showing none.

**Execution request txs move onto the fork with their blocks.** A fork id handed out while the chain was still being resolved is superseded once blocks are re-linked. Consensus rows follow because their blocks are re-persisted; the execution request transactions are written once by the contract indexers and kept the stale id forever, making canonical transactions read as orphaned. Re-tagged in the same transaction, keyed on the execution block hash (`block_root` on these tables is `log.BlockHash`) rather than block number, which collides across forks.

## Performance

**`depositsig.VerifyBatch` no longer bisects a failing batch.** Bisection looks cheap — O(log n) checks per invalid signature — but every level re-runs an aggregate check over half the remaining items, and the constant swamps the log. Measured over 2000 deposits against verifying one by one:

| | before | after |
|---|---|---|
| all valid | 1.9x faster | 2.3x faster |
| 1% wrong-signer | 2.6x **slower** | parity |
| 10% wrong-signer | 4.5x **slower** | parity |
| 100% wrong-signer | 7x **slower** | parity |

It was a pessimisation on exactly the input it meets in practice — deposit spam arrives in runs of invalid proofs-of-possession, and the fork transition verifies the whole pending queue at once. Now verified in fixed groups, with a failing group re-verified item by item.

## Known limitation

Post-fork builder deposits still queued in the contract get no projected index. Index reuse is the easy half (lowest fully-withdrawn slot, currently inert — no zero-balance builders exist yet); the work is verifying each pending deposit against `DOMAIN_BUILDER_DEPOSIT`, since `builder_deposit_request_txs` records no signature verdict.
