### PR TITLE
Xatu-cbt slot panels: attestation wave and data column availability

### DIFF
--- a/cache/nil_fidelity_waves_test.go
+++ b/cache/nil_fidelity_waves_test.go
@@ -1,0 +1,78 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/dora/types"
+	"github.com/ethpandaops/dora/types/models"
+	"github.com/ethpandaops/dora/utils"
+	"github.com/sirupsen/logrus"
+)
+
+// The waves response leans on nil to mean "no data": a nil section hides its
+// panel, a nil FirstSeenMs renders "not seen". Like the arrival response, it
+// must stay on the cache's JSON path, where nil survives a round trip.
+func TestWavesNilFidelityThroughCache(t *testing.T) {
+	utils.Config = &types.Config{}
+
+	tc, err := NewTieredCache(100, "", "test", logrus.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pct := 87.5
+	in := &models.SlotWavesResponse{
+		Slot: 9, Settled: true,
+		// Attestations deliberately nil: a network without the cbt attestation
+		// model must not come back as an empty wave.
+		Columns: &models.SlotColumnWave{
+			BlobCount: 3,
+			Columns: []*models.SlotColumn{
+				// probed but never seen
+				{Index: 0, AvailabilityPct: &pct, Probes: 4},
+				// seen but never probed
+				{Index: 1, FirstSeenMs: ptr(uint32(1300))},
+			},
+		},
+	}
+
+	if err := tc.Set("slotwaves:9:x", in, time.Hour); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	out := &models.SlotWavesResponse{}
+	if _, err := tc.Get("slotwaves:9:x", out); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if out.Attestations != nil {
+		t.Errorf("Attestations should stay nil, got %+v", out.Attestations)
+	}
+
+	if out.Columns == nil {
+		t.Fatal("Columns section lost")
+	}
+
+	unseen, unprobed := out.Columns.Columns[0], out.Columns.Columns[1]
+
+	if unseen.FirstSeenMs != nil {
+		t.Errorf("unseen column got FirstSeenMs %d", *unseen.FirstSeenMs)
+	}
+
+	if unseen.AvailabilityPct == nil || *unseen.AvailabilityPct != pct {
+		t.Errorf("availability lost: %v", unseen.AvailabilityPct)
+	}
+
+	if unprobed.AvailabilityPct != nil {
+		t.Errorf("unprobed column got AvailabilityPct %v", *unprobed.AvailabilityPct)
+	}
+
+	if unprobed.FirstSeenMs == nil || *unprobed.FirstSeenMs != 1300 {
+		t.Errorf("first seen lost: %v", unprobed.FirstSeenMs)
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/clients/consensus/chainspec.go
+++ b/clients/consensus/chainspec.go
@@ -136,6 +136,8 @@ type ChainSpecConfig struct {
 	ContributionDueBpsGloas              uint64 `yaml:"CONTRIBUTION_DUE_BPS_GLOAS"                 check-if-fork:"GloasForkEpoch"`
 	SyncMessageDueBpsGloas               uint64 `yaml:"SYNC_MESSAGE_DUE_BPS_GLOAS"                 check-if-fork:"GloasForkEpoch"`
 	PayloadAttestationDueBps             uint64 `yaml:"PAYLOAD_ATTESTATION_DUE_BPS"                check-if-fork:"GloasForkEpoch"`
+	BuilderPaymentThresholdNumerator     uint64 `yaml:"BUILDER_PAYMENT_THRESHOLD_NUMERATOR"        check-if-fork:"GloasForkEpoch"`
+	BuilderPaymentThresholdDenominator   uint64 `yaml:"BUILDER_PAYMENT_THRESHOLD_DENOMINATOR"      check-if-fork:"GloasForkEpoch"`
 	PayloadDueBps                        uint64 `yaml:"PAYLOAD_DUE_BPS"                            check-if-fork:"GloasForkEpoch"`
 	MaxRequestPayloads                   uint64 `yaml:"MAX_REQUEST_PAYLOADS"                       check-if-fork:"GloasForkEpoch"`
 

--- a/clients/xatu/client.go
+++ b/clients/xatu/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/ethpandaops/dora/types"
-	xch "github.com/ethpandaops/xatu/pkg/proto/clickhouse"
 )
 
 const (
@@ -29,11 +28,21 @@ const (
 	maxQueryPages           = 10
 	defaultSettleDelay      = 30 * time.Second
 	defaultConcurrencyLimit = 2
+	// cbtSettleDelay is how long after slot start the cbt transformations are
+	// assumed to still be rewriting a slot's rows. The attestation chunk window
+	// extends 12s past slot start, availability probes run within the probed
+	// slot itself, and the transformation batches lag under a minute, so two
+	// minutes covers all three with room.
+	cbtSettleDelay = 2 * time.Minute
 )
 
 // GlobalClient is the process-wide xatu client. It is nil when xatu is not
 // configured; all xatu-backed features must treat that as disabled.
 var GlobalClient *Client
+
+// GlobalCbtClient is the process-wide xatu-cbt client. It is nil when no cbt
+// source is configured; all cbt-backed features must treat that as disabled.
+var GlobalCbtClient *Client
 
 // Client wraps ClickHouse connections to a Xatu instance. Queries for settled
 // slots are routed to the cached endpoint when one is configured, so a
@@ -47,43 +56,97 @@ type Client struct {
 	sem         chan struct{}
 }
 
-// NewClient connects to the configured ClickHouse endpoints. defaultNetwork is
-// used as the meta_network_name filter when the config does not set one.
+// NewClient connects to the configured raw ClickHouse endpoints.
+// defaultNetwork is used as the meta_network_name filter when the config does
+// not set one.
 func NewClient(cfg *types.XatuConfig, defaultNetwork string, logger logrus.FieldLogger) (*Client, error) {
-	if cfg.Raw.ClickhouseDsn == "" {
-		return nil, fmt.Errorf("xatu clickhouse dsn is required")
+	network := cfg.NetworkName
+	if network == "" {
+		network = defaultNetwork
 	}
 
-	conn, err := connect(cfg.Raw.ClickhouseDsn, cfg.Raw.Database)
+	settleDelay := cfg.SettleDelay
+	if settleDelay <= 0 {
+		settleDelay = defaultSettleDelay
+	}
+
+	return newClient(clientParams{
+		module:      "xatu",
+		dsn:         cfg.Raw.ClickhouseDsn,
+		cachedDsn:   cfg.Raw.ClickhouseCachedDsn,
+		database:    cfg.Raw.Database,
+		network:     network,
+		settleDelay: settleDelay,
+		concurrency: cfg.ConcurrencyLimit,
+	}, logger)
+}
+
+// NewCbtClient connects to the configured xatu-cbt ClickHouse endpoints. The
+// cbt models live in one database per network, so the database defaults to
+// the network name instead of a fixed schema. The settle delay is fixed: it
+// covers the transformation pipeline, not the raw ingest lag the configured
+// SettleDelay describes.
+func NewCbtClient(cfg *types.XatuConfig, defaultNetwork string, logger logrus.FieldLogger) (*Client, error) {
+	network := cfg.NetworkName
+	if network == "" {
+		network = defaultNetwork
+	}
+
+	database := cfg.Cbt.Database
+	if database == "" {
+		database = network
+	}
+
+	return newClient(clientParams{
+		module:      "xatu-cbt",
+		dsn:         cfg.Cbt.ClickhouseDsn,
+		cachedDsn:   cfg.Cbt.ClickhouseCachedDsn,
+		database:    database,
+		network:     network,
+		settleDelay: cbtSettleDelay,
+		concurrency: cfg.ConcurrencyLimit,
+	}, logger)
+}
+
+// clientParams carries one source's resolved connection settings into
+// newClient.
+type clientParams struct {
+	module      string
+	dsn         string
+	cachedDsn   string
+	database    string
+	network     string
+	settleDelay time.Duration
+	concurrency int
+}
+
+func newClient(params clientParams, logger logrus.FieldLogger) (*Client, error) {
+	if params.dsn == "" {
+		return nil, fmt.Errorf("%s clickhouse dsn is required", params.module)
+	}
+
+	conn, err := connect(params.dsn, params.database)
 	if err != nil {
-		return nil, fmt.Errorf("xatu clickhouse: %w", err)
+		return nil, fmt.Errorf("%s clickhouse: %w", params.module, err)
 	}
 
 	client := &Client{
-		logger:      logger.WithField("module", "xatu"),
+		logger:      logger.WithField("module", params.module),
 		conn:        conn,
-		network:     cfg.NetworkName,
-		settleDelay: cfg.SettleDelay,
+		network:     params.network,
+		settleDelay: params.settleDelay,
 	}
 
-	if cfg.Raw.ClickhouseCachedDsn != "" {
-		cachedConn, err := connect(cfg.Raw.ClickhouseCachedDsn, cfg.Raw.Database)
+	if params.cachedDsn != "" {
+		cachedConn, err := connect(params.cachedDsn, params.database)
 		if err != nil {
-			return nil, fmt.Errorf("xatu cached clickhouse: %w", err)
+			return nil, fmt.Errorf("%s cached clickhouse: %w", params.module, err)
 		}
 
 		client.cachedConn = cachedConn
 	}
 
-	if client.network == "" {
-		client.network = defaultNetwork
-	}
-
-	if client.settleDelay <= 0 {
-		client.settleDelay = defaultSettleDelay
-	}
-
-	concurrency := cfg.ConcurrencyLimit
+	concurrency := params.concurrency
 	if concurrency <= 0 {
 		concurrency = defaultConcurrencyLimit
 	}
@@ -140,7 +203,7 @@ func (c *Client) SettleDelay() time.Duration {
 // Query runs a built query. Settled queries use the cached endpoint when one
 // is configured; unsettled queries always bypass it so a pre-settle response
 // never gets frozen into a shared response cache.
-func (c *Client) Query(ctx context.Context, settled bool, query xch.SQLQuery) (driver.Rows, error) {
+func (c *Client) Query(ctx context.Context, settled bool, query string, args ...any) (driver.Rows, error) {
 	select {
 	case c.sem <- struct{}{}:
 	case <-ctx.Done():
@@ -153,7 +216,7 @@ func (c *Client) Query(ctx context.Context, settled bool, query xch.SQLQuery) (d
 		conn = c.cachedConn
 	}
 
-	return conn.Query(ctx, query.Query, query.Args...)
+	return conn.Query(ctx, query, args...)
 }
 
 // QueryPaged runs a query across every result page, calling scan for each row.
@@ -161,28 +224,25 @@ func (c *Client) Query(ctx context.Context, settled bool, query xch.SQLQuery) (d
 // The generated builders cap page_size at maxQueryPageSize and cannot express
 // aggregates, so a caller reducing a whole epoch has to pull the rows and
 // follow the page tokens. Reading only the first page loses rows silently,
-// which is worse than being slow. build receives the token for the page to
-// fetch, empty for the first.
+// which is worse than being slow. build receives the row offset of the page
+// to fetch, zero for the first; it encodes the offset into a page token with
+// its own table's generated helper, which keeps this client independent of
+// which generated package (xatu or xatu-cbt) produced the query.
 func (c *Client) QueryPaged(
 	ctx context.Context,
 	settled bool,
-	build func(pageToken string) (xch.SQLQuery, error),
+	build func(pageOffset uint32) (query string, args []any, err error),
 	scan func(rows driver.Rows) error,
 ) error {
 	offset := uint32(0)
 
 	for page := 0; page < maxQueryPages; page++ {
-		pageToken := ""
-		if offset > 0 {
-			pageToken = xch.EncodePageToken(offset)
-		}
-
-		query, err := build(pageToken)
+		query, args, err := build(offset)
 		if err != nil {
 			return err
 		}
 
-		rows, err := c.Query(ctx, settled, query)
+		rows, err := c.Query(ctx, settled, query, args...)
 		if err != nil {
 			return err
 		}

--- a/cmd/dora-explorer/main.go
+++ b/cmd/dora-explorer/main.go
@@ -102,6 +102,16 @@ func main() {
 
 		xatu.GlobalClient = xatuClient
 		logger.WithField("module", "xatu").Infof("xatu clickhouse configured (network: %v)", xatuClient.Network())
+
+		if cfg.Xatu.Cbt.ClickhouseDsn != "" {
+			cbtClient, err := xatu.NewCbtClient(&cfg.Xatu, specs.ConfigName, logger)
+			if err != nil {
+				logger.Fatalf("invalid xatu cbt configuration: %v", err)
+			}
+
+			xatu.GlobalCbtClient = cbtClient
+			logger.WithField("module", "xatu-cbt").Infof("xatu cbt clickhouse configured (network: %v)", cbtClient.Network())
+		}
 	}
 
 	if cfg.RateLimit.Enabled {
@@ -215,6 +225,7 @@ func startFrontend(router *mux.Router) {
 	router.HandleFunc("/slot/{slotOrHash}/duties", handlers.SlotDuties).Methods("GET")
 	router.HandleFunc("/slot/{slotOrHash}/bidseen", handlers.SlotBidSeen).Methods("GET")
 	router.HandleFunc("/slot/{slotOrHash}/arrival", handlers.SlotArrival).Methods("GET")
+	router.HandleFunc("/slot/{slotOrHash}/waves", handlers.SlotWaves).Methods("GET")
 	router.HandleFunc("/slot/{root}/blob/{index}", handlers.SlotBlob).Methods("GET")
 	router.HandleFunc("/blocks", handlers.Blocks).Methods("GET")
 	router.HandleFunc("/blocks/filtered", handlers.BlocksFiltered).Methods("GET")

--- a/config/default.config.yml
+++ b/config/default.config.yml
@@ -237,3 +237,11 @@ xatu:
     # cached response.
     clickhouseCachedDsn: ""
     database: "default"
+  # xatu-cbt's transformed models (fct_*), which live on a separate cluster
+  # with one database per network. Optional: features backed by cbt tables
+  # (attestation wave, data column panels) stay hidden when no DSN is set.
+  cbt:
+    clickhouseDsn: ""
+    clickhouseCachedDsn: ""
+    # Defaults to the network name (e.g. "mainnet").
+    database: ""

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ethpandaops/ethwallclock v0.4.0
 	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260812120339-e742ab5a2de1
 	github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3
+	github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/ethpandaops/go-eth2-client v0.1.7-0.20260812120339-e742ab5a2de1 h1:Hh
 github.com/ethpandaops/go-eth2-client v0.1.7-0.20260812120339-e742ab5a2de1/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3 h1:83LDwFEAijcssPdQ8ojzzbi+2mD3a+zL1b4V4cY1sMo=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3/go.mod h1:sDLPtT/bQgK+vExtPq77y2W4yHq9tRdiDu852yptTcU=
+github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8 h1:YfAXAt5fQcEnzPccCfByhXY2Vy9FlGrOp+NxGLx3QNY=
+github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8/go.mod h1:arOg52bVEiL5DTA2AGrxQzBcIzKWqep6G9vgPAULMl0=
 github.com/ferranbt/fastssz v1.0.0 h1:9EXXYsracSqQRBQiHeaVsG/KQeYblPf40hsQPb9Dzk8=
 github.com/ferranbt/fastssz v1.0.0/go.mod h1:Ea3+oeoRGGLGm5shYAeDgu6PGUlcvQhE2fILyD9+tGg=
 github.com/filecoin-project/go-clock v0.1.0 h1:SFbYIM75M8NnFm1yMHhN9Ahy3W5bEZV9gd6MPfXbKVU=

--- a/handlers/epoch_arrival.go
+++ b/handlers/epoch_arrival.go
@@ -118,12 +118,14 @@ func buildEpochArrivalData(ctx context.Context, epoch phase0.Epoch) (*models.Epo
 
 	// Every observation in the epoch has to be reduced here: the generated
 	// builders cannot aggregate, so min/p90 cannot be pushed into ClickHouse.
-	err := client.QueryPaged(queryCtx, settled, func(pageToken string) (xch.SQLQuery, error) {
-		return xch.BuildListBeaconApiEthV1EventsBlockQuery(&xch.ListBeaconApiEthV1EventsBlockRequest{
+	err := client.QueryPaged(queryCtx, settled, func(pageOffset uint32) (string, []any, error) {
+		query, err := xch.BuildListBeaconApiEthV1EventsBlockQuery(&xch.ListBeaconApiEthV1EventsBlockRequest{
 			MetaNetworkName: networkFilter, Slot: slotFilter, SlotStartDateTime: timeFilter,
 			PropagationSlotStartDiff: freshFilter,
-			PageSize:                 pageSize, PageToken: pageToken,
+			PageSize:                 pageSize, PageToken: xatuPageToken(pageOffset),
 		})
+
+		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
 		var row xch.BeaconApiEthV1EventsBlockRow
 		if err := rows.ScanStruct(&row); err != nil {
@@ -138,12 +140,14 @@ func buildEpochArrivalData(ctx context.Context, epoch phase0.Epoch) (*models.Epo
 		return nil, -1, fmt.Errorf("api query: %w", err)
 	}
 
-	err = client.QueryPaged(queryCtx, settled, func(pageToken string) (xch.SQLQuery, error) {
-		return xch.BuildListLibp2PGossipsubBeaconBlockQuery(&xch.ListLibp2PGossipsubBeaconBlockRequest{
+	err = client.QueryPaged(queryCtx, settled, func(pageOffset uint32) (string, []any, error) {
+		query, err := xch.BuildListLibp2PGossipsubBeaconBlockQuery(&xch.ListLibp2PGossipsubBeaconBlockRequest{
 			MetaNetworkName: networkFilter, Slot: slotFilter, SlotStartDateTime: timeFilter,
 			PropagationSlotStartDiff: freshFilter,
-			PageSize:                 pageSize, PageToken: pageToken,
+			PageSize:                 pageSize, PageToken: xatuPageToken(pageOffset),
 		})
+
+		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
 		var row xch.Libp2PGossipsubBeaconBlockRow
 		if err := rows.ScanStruct(&row); err != nil {
@@ -158,12 +162,14 @@ func buildEpochArrivalData(ctx context.Context, epoch phase0.Epoch) (*models.Epo
 		return nil, -1, fmt.Errorf("p2p query: %w", err)
 	}
 
-	err = client.QueryPaged(queryCtx, settled, func(pageToken string) (xch.SQLQuery, error) {
-		return xch.BuildListBeaconApiEthV1EventsHeadQuery(&xch.ListBeaconApiEthV1EventsHeadRequest{
+	err = client.QueryPaged(queryCtx, settled, func(pageOffset uint32) (string, []any, error) {
+		query, err := xch.BuildListBeaconApiEthV1EventsHeadQuery(&xch.ListBeaconApiEthV1EventsHeadRequest{
 			MetaNetworkName: networkFilter, Slot: slotFilter, SlotStartDateTime: timeFilter,
 			PropagationSlotStartDiff: freshFilter,
-			PageSize:                 pageSize, PageToken: pageToken,
+			PageSize:                 pageSize, PageToken: xatuPageToken(pageOffset),
 		})
+
+		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
 		var row xch.BeaconApiEthV1EventsHeadRow
 		if err := rows.ScanStruct(&row); err != nil {

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -269,6 +269,7 @@ func buildSlotPageData(ctx context.Context, blockSlot int64, blockRoot []byte) (
 		Badges:         []*models.SlotPageBlockBadge{},
 		TracoorUrl:     utils.Config.Frontend.TracoorUrl,
 		XatuEnabled:    xatu.GlobalClient != nil,
+		XatuCbtEnabled: xatu.GlobalCbtClient != nil,
 	}
 
 	var epochStatsValues *beacon.EpochStatsValues

--- a/handlers/slot_arrival.go
+++ b/handlers/slot_arrival.go
@@ -180,10 +180,12 @@ func loadAPIArrivals(ctx context.Context, client *xatu.Client, slot phase0.Slot,
 
 	observations := 0
 
-	err := client.QueryPaged(ctx, settled, func(pageToken string) (xch.SQLQuery, error) {
-		req.PageToken = pageToken
+	err := client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
+		req.PageToken = xatuPageToken(pageOffset)
 
-		return xch.BuildListBeaconApiEthV1EventsBlockQuery(req)
+		query, err := xch.BuildListBeaconApiEthV1EventsBlockQuery(req)
+
+		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
 		var row xch.BeaconApiEthV1EventsBlockRow
 		if err := rows.ScanStruct(&row); err != nil {
@@ -238,10 +240,12 @@ func loadP2PArrivals(ctx context.Context, client *xatu.Client, slot phase0.Slot,
 
 	observations := 0
 
-	err := client.QueryPaged(ctx, settled, func(pageToken string) (xch.SQLQuery, error) {
-		req.PageToken = pageToken
+	err := client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
+		req.PageToken = xatuPageToken(pageOffset)
 
-		return xch.BuildListLibp2PGossipsubBeaconBlockQuery(req)
+		query, err := xch.BuildListLibp2PGossipsubBeaconBlockQuery(req)
+
+		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
 		var row xch.Libp2PGossipsubBeaconBlockRow
 		if err := rows.ScanStruct(&row); err != nil {
@@ -314,10 +318,12 @@ func loadHeadArrivals(ctx context.Context, client *xatu.Client, slot phase0.Slot
 
 	observations := 0
 
-	err := client.QueryPaged(ctx, settled, func(pageToken string) (xch.SQLQuery, error) {
-		req.PageToken = pageToken
+	err := client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
+		req.PageToken = xatuPageToken(pageOffset)
 
-		return xch.BuildListBeaconApiEthV1EventsHeadQuery(req)
+		query, err := xch.BuildListBeaconApiEthV1EventsHeadQuery(req)
+
+		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
 		var row xch.BeaconApiEthV1EventsHeadRow
 		if err := rows.ScanStruct(&row); err != nil {
@@ -393,10 +399,12 @@ func loadEngineTimings(ctx context.Context, client *xatu.Client, slot phase0.Slo
 	slotStartMs := slotTime.UnixMilli()
 	observations := 0
 
-	err := client.QueryPaged(ctx, settled, func(pageToken string) (xch.SQLQuery, error) {
-		req.PageToken = pageToken
+	err := client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
+		req.PageToken = xatuPageToken(pageOffset)
 
-		return xch.BuildListConsensusEngineApiNewPayloadQuery(req)
+		query, err := xch.BuildListConsensusEngineApiNewPayloadQuery(req)
+
+		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
 		var row xch.ConsensusEngineApiNewPayloadRow
 		if err := rows.ScanStruct(&row); err != nil {

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -105,7 +105,7 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 	}
 
 	if attestations != nil {
-		attestations.DeadlineMs = lateThreshold(chainState) / 3
+		attestations.DeadlineMs = attestationDeadlineMs(chainState, slot)
 		attestations.ExpectedCount = expectedAttesters(queryCtx, chainState, slot)
 
 		if xatu.GlobalClient != nil {
@@ -136,6 +136,11 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 
 			ptc = nil
 		}
+
+		if ptc != nil {
+			// PAYLOAD_ATTESTATION_DUE_BPS: votes are due within 75% of the slot
+			ptc.DeadlineMs = lateThreshold(chainState) * 75 / 100
+		}
 	}
 
 	response := &models.SlotWavesResponse{
@@ -159,6 +164,20 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 	}
 
 	return response, cacheTimeout, nil
+}
+
+// attestationDeadlineMs is the point where validators attest without a block
+// in hand: a third of the slot, moved to a quarter by gloas
+// (ATTESTATION_DUE_BPS_GLOAS = 2500).
+func attestationDeadlineMs(chainState *consensus.ChainState, slot phase0.Slot) uint32 {
+	slotMs := lateThreshold(chainState)
+	specs := chainState.GetSpecs()
+
+	if specs.GloasForkEpoch != nil && chainState.EpochOfSlot(slot) >= phase0.Epoch(*specs.GloasForkEpoch) {
+		return slotMs * 25 / 100
+	}
+
+	return slotMs / 3
 }
 
 // expectedAttesters is how many validators were due to attest in the slot:

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -1,0 +1,416 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+
+	"github.com/ethpandaops/dora/clients/xatu"
+	"github.com/ethpandaops/dora/services"
+	"github.com/ethpandaops/dora/types/models"
+	cbtch "github.com/ethpandaops/xatu-cbt/pkg/proto/clickhouse"
+)
+
+// maxWaveRoots caps how many voted block roots the attestation wave reports
+// individually. A contested slot rarely splits across more than two or three
+// roots; anything beyond the cap is merged into one unnamed entry so a chain
+// spam incident cannot inflate the payload.
+const maxWaveRoots = 4
+
+// SlotWaves returns the xatu-cbt backed slot panels as JSON for the lazy
+// propagation tab on the slot page: the attestation first-seen wave and the
+// data column propagation strip.
+func SlotWaves(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if xatu.GlobalCbtClient == nil {
+		http.Error(w, "Xatu cbt is not configured", http.StatusNotFound)
+		return
+	}
+
+	vars := mux.Vars(r)
+	slot, err := strconv.ParseUint(vars["slotOrHash"], 10, 64)
+	if err != nil {
+		http.Error(w, "Invalid slot", http.StatusBadRequest)
+		return
+	}
+
+	// Scope to the block being viewed, so a slot with competing blocks reports
+	// each block's own wave rather than merging them. Requests without a
+	// usable root fall back to the whole slot.
+	blockRoot := normalizeBlockRoot(r.URL.Query().Get("root"))
+
+	cacheKey := fmt.Sprintf("slotwaves:%d:%s", slot, blockRoot)
+	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(cacheKey, true, &models.SlotWavesResponse{}, func(pageCall *services.FrontendCacheProcessingPage) any {
+		data, cacheTimeout, buildErr := buildSlotWavesData(pageCall.CallCtx, phase0.Slot(slot), blockRoot)
+		if buildErr != nil {
+			logrus.WithError(buildErr).Error("error loading slot waves data from xatu-cbt")
+			pageCall.CacheTimeout = -1
+
+			return &models.SlotWavesResponse{Slot: slot}
+		}
+
+		pageCall.CacheTimeout = cacheTimeout
+
+		return data
+	})
+	if pageErr != nil {
+		logrus.WithError(pageErr).Error("error building slot waves data")
+		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
+		return
+	}
+
+	result, ok := pageRes.(*models.SlotWavesResponse)
+	if !ok {
+		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		logrus.WithError(err).Error("error encoding slot waves data")
+		http.Error(w, "Internal server error", http.StatusServiceUnavailable)
+	}
+}
+
+// buildSlotWavesData queries xatu-cbt for the slot's attestation wave and
+// data column measurements. It returns the response and the cache timeout,
+// following the same ladder as the arrival endpoint: one slot while the cbt
+// transformations may still rewrite the slot's rows, then short, then long.
+func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string) (*models.SlotWavesResponse, time.Duration, error) {
+	client := xatu.GlobalCbtClient
+	chainState := services.GlobalBeaconService.GetChainState()
+	slotTime := chainState.SlotToTime(slot)
+
+	settled := time.Now().After(slotTime.Add(client.SettleDelay()))
+
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	attestations, err := loadAttestationWave(queryCtx, client, slot, slotTime, settled, blockRoot)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	if attestations != nil {
+		attestations.DeadlineMs = lateThreshold(chainState) / 3
+	}
+
+	columns, err := loadColumnWave(queryCtx, client, slot, slotTime, settled, blockRoot)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	response := &models.SlotWavesResponse{
+		Slot:         uint64(slot),
+		Settled:      settled,
+		Attestations: attestations,
+		Columns:      columns,
+	}
+
+	cacheTimeout := time.Duration(-1)
+
+	switch {
+	case !settled:
+		cacheTimeout = unsettledCacheTimeout(chainState)
+	case time.Since(slotTime) < 30*time.Minute:
+		cacheTimeout = 30 * time.Second
+	default:
+		cacheTimeout = time.Hour
+	}
+
+	return response, cacheTimeout, nil
+}
+
+// waveRoot accumulates one voted block root's buckets before they are sorted
+// into the response.
+type waveRoot struct {
+	root    string
+	count   int
+	buckets map[uint32]int
+}
+
+// loadAttestationWave loads the 50ms attestation first-seen chunks for the
+// slot, grouped by voted block root. The cbt tables hold one network per
+// database, so no network filter is needed. It returns nil when the table has
+// no rows for the slot.
+func loadAttestationWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, slotTime time.Time, settled bool, blockRoot string) (*models.SlotAttestationWave, error) {
+	// Both slot and slot_start_date_time are filtered: the cbt cluster rejects
+	// queries that cannot use a table's primary key, and which of the two
+	// leads the key varies between tables.
+	req := &cbtch.ListFctAttestationFirstSeenChunked50MsRequest{
+		Slot: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: uint32(slot)}},
+		SlotStartDateTime: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{
+			Eq: uint32(slotTime.Unix()),
+		}},
+		OrderBy:  "chunk_slot_start_diff",
+		PageSize: xatu.MaxQueryPageSize(),
+	}
+
+	roots := map[string]*waveRoot{}
+	total := 0
+
+	err := client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
+		req.PageToken = cbtPageToken(pageOffset)
+
+		query, err := cbtch.BuildListFctAttestationFirstSeenChunked50MsQuery(req)
+
+		return query.Query, query.Args, err
+	}, func(rows driver.Rows) error {
+		var row cbtch.FctAttestationFirstSeenChunked50MsRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return fmt.Errorf("attestation wave scan: %w", err)
+		}
+
+		root := roots[row.BlockRoot]
+		if root == nil {
+			root = &waveRoot{root: row.BlockRoot, buckets: map[uint32]int{}}
+			roots[row.BlockRoot] = root
+		}
+
+		count := int(row.AttestationCount)
+		root.count += count
+		root.buckets[row.ChunkSlotStartDiff] += count
+		total += count
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attestation wave query: %w", err)
+	}
+
+	if total == 0 {
+		return nil, nil
+	}
+
+	return assembleWaveRoots(roots, total, blockRoot), nil
+}
+
+// assembleWaveRoots orders the accumulated roots by vote count, merges the
+// tail beyond maxWaveRoots into one unnamed entry and marks the viewed root.
+func assembleWaveRoots(roots map[string]*waveRoot, total int, blockRoot string) *models.SlotAttestationWave {
+	ordered := make([]*waveRoot, 0, len(roots))
+	for _, root := range roots {
+		ordered = append(ordered, root)
+	}
+
+	sort.Slice(ordered, func(a, b int) bool {
+		return ordered[a].count > ordered[b].count
+	})
+
+	if len(ordered) > maxWaveRoots {
+		rest := &waveRoot{buckets: map[uint32]int{}}
+
+		for _, root := range ordered[maxWaveRoots:] {
+			rest.count += root.count
+
+			for ms, count := range root.buckets {
+				rest.buckets[ms] += count
+			}
+		}
+
+		ordered = append(ordered[:maxWaveRoots], rest)
+	}
+
+	wave := &models.SlotAttestationWave{TotalCount: total}
+
+	for _, root := range ordered {
+		entry := &models.SlotAttestationRoot{
+			Root:    root.root,
+			Viewed:  blockRoot != "" && root.root == blockRoot,
+			Count:   root.count,
+			Buckets: make([]*models.SlotAttestationBucket, 0, len(root.buckets)),
+		}
+
+		for ms, count := range root.buckets {
+			entry.Buckets = append(entry.Buckets, &models.SlotAttestationBucket{Ms: ms, Count: count})
+		}
+
+		sort.Slice(entry.Buckets, func(a, b int) bool {
+			return entry.Buckets[a].Ms < entry.Buckets[b].Ms
+		})
+
+		wave.Roots = append(wave.Roots, entry)
+	}
+
+	return wave
+}
+
+// loadColumnWave loads the per-column first-seen times and availability
+// probes for the slot and merges them into one entry per column index. It
+// returns nil when neither table has rows, and also for a blobless slot,
+// where there are no columns to spread.
+func loadColumnWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, slotTime time.Time, settled bool, blockRoot string) (*models.SlotColumnWave, error) {
+	columns := map[uint32]*models.SlotColumn{}
+
+	column := func(index uint32) *models.SlotColumn {
+		entry := columns[index]
+		if entry == nil {
+			entry = &models.SlotColumn{Index: index}
+			columns[index] = entry
+		}
+
+		return entry
+	}
+
+	seenReq := &cbtch.ListFctBlockDataColumnSidecarFirstSeenRequest{
+		Slot: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: uint32(slot)}},
+		SlotStartDateTime: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{
+			Eq: uint32(slotTime.Unix()),
+		}},
+		OrderBy:  "column_index",
+		PageSize: xatu.MaxQueryPageSize(),
+	}
+
+	if blockRoot != "" {
+		seenReq.BlockRoot = &cbtch.StringFilter{Filter: &cbtch.StringFilter_Eq{Eq: blockRoot}}
+	}
+
+	blobCount := 0
+
+	err := client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
+		seenReq.PageToken = cbtPageToken(pageOffset)
+
+		query, err := cbtch.BuildListFctBlockDataColumnSidecarFirstSeenQuery(seenReq)
+
+		return query.Query, query.Args, err
+	}, func(rows driver.Rows) error {
+		var row cbtch.FctBlockDataColumnSidecarFirstSeenRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return fmt.Errorf("column first seen scan: %w", err)
+		}
+
+		entry := column(row.ColumnIndex)
+
+		// Without a root filter a reorged slot yields one row per root and
+		// column; keep the earliest.
+		if entry.FirstSeenMs == nil || row.SeenSlotStartDiff < *entry.FirstSeenMs {
+			ms := row.SeenSlotStartDiff
+			entry.FirstSeenMs = &ms
+
+			_, _, display := parseSentryName(row.MetaClientName, client.Network())
+			entry.FirstSeenBy = display
+			entry.CountryCode = row.MetaClientGeoCountryCode
+
+			entry.Implementation = row.MetaConsensusImplementation
+			if entry.Implementation == "" {
+				entry.Implementation = reduceSidecarName(row.MetaClientImplementation)
+			}
+		}
+
+		if int(row.RowCount) > blobCount {
+			blobCount = int(row.RowCount)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("column first seen query: %w", err)
+	}
+
+	// Availability is probed per slot and column, not per block root, so it
+	// stays unfiltered even when the page views one specific block.
+	availReq := &cbtch.ListFctDataColumnAvailabilityBySlotRequest{
+		Slot: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: uint32(slot)}},
+		SlotStartDateTime: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{
+			Eq: uint32(slotTime.Unix()),
+		}},
+		OrderBy:  "column_index",
+		PageSize: xatu.MaxQueryPageSize(),
+	}
+
+	err = client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
+		availReq.PageToken = cbtPageToken(pageOffset)
+
+		query, err := cbtch.BuildListFctDataColumnAvailabilityBySlotQuery(availReq)
+
+		return query.Query, query.Args, err
+	}, func(rows driver.Rows) error {
+		var row cbtch.FctDataColumnAvailabilityBySlotRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return fmt.Errorf("column availability scan: %w", err)
+		}
+
+		entry := column(uint32(row.ColumnIndex)) //nolint:gosec // column indexes are 0-127
+
+		pct := row.AvailabilityPct
+		entry.AvailabilityPct = &pct
+		entry.Probes = int(row.ProbeCount)
+		entry.P50ResponseMs = row.P50ResponseTimeMs
+
+		if int(row.BlobCount) > blobCount {
+			blobCount = int(row.BlobCount)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("column availability query: %w", err)
+	}
+
+	if len(columns) == 0 || blobCount == 0 {
+		return nil, nil
+	}
+
+	wave := &models.SlotColumnWave{
+		BlobCount:       blobCount,
+		MinAvailability: 100,
+		Columns:         make([]*models.SlotColumn, 0, len(columns)),
+	}
+
+	availabilitySum := float64(0)
+
+	for _, entry := range columns {
+		wave.Columns = append(wave.Columns, entry)
+
+		if entry.FirstSeenMs != nil {
+			wave.SeenColumns++
+
+			if wave.FirstMs == 0 || *entry.FirstSeenMs < wave.FirstMs {
+				wave.FirstMs = *entry.FirstSeenMs
+			}
+
+			if *entry.FirstSeenMs > wave.LastMs {
+				wave.LastMs = *entry.FirstSeenMs
+			}
+		}
+
+		if entry.AvailabilityPct != nil {
+			wave.ProbedColumns++
+			wave.TotalProbes += entry.Probes
+			availabilitySum += *entry.AvailabilityPct
+
+			if *entry.AvailabilityPct < wave.MinAvailability {
+				wave.MinAvailability = *entry.AvailabilityPct
+			}
+
+			// p50 covers successful probes only, so a fully failed column
+			// reports zero and cannot be the slowest.
+			if entry.P50ResponseMs > wave.WorstP50Ms {
+				wave.WorstP50Ms = entry.P50ResponseMs
+			}
+		}
+	}
+
+	if wave.ProbedColumns > 0 {
+		wave.AvgAvailability = availabilitySum / float64(wave.ProbedColumns)
+	} else {
+		wave.MinAvailability = 0
+	}
+
+	sort.Slice(wave.Columns, func(a, b int) bool {
+		return wave.Columns[a].Index < wave.Columns[b].Index
+	})
+
+	return wave, nil
+}

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 
+	"github.com/ethpandaops/dora/clients/consensus"
 	"github.com/ethpandaops/dora/clients/xatu"
+	"github.com/ethpandaops/dora/db"
 	"github.com/ethpandaops/dora/services"
 	"github.com/ethpandaops/dora/types/models"
 	cbtch "github.com/ethpandaops/xatu-cbt/pkg/proto/clickhouse"
@@ -104,6 +106,18 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 
 	if attestations != nil {
 		attestations.DeadlineMs = lateThreshold(chainState) / 3
+		attestations.ExpectedCount = expectedAttesters(queryCtx, chainState, slot)
+
+		if xatu.GlobalClient != nil {
+			p50, plErr := queryPayloadP50(queryCtx, xatu.GlobalClient, slot, slotTime, settled, blockRoot)
+			if plErr != nil {
+				// the payload marker is garnish on the attestation chart, so
+				// its failure must not take the whole panel down
+				logrus.WithError(plErr).Warn("error loading payload p50 from xatu")
+			} else {
+				attestations.PayloadP50Ms = p50
+			}
+		}
 	}
 
 	columns, err := loadColumnWave(queryCtx, client, slot, slotTime, settled, blockRoot)
@@ -131,6 +145,82 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 	}
 
 	return response, cacheTimeout, nil
+}
+
+// expectedAttesters is how many validators were due to attest in the slot:
+// the epoch's active validator count spread over its slots. Recent epochs
+// come from the in-memory epoch stats; older ones fall back to the epochs
+// table, which serves history but only fills when the synchronizer runs.
+func expectedAttesters(ctx context.Context, chainState *consensus.ChainState, slot phase0.Slot) int {
+	epoch := chainState.EpochOfSlot(slot)
+
+	slotsPerEpoch := chainState.GetSpecs().SlotsPerEpoch
+	if slotsPerEpoch == 0 {
+		return 0
+	}
+
+	beaconIndexer := services.GlobalBeaconService.GetBeaconIndexer()
+	if epochStats := beaconIndexer.GetEpochStats(epoch, nil); epochStats != nil {
+		if values := epochStats.GetOrLoadValues(ctx, beaconIndexer, true, false); values != nil && values.ActiveValidators > 0 {
+			return int(values.ActiveValidators / slotsPerEpoch) //nolint:gosec // bounded by the validator set
+		}
+	}
+
+	rows := db.GetEpochs(ctx, uint64(epoch), 1)
+	if len(rows) == 0 || rows[0].Epoch != uint64(epoch) {
+		return 0
+	}
+
+	return int(rows[0].ValidatorCount / slotsPerEpoch) //nolint:gosec // bounded by the validator set
+}
+
+// payloadP50Query reduces the gloas payload gossip series to its median; see
+// payloadGossipQuery for why this is plain SQL.
+const payloadP50Query = `SELECT count() AS observations, toUInt32(quantileExact(0.5)(propagation_slot_start_diff)) AS p50
+FROM beacon_api_eth_v1_events_execution_payload_gossip
+WHERE meta_network_name = ? AND slot_start_date_time = toDateTime(?) AND slot = ?%s`
+
+// queryPayloadP50 returns the median payload arrival for the slot, or zero on
+// networks without the gloas payload series.
+func queryPayloadP50(ctx context.Context, client *xatu.Client, slot phase0.Slot, slotTime time.Time, settled bool, blockRoot string) (uint32, error) {
+	filter := ""
+	args := []any{client.Network(), slotTime.Unix(), uint32(slot)}
+
+	if blockRoot != "" {
+		filter = " AND block_root = ?"
+
+		args = append(args, blockRoot)
+	}
+
+	rows, err := client.Query(ctx, settled, fmt.Sprintf(payloadP50Query, filter), args...)
+	if err != nil {
+		if isMissingTableError(err) {
+			return 0, nil
+		}
+
+		return 0, fmt.Errorf("payload p50 query: %w", err)
+	}
+	defer rows.Close()
+
+	var observations uint64
+
+	var p50 uint32
+
+	for rows.Next() {
+		if err := rows.Scan(&observations, &p50); err != nil {
+			return 0, fmt.Errorf("payload p50 scan: %w", err)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("payload p50 query: %w", err)
+	}
+
+	if observations == 0 {
+		return 0, nil
+	}
+
+	return p50, nil
 }
 
 // waveRoot accumulates one voted block root's buckets before they are sorted

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -114,6 +114,7 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 	response := &models.SlotWavesResponse{
 		Slot:         uint64(slot),
 		Settled:      settled,
+		SlotMs:       lateThreshold(chainState),
 		Attestations: attestations,
 		Columns:      columns,
 	}

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -247,12 +247,14 @@ func assembleWaveRoots(roots map[string]*waveRoot, total int, blockRoot string) 
 	return wave
 }
 
-// loadColumnWave loads the per-column first-seen times and availability
-// probes for the slot and merges them into one entry per column index. It
-// returns nil when neither table has rows, and also for a blobless slot,
-// where there are no columns to spread.
+// loadColumnWave loads every node's first sighting of each data column and
+// the availability probes for the slot, and reduces them into one entry per
+// column index with min/p50/p90 timings. It returns nil when neither table
+// has rows, and also for a blobless slot, where there are no columns to
+// spread.
 func loadColumnWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, slotTime time.Time, settled bool, blockRoot string) (*models.SlotColumnWave, error) {
 	columns := map[uint32]*models.SlotColumn{}
+	sightings := map[uint32][]uint32{}
 
 	column := func(index uint32) *models.SlotColumn {
 		entry := columns[index]
@@ -264,7 +266,7 @@ func loadColumnWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, 
 		return entry
 	}
 
-	seenReq := &cbtch.ListFctBlockDataColumnSidecarFirstSeenRequest{
+	seenReq := &cbtch.ListFctBlockDataColumnSidecarFirstSeenByNodeRequest{
 		Slot: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: uint32(slot)}},
 		SlotStartDateTime: &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{
 			Eq: uint32(slotTime.Unix()),
@@ -282,19 +284,18 @@ func loadColumnWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, 
 	err := client.QueryPaged(ctx, settled, func(pageOffset uint32) (string, []any, error) {
 		seenReq.PageToken = cbtPageToken(pageOffset)
 
-		query, err := cbtch.BuildListFctBlockDataColumnSidecarFirstSeenQuery(seenReq)
+		query, err := cbtch.BuildListFctBlockDataColumnSidecarFirstSeenByNodeQuery(seenReq)
 
 		return query.Query, query.Args, err
 	}, func(rows driver.Rows) error {
-		var row cbtch.FctBlockDataColumnSidecarFirstSeenRow
+		var row cbtch.FctBlockDataColumnSidecarFirstSeenByNodeRow
 		if err := rows.ScanStruct(&row); err != nil {
-			return fmt.Errorf("column first seen scan: %w", err)
+			return fmt.Errorf("column sightings scan: %w", err)
 		}
 
 		entry := column(row.ColumnIndex)
+		sightings[row.ColumnIndex] = append(sightings[row.ColumnIndex], row.SeenSlotStartDiff)
 
-		// Without a root filter a reorged slot yields one row per root and
-		// column; keep the earliest.
 		if entry.FirstSeenMs == nil || row.SeenSlotStartDiff < *entry.FirstSeenMs {
 			ms := row.SeenSlotStartDiff
 			entry.FirstSeenMs = &ms
@@ -316,7 +317,7 @@ func loadColumnWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, 
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("column first seen query: %w", err)
+		return nil, fmt.Errorf("column sightings query: %w", err)
 	}
 
 	// Availability is probed per slot and column, not per block root, so it
@@ -370,9 +371,20 @@ func loadColumnWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, 
 	}
 
 	availabilitySum := float64(0)
+	allSightings := []uint32{}
 
 	for _, entry := range columns {
 		wave.Columns = append(wave.Columns, entry)
+
+		if times := sightings[entry.Index]; len(times) > 0 {
+			sort.Slice(times, func(a, b int) bool { return times[a] < times[b] })
+			entry.P50Ms = times[len(times)/2]
+			entry.P90Ms = times[len(times)*9/10]
+			entry.Observations = len(times)
+
+			wave.Observations += len(times)
+			allSightings = append(allSightings, times...)
+		}
 
 		if entry.FirstSeenMs != nil {
 			wave.SeenColumns++
@@ -401,6 +413,11 @@ func loadColumnWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, 
 				wave.WorstP50Ms = entry.P50ResponseMs
 			}
 		}
+	}
+
+	if len(allSightings) > 0 {
+		sort.Slice(allSightings, func(a, b int) bool { return allSightings[a] < allSightings[b] })
+		wave.MedianMs = allSightings[len(allSightings)/2]
 	}
 
 	if wave.ProbedColumns > 0 {

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -107,6 +107,7 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 	if attestations != nil {
 		attestations.DeadlineMs = attestationDeadlineMs(chainState, slot)
 		attestations.ExpectedCount = expectedAttesters(queryCtx, chainState, slot)
+		attestations.ThresholdCount = voteThreshold(chainState, attestations.ExpectedCount)
 
 		if xatu.GlobalClient != nil {
 			p50, plErr := queryPayloadP50(queryCtx, xatu.GlobalClient, slot, slotTime, settled, blockRoot)
@@ -138,8 +139,8 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 		}
 
 		if ptc != nil {
-			// PAYLOAD_ATTESTATION_DUE_BPS: votes are due within 75% of the slot
-			ptc.DeadlineMs = lateThreshold(chainState) * 75 / 100
+			// votes are due within PAYLOAD_ATTESTATION_DUE_BPS of the slot
+			ptc.DeadlineMs = bpsOfSlot(chainState, chainState.GetSpecs().PayloadAttestationDueBps, 7500)
 		}
 	}
 
@@ -166,18 +167,50 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 	return response, cacheTimeout, nil
 }
 
-// attestationDeadlineMs is the point where validators attest without a block
-// in hand: a third of the slot, moved to a quarter by gloas
-// (ATTESTATION_DUE_BPS_GLOAS = 2500).
-func attestationDeadlineMs(chainState *consensus.ChainState, slot phase0.Slot) uint32 {
-	slotMs := lateThreshold(chainState)
+// gloasActive reports whether the slot is past the gloas fork.
+func gloasActive(chainState *consensus.ChainState, slot phase0.Slot) bool {
 	specs := chainState.GetSpecs()
 
-	if specs.GloasForkEpoch != nil && chainState.EpochOfSlot(slot) >= phase0.Epoch(*specs.GloasForkEpoch) {
-		return slotMs * 25 / 100
+	return specs.GloasForkEpoch != nil && chainState.EpochOfSlot(slot) >= phase0.Epoch(*specs.GloasForkEpoch)
+}
+
+// bpsOfSlot resolves a basis-points spec value against the slot duration,
+// with the spec's own default for nodes that do not serve the key yet.
+func bpsOfSlot(chainState *consensus.ChainState, bps, defaultBps uint64) uint32 {
+	if bps == 0 {
+		bps = defaultBps
 	}
 
-	return slotMs / 3
+	return uint32(uint64(lateThreshold(chainState)) * bps / 10000) //nolint:gosec // bounded by the slot length
+}
+
+// attestationDeadlineMs is the point where validators attest without a block
+// in hand: ATTESTATION_DUE_BPS of the slot, moved earlier by gloas.
+func attestationDeadlineMs(chainState *consensus.ChainState, slot phase0.Slot) uint32 {
+	specs := chainState.GetSpecs()
+
+	if gloasActive(chainState, slot) {
+		return bpsOfSlot(chainState, specs.AttestationDueBpsGloas, 2500)
+	}
+
+	return bpsOfSlot(chainState, specs.AttestationDueBps, 3333)
+}
+
+// voteThreshold is the vote count where the block clears the gloas builder
+// payment quorum: BUILDER_PAYMENT_THRESHOLD (6/10 by default) of the slot's
+// expected attesters. Pre-gloas networks do not serve the keys, so the
+// gloas default doubles as a plain supermajority reference there.
+func voteThreshold(chainState *consensus.ChainState, expected int) int {
+	specs := chainState.GetSpecs()
+
+	numerator := specs.BuilderPaymentThresholdNumerator
+	denominator := specs.BuilderPaymentThresholdDenominator
+
+	if numerator == 0 || denominator == 0 {
+		numerator, denominator = 6, 10
+	}
+
+	return int(uint64(expected) * numerator / denominator) //nolint:gosec // bounded by the validator set
 }
 
 // expectedAttesters is how many validators were due to attest in the slot:

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -125,11 +125,25 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 		return nil, -1, err
 	}
 
+	var ptc *models.SlotPtcWave
+
+	if xatu.GlobalClient != nil {
+		ptc, err = loadPtcWave(queryCtx, xatu.GlobalClient, slot, slotTime, settled, blockRoot)
+		if err != nil {
+			// like the payload marker, the PTC row must not take the other
+			// panels down with it
+			logrus.WithError(err).Warn("error loading ptc wave from xatu")
+
+			ptc = nil
+		}
+	}
+
 	response := &models.SlotWavesResponse{
 		Slot:         uint64(slot),
 		Settled:      settled,
 		SlotMs:       lateThreshold(chainState),
 		Attestations: attestations,
+		Ptc:          ptc,
 		Columns:      columns,
 	}
 
@@ -221,6 +235,90 @@ func queryPayloadP50(ctx context.Context, client *xatu.Client, slot phase0.Slot,
 	}
 
 	return p50, nil
+}
+
+// ptcWaveQuery reduces the gloas payload attestation events to 50ms chunks of
+// unique PTC votes, split by the vote's payload_present verdict. Each vote is
+// deduplicated to its first sighting across all observing nodes. Plain SQL
+// for the same reason as payloadGossipQuery.
+const ptcWaveQuery = `SELECT chunk, payload_present, count() AS votes
+FROM (
+    SELECT validator_index, payload_present,
+           toUInt32(intDiv(min(propagation_slot_start_diff), 50) * 50) AS chunk
+    FROM beacon_api_eth_v1_events_payload_attestation
+    WHERE meta_network_name = ? AND slot_start_date_time = toDateTime(?) AND slot = ?%s
+    GROUP BY validator_index, payload_present
+)
+GROUP BY chunk, payload_present
+ORDER BY chunk`
+
+// loadPtcWave loads the payload timeliness committee's voting wave, or nil on
+// networks without the gloas schema.
+func loadPtcWave(ctx context.Context, client *xatu.Client, slot phase0.Slot, slotTime time.Time, settled bool, blockRoot string) (*models.SlotPtcWave, error) {
+	filter := ""
+	args := []any{client.Network(), slotTime.Unix(), uint32(slot)}
+
+	if blockRoot != "" {
+		filter = " AND beacon_block_root = ?"
+
+		args = append(args, blockRoot)
+	}
+
+	rows, err := client.Query(ctx, settled, fmt.Sprintf(ptcWaveQuery, filter), args...)
+	if err != nil {
+		if isMissingTableError(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("ptc wave query: %w", err)
+	}
+	defer rows.Close()
+
+	buckets := map[uint32]*models.SlotPtcBucket{}
+	wave := &models.SlotPtcWave{}
+
+	for rows.Next() {
+		var chunk uint32
+
+		var present bool
+
+		var votes uint64
+
+		if err := rows.Scan(&chunk, &present, &votes); err != nil {
+			return nil, fmt.Errorf("ptc wave scan: %w", err)
+		}
+
+		bucket := buckets[chunk]
+		if bucket == nil {
+			bucket = &models.SlotPtcBucket{Ms: chunk}
+			buckets[chunk] = bucket
+			wave.Buckets = append(wave.Buckets, bucket)
+		}
+
+		count := int(votes) //nolint:gosec // bounded by the committee size
+		wave.TotalCount += count
+
+		if present {
+			bucket.Present += count
+			wave.PresentCount += count
+		} else {
+			bucket.Missing += count
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ptc wave query: %w", err)
+	}
+
+	if wave.TotalCount == 0 {
+		return nil, nil
+	}
+
+	sort.Slice(wave.Buckets, func(a, b int) bool {
+		return wave.Buckets[a].Ms < wave.Buckets[b].Ms
+	})
+
+	return wave, nil
 }
 
 // waveRoot accumulates one voted block root's buckets before they are sorted

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -53,9 +53,14 @@ func SlotWaves(w http.ResponseWriter, r *http.Request) {
 	// usable root fall back to the whole slot.
 	blockRoot := normalizeBlockRoot(r.URL.Query().Get("root"))
 
-	cacheKey := fmt.Sprintf("slotwaves:%d:%s", slot, blockRoot)
+	// the execution block identity comes from the page, like on the arrival
+	// endpoint; a bad value only misses the executed series
+	execHash := normalizeBlockRoot(r.URL.Query().Get("exec"))
+	execNumber, _ := strconv.ParseUint(r.URL.Query().Get("num"), 10, 64)
+
+	cacheKey := fmt.Sprintf("slotwaves:%d:%s:%s:%d", slot, blockRoot, execHash, execNumber)
 	pageRes, pageErr := services.GlobalFrontendCache.ProcessCachedPage(cacheKey, true, &models.SlotWavesResponse{}, func(pageCall *services.FrontendCacheProcessingPage) any {
-		data, cacheTimeout, buildErr := buildSlotWavesData(pageCall.CallCtx, phase0.Slot(slot), blockRoot)
+		data, cacheTimeout, buildErr := buildSlotWavesData(pageCall.CallCtx, phase0.Slot(slot), blockRoot, execHash, execNumber)
 		if buildErr != nil {
 			logrus.WithError(buildErr).Error("error loading slot waves data from xatu-cbt")
 			pageCall.CacheTimeout = -1
@@ -89,7 +94,7 @@ func SlotWaves(w http.ResponseWriter, r *http.Request) {
 // data column measurements. It returns the response and the cache timeout,
 // following the same ladder as the arrival endpoint: one slot while the cbt
 // transformations may still rewrite the slot's rows, then short, then long.
-func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string) (*models.SlotWavesResponse, time.Duration, error) {
+func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot, execHash string, execNumber uint64) (*models.SlotWavesResponse, time.Duration, error) {
 	client := xatu.GlobalCbtClient
 	chainState := services.GlobalBeaconService.GetChainState()
 	slotTime := chainState.SlotToTime(slot)
@@ -118,7 +123,7 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 
 	var ptc *models.SlotPtcWave
 
-	var payload, head *models.SlotSeenWave
+	var payload, head, executed *models.SlotSeenWave
 
 	if xatu.GlobalClient != nil {
 		slotMs := lateThreshold(chainState)
@@ -151,6 +156,13 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 
 			head = nil
 		}
+
+		executed, err = loadExecutedWave(queryCtx, xatu.GlobalClient, execHash, execNumber, slotTime, settled, slotMs)
+		if err != nil {
+			logrus.WithError(err).Warn("error loading executed wave from xatu")
+
+			executed = nil
+		}
 	}
 
 	response := &models.SlotWavesResponse{
@@ -161,6 +173,7 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 		Ptc:          ptc,
 		Payload:      payload,
 		Head:         head,
+		Executed:     executed,
 		Columns:      columns,
 	}
 
@@ -222,6 +235,68 @@ func voteThreshold(chainState *consensus.ChainState, expected int) int {
 	}
 
 	return int(uint64(expected) * numerator / denominator) //nolint:gosec // bounded by the validator set
+}
+
+// executedWaveQuery buckets when each node's execution client finished
+// importing the payload: the newPayload call start plus its duration, taken
+// from the execution-side captures, which are keyed by block rather than
+// slot. Bounded to the slot like the other waves.
+const executedWaveQuery = `SELECT toUInt32(intDiv(first_ms, 50) * 50) AS chunk, count() AS nodes
+FROM (
+    SELECT meta_client_name,
+           min(toUnixTimestamp64Milli(requested_date_time) + toInt64(duration_ms)) - ? AS first_ms
+    FROM execution_engine_new_payload
+    WHERE meta_network_name = ? AND block_number = ? AND block_hash = ?
+    GROUP BY meta_client_name
+    HAVING first_ms BETWEEN 0 AND ?
+)
+GROUP BY chunk
+ORDER BY chunk`
+
+// loadExecutedWave loads the per-node payload execution wave, or nil when the
+// page provided no execution block or the network lacks the capture table.
+func loadExecutedWave(ctx context.Context, client *xatu.Client, execHash string, execNumber uint64, slotTime time.Time, settled bool, slotMs uint32) (*models.SlotSeenWave, error) {
+	if execHash == "" || execNumber == 0 {
+		return nil, nil
+	}
+
+	args := []any{slotTime.UnixMilli(), client.Network(), execNumber, execHash, slotMs}
+
+	rows, err := client.Query(ctx, settled, executedWaveQuery, args...)
+	if err != nil {
+		if isMissingTableError(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("executed wave query: %w", err)
+	}
+	defer rows.Close()
+
+	wave := &models.SlotSeenWave{}
+
+	for rows.Next() {
+		var chunk uint32
+
+		var nodes uint64
+
+		if err := rows.Scan(&chunk, &nodes); err != nil {
+			return nil, fmt.Errorf("executed wave scan: %w", err)
+		}
+
+		count := int(nodes) //nolint:gosec // bounded by the node fleet
+		wave.TotalCount += count
+		wave.Buckets = append(wave.Buckets, &models.SlotAttestationBucket{Ms: chunk, Count: count})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("executed wave query: %w", err)
+	}
+
+	if wave.TotalCount == 0 {
+		return nil, nil
+	}
+
+	return wave, nil
 }
 
 // expectedAttesters is how many validators were due to attest in the slot:

--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -109,16 +109,6 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 		attestations.ExpectedCount = expectedAttesters(queryCtx, chainState, slot)
 		attestations.ThresholdCount = voteThreshold(chainState, attestations.ExpectedCount)
 
-		if xatu.GlobalClient != nil {
-			p50, plErr := queryPayloadP50(queryCtx, xatu.GlobalClient, slot, slotTime, settled, blockRoot)
-			if plErr != nil {
-				// the payload marker is garnish on the attestation chart, so
-				// its failure must not take the whole panel down
-				logrus.WithError(plErr).Warn("error loading payload p50 from xatu")
-			} else {
-				attestations.PayloadP50Ms = p50
-			}
-		}
 	}
 
 	columns, err := loadColumnWave(queryCtx, client, slot, slotTime, settled, blockRoot)
@@ -128,19 +118,38 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 
 	var ptc *models.SlotPtcWave
 
+	var payload, head *models.SlotSeenWave
+
 	if xatu.GlobalClient != nil {
+		slotMs := lateThreshold(chainState)
+
 		ptc, err = loadPtcWave(queryCtx, xatu.GlobalClient, slot, slotTime, settled, blockRoot)
 		if err != nil {
-			// like the payload marker, the PTC row must not take the other
-			// panels down with it
+			// the raw-backed series must not take the cbt panels down
 			logrus.WithError(err).Warn("error loading ptc wave from xatu")
 
 			ptc = nil
 		}
 
 		if ptc != nil {
-			// votes are due within PAYLOAD_ATTESTATION_DUE_BPS of the slot
+			// votes are due within PAYLOAD_ATTESTATION_DUE_BPS of the slot,
+			// from a committee of PTC_SIZE
 			ptc.DeadlineMs = bpsOfSlot(chainState, chainState.GetSpecs().PayloadAttestationDueBps, 7500)
+			ptc.ExpectedCount = int(chainState.GetSpecs().PtcSize) //nolint:gosec // committee sizes are small
+		}
+
+		payload, err = loadSeenWave(queryCtx, xatu.GlobalClient, "beacon_api_eth_v1_events_execution_payload_gossip", "block_root", slot, slotTime, settled, blockRoot, slotMs)
+		if err != nil {
+			logrus.WithError(err).Warn("error loading payload wave from xatu")
+
+			payload = nil
+		}
+
+		head, err = loadSeenWave(queryCtx, xatu.GlobalClient, "beacon_api_eth_v1_events_head", "block", slot, slotTime, settled, blockRoot, slotMs)
+		if err != nil {
+			logrus.WithError(err).Warn("error loading head wave from xatu")
+
+			head = nil
 		}
 	}
 
@@ -150,6 +159,8 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot string)
 		SlotMs:       lateThreshold(chainState),
 		Attestations: attestations,
 		Ptc:          ptc,
+		Payload:      payload,
+		Head:         head,
 		Columns:      columns,
 	}
 
@@ -240,53 +251,68 @@ func expectedAttesters(ctx context.Context, chainState *consensus.ChainState, sl
 	return int(rows[0].ValidatorCount / slotsPerEpoch) //nolint:gosec // bounded by the validator set
 }
 
-// payloadP50Query reduces the gloas payload gossip series to its median; see
-// payloadGossipQuery for why this is plain SQL.
-const payloadP50Query = `SELECT count() AS observations, toUInt32(quantileExact(0.5)(propagation_slot_start_diff)) AS p50
-FROM beacon_api_eth_v1_events_execution_payload_gossip
-WHERE meta_network_name = ? AND slot_start_date_time = toDateTime(?) AND slot = ?%s`
+// seenWaveQuery buckets when each observing node first saw one per-slot
+// object, capped to the slot so an hours-late straggler cannot stretch the
+// chart. Aggregated in ClickHouse because the generated builders cannot
+// express GROUP BY; the object table and its block-root column are
+// interpolated from constants, never from user input.
+const seenWaveQuery = `SELECT toUInt32(intDiv(first_ms, 50) * 50) AS chunk, count() AS nodes
+FROM (
+    SELECT meta_client_name, min(propagation_slot_start_diff) AS first_ms
+    FROM %s
+    WHERE meta_network_name = ? AND slot_start_date_time = toDateTime(?) AND slot = ? AND propagation_slot_start_diff <= ?%s
+    GROUP BY meta_client_name
+)
+GROUP BY chunk
+ORDER BY chunk`
 
-// queryPayloadP50 returns the median payload arrival for the slot, or zero on
-// networks without the gloas payload series.
-func queryPayloadP50(ctx context.Context, client *xatu.Client, slot phase0.Slot, slotTime time.Time, settled bool, blockRoot string) (uint32, error) {
+// loadSeenWave loads one first-seen-per-node wave, or nil on networks whose
+// xatu schema lacks the table.
+func loadSeenWave(ctx context.Context, client *xatu.Client, table, rootColumn string, slot phase0.Slot, slotTime time.Time, settled bool, blockRoot string, slotMs uint32) (*models.SlotSeenWave, error) {
 	filter := ""
-	args := []any{client.Network(), slotTime.Unix(), uint32(slot)}
+	args := []any{client.Network(), slotTime.Unix(), uint32(slot), slotMs}
 
 	if blockRoot != "" {
-		filter = " AND block_root = ?"
+		filter = " AND " + rootColumn + " = ?"
 
 		args = append(args, blockRoot)
 	}
 
-	rows, err := client.Query(ctx, settled, fmt.Sprintf(payloadP50Query, filter), args...)
+	rows, err := client.Query(ctx, settled, fmt.Sprintf(seenWaveQuery, table, filter), args...)
 	if err != nil {
 		if isMissingTableError(err) {
-			return 0, nil
+			return nil, nil
 		}
 
-		return 0, fmt.Errorf("payload p50 query: %w", err)
+		return nil, fmt.Errorf("%s wave query: %w", table, err)
 	}
 	defer rows.Close()
 
-	var observations uint64
-
-	var p50 uint32
+	wave := &models.SlotSeenWave{}
 
 	for rows.Next() {
-		if err := rows.Scan(&observations, &p50); err != nil {
-			return 0, fmt.Errorf("payload p50 scan: %w", err)
+		var chunk uint32
+
+		var nodes uint64
+
+		if err := rows.Scan(&chunk, &nodes); err != nil {
+			return nil, fmt.Errorf("%s wave scan: %w", table, err)
 		}
+
+		count := int(nodes) //nolint:gosec // bounded by the node fleet
+		wave.TotalCount += count
+		wave.Buckets = append(wave.Buckets, &models.SlotAttestationBucket{Ms: chunk, Count: count})
 	}
 
 	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("payload p50 query: %w", err)
+		return nil, fmt.Errorf("%s wave query: %w", table, err)
 	}
 
-	if observations == 0 {
-		return 0, nil
+	if wave.TotalCount == 0 {
+		return nil, nil
 	}
 
-	return p50, nil
+	return wave, nil
 }
 
 // ptcWaveQuery reduces the gloas payload attestation events to 50ms chunks of

--- a/handlers/slot_waves_test.go
+++ b/handlers/slot_waves_test.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	cbtch "github.com/ethpandaops/xatu-cbt/pkg/proto/clickhouse"
+)
+
+// The cbt cluster runs with force_primary_key, and which of slot or
+// slot_start_date_time leads a table's primary key differs between tables and
+// replicas. Every cbt query therefore has to filter on both; a builder that
+// silently dropped one would only fail in production.
+func TestCbtQueriesFilterBothPrimaryKeys(t *testing.T) {
+	slotFilter := &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: 123}}
+	timeFilter := &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: 456}}
+
+	queries := map[string]func() (cbtch.SQLQuery, error){
+		"attestation wave": func() (cbtch.SQLQuery, error) {
+			return cbtch.BuildListFctAttestationFirstSeenChunked50MsQuery(&cbtch.ListFctAttestationFirstSeenChunked50MsRequest{
+				Slot: slotFilter, SlotStartDateTime: timeFilter,
+			})
+		},
+		"column first seen": func() (cbtch.SQLQuery, error) {
+			return cbtch.BuildListFctBlockDataColumnSidecarFirstSeenQuery(&cbtch.ListFctBlockDataColumnSidecarFirstSeenRequest{
+				Slot: slotFilter, SlotStartDateTime: timeFilter,
+			})
+		},
+		"column availability": func() (cbtch.SQLQuery, error) {
+			return cbtch.BuildListFctDataColumnAvailabilityBySlotQuery(&cbtch.ListFctDataColumnAvailabilityBySlotRequest{
+				Slot: slotFilter, SlotStartDateTime: timeFilter,
+			})
+		},
+	}
+
+	for name, build := range queries {
+		q, err := build()
+		if err != nil {
+			t.Fatalf("%s: build: %v", name, err)
+		}
+
+		for _, column := range []string{"slot =", "slot_start_date_time ="} {
+			if !strings.Contains(q.Query, column) {
+				t.Errorf("%s: missing %q filter in %q", name, column, q.Query)
+			}
+		}
+	}
+}
+
+// The paged reader contract from the raw tables holds for the cbt builders
+// too: a page token is a row offset, and the ceiling matches MaxQueryPageSize.
+func TestCbtPageTokenIsRowOffset(t *testing.T) {
+	const pageSize = 10000
+
+	for page, wantOffset := range map[int]string{0: "", 1: "10000", 2: "20000"} {
+		q, err := cbtch.BuildListFctAttestationFirstSeenChunked50MsQuery(&cbtch.ListFctAttestationFirstSeenChunked50MsRequest{
+			Slot:      &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: 1}},
+			PageSize:  pageSize,
+			PageToken: cbtPageToken(uint32(page * pageSize)),
+		})
+		if err != nil {
+			t.Fatalf("page %d: build: %v", page, err)
+		}
+
+		if !strings.Contains(q.Query, "LIMIT 10000") {
+			t.Errorf("page %d: expected LIMIT 10000 in %q", page, q.Query)
+		}
+
+		if wantOffset == "" {
+			if strings.Contains(q.Query, "OFFSET") {
+				t.Errorf("page 0 should not paginate, got %q", q.Query)
+			}
+
+			continue
+		}
+
+		if !strings.Contains(q.Query, "OFFSET "+wantOffset) {
+			t.Errorf("page %d: expected OFFSET %s, got %q", page, wantOffset, q.Query)
+		}
+	}
+}
+
+func TestCbtMaxPageSizeIsTheCeiling(t *testing.T) {
+	build := func(size int32) error {
+		_, err := cbtch.BuildListFctAttestationFirstSeenChunked50MsQuery(&cbtch.ListFctAttestationFirstSeenChunked50MsRequest{
+			Slot:     &cbtch.UInt32Filter{Filter: &cbtch.UInt32Filter_Eq{Eq: 1}},
+			PageSize: size,
+		})
+
+		return err
+	}
+
+	if err := build(10000); err != nil {
+		t.Fatalf("page size 10000 must be accepted: %v", err)
+	}
+
+	if err := build(10001); err == nil {
+		t.Fatal("page size 10001 must be rejected")
+	}
+}
+
+// A slot under attack can carry votes for many roots; the response merges the
+// tail so the payload stays bounded, and the viewed root keeps its own entry
+// even when it is not the most voted one.
+func TestAssembleWaveRootsMergesTheTail(t *testing.T) {
+	roots := map[string]*waveRoot{}
+
+	for i := 0; i < maxWaveRoots+3; i++ {
+		root := fmt.Sprintf("0x%064d", i)
+		roots[root] = &waveRoot{
+			root:    root,
+			count:   100 - i,
+			buckets: map[uint32]int{4000: 100 - i},
+		}
+	}
+
+	total := 0
+	for _, root := range roots {
+		total += root.count
+	}
+
+	viewedRoot := fmt.Sprintf("0x%064d", 1)
+	wave := assembleWaveRoots(roots, total, viewedRoot)
+
+	if len(wave.Roots) != maxWaveRoots+1 {
+		t.Fatalf("expected %d roots after merge, got %d", maxWaveRoots+1, len(wave.Roots))
+	}
+
+	last := wave.Roots[len(wave.Roots)-1]
+	if last.Root != "" {
+		t.Errorf("merged tail must have an empty root, got %q", last.Root)
+	}
+
+	if last.Count != (100-maxWaveRoots)+(100-maxWaveRoots-1)+(100-maxWaveRoots-2) {
+		t.Errorf("merged tail count wrong: %d", last.Count)
+	}
+
+	if !wave.Roots[1].Viewed || wave.Roots[1].Root != viewedRoot {
+		t.Errorf("viewed root not marked: %+v", wave.Roots[1])
+	}
+
+	sum := 0
+	for _, root := range wave.Roots {
+		sum += root.Count
+	}
+
+	if sum != total {
+		t.Errorf("merge lost votes: %d != %d", sum, total)
+	}
+}

--- a/handlers/xatu_paging.go
+++ b/handlers/xatu_paging.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	cbtch "github.com/ethpandaops/xatu-cbt/pkg/proto/clickhouse"
+	xch "github.com/ethpandaops/xatu/pkg/proto/clickhouse"
+)
+
+// xatuPageToken encodes a QueryPaged row offset into a page token for the
+// xatu raw table builders. The zero offset must stay an empty token: the
+// builders treat "" as page one, and a token of zero would be decoded and
+// re-applied as OFFSET 0 anyway.
+func xatuPageToken(pageOffset uint32) string {
+	if pageOffset == 0 {
+		return ""
+	}
+
+	return xch.EncodePageToken(pageOffset)
+}
+
+// cbtPageToken is xatuPageToken for the xatu-cbt table builders. The two
+// generated packages use the same token format, but each builder only decodes
+// tokens produced by its own package's helper.
+func cbtPageToken(pageOffset uint32) string {
+	if pageOffset == 0 {
+		return ""
+	}
+
+	return cbtch.EncodePageToken(pageOffset)
+}

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -296,13 +296,9 @@
           <div class="col-md-10" id="arrival-regions"></div>
         </div>
         {{ if .XatuCbtEnabled }}
-        <div class="row border-bottom p-2 mx-0" id="waves-att" style="display: none;">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="When the network first saw this slot's attestations, in 50ms buckets. Votes for other roots mean those attesters had not imported this block in time.">Attestations:</span></div>
-          <div class="col-md-10" id="waves-att-body"></div>
-        </div>
-        <div class="row border-bottom p-2 mx-0" id="waves-ptc" style="display: none;">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="The payload timeliness committee's votes on whether the proposer revealed the execution payload on time, in 50ms buckets of when each vote was first seen.">PTC votes:</span></div>
-          <div class="col-md-10" id="waves-ptc-body"></div>
+        <div class="row border-bottom p-2 mx-0" id="waves-timeline" style="display: none;">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="The slot's phases as cumulative curves: each line is the share of its own population that has acted by that time. Attestations count against the slot's expected attesters, PTC votes against the committee, payload and head against the nodes that observed them.">Timeline:</span></div>
+          <div class="col-md-10" id="waves-timeline-body"></div>
         </div>
         <div class="row border-bottom p-2 mx-0" id="waves-cols" style="display: none;">
           <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="PeerDAS data column sidecars: when each of the 128 columns of this block's blob data was first seen, and how available each measured under custody probing.">Data columns:</span></div>
@@ -762,142 +758,92 @@
         return { lo: axLo, hi: axHi, span: span, lines: lines };
       }
 
-      // waveDomain spans the whole slot, so every slot's charts share one
-      // axis and the two rows line up vertically; data past the slot end
-      // stretches it rather than being cut off.
-      function waveDomain(slotMs, dataHi, binMs) {
-        return Math.max(slotMs || 12000, dataHi + binMs * 2);
-      }
+      // The timeline reads the slot as its phases race to completion: the two
+      // halves of a gloas block (the bid, then the payload) and the votes on
+      // each become comparable cumulative curves on one axis. Each series is
+      // normalized to its own population.
+      function renderTimeline(data) {
+        var slotMs = data.slot_ms || 12000;
+        var att = data.attestations;
+        var series = [];
+        var viewed = null;
 
-      function waveBin(domain) {
-        var sizes = [50, 100, 250, 500, 1000];
-
-        for (var i = 0; i < sizes.length; i++) {
-          if (domain / sizes[i] <= 130) return sizes[i];
+        if (att && att.total_count) {
+          (att.roots || []).forEach(function(r) { if (r.viewed) viewed = r; });
+          if (!viewed) viewed = (att.roots || [])[0];
         }
 
-        return sizes[sizes.length - 1];
-      }
+        if (viewed) {
+          series.push({
+            label: 'attestations', color: '#5b8def',
+            buckets: viewed.buckets || [],
+            count: viewed.count,
+            denom: att.expected_count || viewed.count,
+          });
+        }
 
-      // renderHist draws chunky bars with gaps into the histogram block:
-      // bins = [{ms, green, red, tip}], stacked red on green, scaled to the
-      // tallest bin. Returns null when there is nothing to draw.
-      function renderHist(ax, bins, binMs, marks, small) {
+        if (data.ptc && data.ptc.total_count) {
+          series.push({
+            label: 'PTC votes', color: '#9775fa',
+            buckets: (data.ptc.buckets || []).map(function(b) { return { ms: b.ms, count: b.present + b.missing }; }),
+            count: data.ptc.total_count,
+            denom: data.ptc.expected_count || data.ptc.total_count,
+          });
+        }
+
+        if (data.payload && data.payload.total_count) {
+          series.push({
+            label: 'payload seen', color: '#e64980',
+            buckets: data.payload.buckets || [],
+            count: data.payload.total_count,
+            denom: data.payload.total_count,
+          });
+        }
+
+        if (data.head && data.head.total_count) {
+          series.push({
+            label: 'head adopted', color: '#20c997',
+            buckets: data.head.buckets || [],
+            count: data.head.total_count,
+            denom: data.head.total_count,
+          });
+        }
+
+        if (!series.length) return;
+
+        document.getElementById('waves-timeline').style.display = '';
+
+        var ax = histAxis(0, slotMs);
         var pos = function(ms) { return (ms - ax.lo) / ax.span * 100; };
-        var peak = 0;
 
-        bins.forEach(function(b) {
-          if (b.green + b.red > peak) peak = b.green + b.red;
+        var chart = '';
+
+        [25, 50, 75].forEach(function(pct) {
+          chart += '<div class="hgrid" style="top:' + (100 - pct) + '%"></div>' +
+            '<span class="ylab" style="top:' + (100 - pct) + '%">' + pct + '%</span>';
         });
-        if (!peak) return null;
-
-        var html = '';
 
         ax.lines.forEach(function(t) {
-          html += '<div class="grid" style="left:' + pos(t) + '%"></div>';
-        });
-
-        // each marker label gets its own row, so close markers stay readable
-        (marks || []).forEach(function(m, idx) {
-          if (m.ms <= ax.lo || m.ms >= ax.hi) return;
-
-          html += '<div class="deadline" style="left:' + pos(m.ms) + '%;border-left-color:' + m.color + '">' +
-            '<span class="note" style="top:' + (1 + idx * 13) + 'px;color:' + m.color + '" title="' + esc(m.title) + '">' +
-            m.label + '</span></div>';
-        });
-
-        var slotW = binMs / ax.span * 100;
-        var barW = slotW * 0.7;
-        var off = (slotW - barW) / 2;
-
-        bins.forEach(function(b) {
-          var total = b.green + b.red;
-          if (!total) return;
-
-          var left = (pos(b.ms) + off).toFixed(3) + '%';
-          var width = barW.toFixed(3) + '%';
-          var greenH = b.green ? Math.max(2, b.green / peak * 100) : 0;
-
-          if (b.green) {
-            html += '<div class="bar" style="left:' + left + ';width:' + width + ';height:' + greenH +
-              '%;background:#34c38f;border-radius:' + (b.red ? '0' : '2px 2px 0 0') + '" title="' + b.tip + '"></div>';
-          }
-
-          if (b.red) {
-            html += '<div class="bar" style="left:' + left + ';width:' + width + ';bottom:' + greenH +
-              '%;height:' + Math.max(2, b.red / peak * 100) +
-              '%;background:#f46a6a;border-radius:2px 2px 0 0" title="' + b.tip + '"></div>';
-          }
-        });
-
-        var labels = '';
-
-        ax.lines.forEach(function(t) {
-          labels += '<span style="left:' + pos(t) + '%">' + fmtAxis(t) + '</span>';
-        });
-        labels += '<span style="left:100%">' + fmtAxis(ax.hi) + '</span>';
-
-        return '<div class="arrival-hist' + (small ? ' hist-sm' : '') + '">' + html + '</div>' +
-          '<div class="arrival-hist-axis">' + labels + '</div>';
-      }
-
-      function renderAttWave(att, settled, slotMs) {
-        if (!att.total_count) return;
-
-        var viewed = null;
-        var otherCount = 0;
-        var otherRoots = [];
-
-        (att.roots || []).forEach(function(r) {
-          if (r.viewed) { viewed = r; return; }
-          otherCount += r.count;
-          otherRoots.push(r.root ? r.root.slice(0, 10) + '\u2026' : 'smaller roots');
-        });
-
-        var lo = null, hi = null;
-
-        (att.roots || []).forEach(function(r) {
-          (r.buckets || []).forEach(function(b) {
-            if (lo == null || b.ms < lo) lo = b.ms;
-            if (hi == null || b.ms > hi) hi = b.ms;
-          });
-        });
-        if (lo == null) return;
-
-        // rebin the 50ms chunks until the bars are chunky enough to read
-        // across the whole slot
-        var binMs = waveBin(waveDomain(slotMs, hi, 50));
-
-        var binned = {};
-
-        (att.roots || []).forEach(function(r) {
-          (r.buckets || []).forEach(function(b) {
-            var ms = Math.floor(b.ms / binMs) * binMs;
-            var bin = binned[ms] || (binned[ms] = { ms: ms, green: 0, red: 0 });
-            bin[r.viewed || !viewed ? 'green' : 'red'] += b.count;
-          });
-        });
-
-        var bins = Object.keys(binned).map(function(ms) {
-          var b = binned[ms];
-          b.tip = fmtStr(b.ms) + '\u2013' + fmtStr(b.ms + binMs) + ': ' + (b.green + b.red).toLocaleString() +
-            ' attestations' + (b.red ? ' (' + b.red.toLocaleString() + ' for other roots)' : '');
-          return b;
+          chart += '<div class="grid" style="left:' + pos(t) + '%"></div>';
         });
 
         var marks = [];
 
-        if (att.deadline_ms > 0) {
+        if (att && att.deadline_ms > 0) {
           marks.push({
-            ms: att.deadline_ms, label: 'deadline', color: 'var(--bs-secondary-color)',
-            title: 'One third into the slot: validators attest now even without a block in hand',
+            ms: att.deadline_ms, label: 'attestation deadline', color: 'var(--bs-secondary-color)',
+            title: 'ATTESTATION_DUE_BPS into the slot: validators attest now even without a block in hand',
           });
         }
 
-        // when the votes for this block clear the builder payment quorum,
-        // walked over the cumulative viewed-root buckets; the count and its
-        // ratio both come from the chain spec via the response
-        if (viewed && att.expected_count > 0 && att.threshold_count > 0) {
+        if (data.ptc && data.ptc.deadline_ms > 0) {
+          marks.push({
+            ms: data.ptc.deadline_ms, label: 'PTC deadline', color: 'var(--bs-secondary-color)',
+            title: 'PAYLOAD_ATTESTATION_DUE_BPS into the slot: PTC votes are due by here',
+          });
+        }
+
+        if (viewed && viewed.viewed && att.expected_count > 0 && att.threshold_count > 0) {
           var cum = 0;
           var thresholdMs = null;
 
@@ -910,39 +856,82 @@
           if (thresholdMs != null) {
             var pct = Math.round(att.threshold_count / att.expected_count * 100);
             marks.push({
-              ms: thresholdMs, label: pct + '% voted', color: '#34c38f',
-              title: 'Attestations for this block passed ' + att.threshold_count.toLocaleString() +
-                ' of the slot\u2019s ' + att.expected_count.toLocaleString() + ' expected attesters',
+              ms: thresholdMs, label: pct + '% quorum', color: '#34c38f',
+              title: 'Attestations for this block passed BUILDER_PAYMENT_THRESHOLD: ' +
+                att.threshold_count.toLocaleString() + ' of ' + att.expected_count.toLocaleString() + ' expected attesters',
             });
           }
         }
 
-        if (att.payload_p50_ms > 0) {
-          marks.push({
-            ms: att.payload_p50_ms, label: 'payload p50', color: '#e64980',
-            title: 'Median time the revealed execution payload reached observing nodes',
-          });
-        }
-
         marks.sort(function(a, b) { return a.ms - b.ms; });
 
-        var ax = histAxis(0, waveDomain(slotMs, hi, binMs));
-        var hist = renderHist(ax, bins, binMs, marks, false);
-        if (!hist) return;
+        marks.forEach(function(m, idx) {
+          if (m.ms <= ax.lo || m.ms >= ax.hi) return;
 
-        document.getElementById('waves-att').style.display = '';
+          chart += '<div class="deadline" style="left:' + pos(m.ms) + '%;border-left-color:' + m.color + '">' +
+            '<span class="note" style="top:' + (1 + idx * 13) + 'px;color:' + m.color + '" title="' + esc(m.title) + '">' +
+            m.label + '</span></div>';
+        });
 
-        var stats = '<b>' + att.total_count.toLocaleString() + '</b> attestations first seen';
-        if (viewed) {
-          stats += sep + '<span class="num" style="color:#34c38f"><b>' +
-            (viewed.count / att.total_count * 100).toFixed(1) + '%</b></span> <span class="text-muted">vote this block</span>';
+        // step curves: a vote in a 50ms chunk counts as landed by its end
+        var svg = '<svg viewBox="0 0 100 100" preserveAspectRatio="none">';
+
+        series.forEach(function(sr) {
+          var cum = 0;
+          var pts = ['0,100'];
+
+          sr.buckets.forEach(function(b) {
+            var x = Math.min(100, pos(b.ms + 50)).toFixed(2);
+            pts.push(x + ',' + (100 - cum / sr.denom * 100).toFixed(2));
+            cum += b.count;
+            pts.push(x + ',' + (100 - cum / sr.denom * 100).toFixed(2));
+          });
+
+          pts.push('100,' + (100 - cum / sr.denom * 100).toFixed(2));
+          svg += '<polyline points="' + pts.join(' ') + '" fill="none" stroke="' + sr.color +
+            '" stroke-width="1.6" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
+        });
+
+        svg += '</svg>';
+
+        var hovers = '';
+        var bins = 24;
+
+        for (var b = 0; b < bins; b++) {
+          var upto = ax.lo + ax.span * (b + 1) / bins;
+          var parts = [];
+
+          series.forEach(function(sr) {
+            var cum = 0;
+            sr.buckets.forEach(function(bk) { if (bk.ms + 50 <= upto) cum += bk.count; });
+            parts.push(sr.label + ' ' + Math.round(cum / sr.denom * 100) + '%');
+          });
+
+          hovers += '<div class="hover" style="left:' + (b / bins * 100) + '%;width:' + (100 / bins) +
+            '%" title="by ' + fmtStr(Math.round(upto)) + ': ' + parts.join(' \u00b7 ') + '"></div>';
         }
-        if (otherCount > 0) {
-          stats += sep + '<span class="num" style="color:#f46a6a" title="' + esc(otherRoots.join(', ')) + '"><b>' +
-            otherCount.toLocaleString() + '</b></span> <span class="text-muted">vote other roots</span>';
+
+        var labels = '';
+
+        ax.lines.forEach(function(t) {
+          labels += '<span style="left:' + pos(t) + '%">' + fmtAxis(t) + '</span>';
+        });
+        labels += '<span style="left:100%">' + fmtAxis(ax.hi) + '</span>';
+
+        var stats = series.map(function(sr) {
+          return '<span class="arrival-heat-key" style="background:' + sr.color + '"></span> ' + sr.label +
+            ' <b>' + sr.count.toLocaleString() + '</b>' +
+            (sr.denom !== sr.count ? '<span class="text-muted">/' + sr.denom.toLocaleString() + '</span>' : '');
+        }).join(sep);
+
+        if (viewed && viewed.viewed && att.total_count > viewed.count) {
+          stats += sep + '<span class="num" style="color:#f46a6a"><b>' +
+            (att.total_count - viewed.count).toLocaleString() + '</b></span> <span class="text-muted">vote other roots</span>';
         }
 
-        document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) + hist;
+        document.getElementById('waves-timeline-body').innerHTML = stats + liveBadge(data.settled) +
+          '<div class="arrival-hist">' + chart + svg + hovers + '</div>' +
+          '<div class="arrival-hist-axis">' + labels + '</div>';
       }
 
       // The column chart follows the lab's data column propagation view:
@@ -1083,73 +1072,8 @@
           '<div class="arrival-hist-axis">' + labels + '</div>' + legend;
       }
 
-      function renderPtcWave(ptc, settled, slotMs, payloadP50) {
-        if (!ptc.total_count) return;
-
-        var lo = null, hi = null;
-
-        (ptc.buckets || []).forEach(function(b) {
-          if (lo == null || b.ms < lo) lo = b.ms;
-          if (hi == null || b.ms > hi) hi = b.ms;
-        });
-        if (lo == null) return;
-
-        var binMs = waveBin(waveDomain(slotMs, hi, 50));
-        var binned = {};
-
-        (ptc.buckets || []).forEach(function(b) {
-          var ms = Math.floor(b.ms / binMs) * binMs;
-          var bin = binned[ms] || (binned[ms] = { ms: ms, green: 0, red: 0 });
-          bin.green += b.present;
-          bin.red += b.missing;
-        });
-
-        var bins = Object.keys(binned).map(function(ms) {
-          var b = binned[ms];
-          b.tip = fmtStr(b.ms) + '\u2013' + fmtStr(b.ms + binMs) + ': ' + (b.green + b.red) + ' PTC votes' +
-            (b.red ? ' (' + b.red + ' payload missing)' : '');
-          return b;
-        });
-
-        var marks = [];
-
-        if (payloadP50 > 0) {
-          marks.push({
-            ms: payloadP50, label: 'payload p50', color: '#e64980',
-            title: 'Median time the revealed execution payload reached observing nodes',
-          });
-        }
-
-        if (ptc.deadline_ms > 0) {
-          marks.push({
-            ms: ptc.deadline_ms, label: 'PTC deadline', color: 'var(--bs-secondary-color)',
-            title: 'Votes are due within the first 75% of the slot; some clients vote as soon as they see the payload, others wait for the deadline',
-          });
-        }
-
-        marks.sort(function(a, b) { return a.ms - b.ms; });
-
-        var ax = histAxis(0, waveDomain(slotMs, hi, binMs));
-        var hist = renderHist(ax, bins, binMs, marks, true);
-        if (!hist) return;
-
-        document.getElementById('waves-ptc').style.display = '';
-
-        var missing = ptc.total_count - ptc.present_count;
-        var stats = '<b>' + ptc.total_count.toLocaleString() + '</b> PTC votes first seen';
-        stats += sep + '<span class="num" style="color:' + (missing ? '#f46a6a' : '#34c38f') + '"><b>' +
-          (ptc.present_count / ptc.total_count * 100).toFixed(1) + '%</b></span> <span class="text-muted">judged the payload present</span>';
-        if (missing) {
-          stats += ' <span class="text-muted small">(' + missing.toLocaleString() + ' missing)</span>';
-        }
-
-        document.getElementById('waves-ptc-body').innerHTML = stats + liveBadge(settled) + hist;
-      }
-
       function renderWaves(data) {
-        var slotMs = data.slot_ms || (data.attestations ? data.attestations.deadline_ms * 3 : 0);
-        if (data.attestations) renderAttWave(data.attestations, data.settled, slotMs);
-        if (data.ptc) renderPtcWave(data.ptc, data.settled, slotMs, data.attestations ? data.attestations.payload_p50_ms : 0);
+        renderTimeline(data);
         if (data.columns) renderColWave(data.columns, data.settled);
       }
 
@@ -1159,7 +1083,7 @@
       // they are additive context, so their failure should not add noise to
       // the arrival panel above them.
       function loadWaves() {
-        if (wavesLoaded || !document.getElementById('waves-att')) return;
+        if (wavesLoaded || !document.getElementById('waves-timeline')) return;
         wavesLoaded = true;
         fetch('/slot/' + arrivalSlot + '/waves?root=' + encodeURIComponent(arrivalBlockRoot))
           .then(function(r) {
@@ -1167,7 +1091,11 @@
             return r.json();
           })
           .then(renderWaves)
-          .catch(function() {});
+          .catch(function(err) {
+            // the panels stay hidden on failure, but silence would hide real
+            // rendering bugs behind the same blank space as missing data
+            console.error('slot waves rendering failed:', err);
+          });
       }
 
       function loadArrival() {

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -300,6 +300,10 @@
           <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="When the network first saw this slot's attestations, in 50ms buckets. Votes for other roots mean those attesters had not imported this block in time.">Attestations:</span></div>
           <div class="col-md-10" id="waves-att-body"></div>
         </div>
+        <div class="row border-bottom p-2 mx-0" id="waves-ptc" style="display: none;">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="The payload timeliness committee's votes on whether the proposer revealed the execution payload on time, in 50ms buckets of when each vote was first seen.">PTC votes:</span></div>
+          <div class="col-md-10" id="waves-ptc-body"></div>
+        </div>
         <div class="row border-bottom p-2 mx-0" id="waves-cols" style="display: none;">
           <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="PeerDAS data column sidecars: when each of the 128 columns of this block's blob data was first seen, and how available each measured under custody probing.">Data columns:</span></div>
           <div class="col-md-10" id="waves-cols-body"></div>
@@ -1074,9 +1078,64 @@
           '<div class="arrival-hist-axis">' + labels + '</div>' + legend;
       }
 
+      function renderPtcWave(ptc, settled, slotMs, payloadP50) {
+        if (!ptc.total_count) return;
+
+        var lo = null, hi = null;
+
+        (ptc.buckets || []).forEach(function(b) {
+          if (lo == null || b.ms < lo) lo = b.ms;
+          if (hi == null || b.ms > hi) hi = b.ms;
+        });
+        if (lo == null) return;
+
+        var binMs = waveBin(waveDomain(slotMs, hi, 50));
+        var binned = {};
+
+        (ptc.buckets || []).forEach(function(b) {
+          var ms = Math.floor(b.ms / binMs) * binMs;
+          var bin = binned[ms] || (binned[ms] = { ms: ms, green: 0, red: 0 });
+          bin.green += b.present;
+          bin.red += b.missing;
+        });
+
+        var bins = Object.keys(binned).map(function(ms) {
+          var b = binned[ms];
+          b.tip = fmtStr(b.ms) + '\u2013' + fmtStr(b.ms + binMs) + ': ' + (b.green + b.red) + ' PTC votes' +
+            (b.red ? ' (' + b.red + ' payload missing)' : '');
+          return b;
+        });
+
+        var marks = [];
+
+        if (payloadP50 > 0) {
+          marks.push({
+            ms: payloadP50, label: 'payload p50', color: '#e64980',
+            title: 'Median time the revealed execution payload reached observing nodes',
+          });
+        }
+
+        var ax = histAxis(0, waveDomain(slotMs, hi, binMs));
+        var hist = renderHist(ax, bins, binMs, marks, true);
+        if (!hist) return;
+
+        document.getElementById('waves-ptc').style.display = '';
+
+        var missing = ptc.total_count - ptc.present_count;
+        var stats = '<b>' + ptc.total_count.toLocaleString() + '</b> PTC votes first seen';
+        stats += sep + '<span class="num" style="color:' + (missing ? '#f46a6a' : '#34c38f') + '"><b>' +
+          (ptc.present_count / ptc.total_count * 100).toFixed(1) + '%</b></span> <span class="text-muted">judged the payload present</span>';
+        if (missing) {
+          stats += ' <span class="text-muted small">(' + missing.toLocaleString() + ' missing)</span>';
+        }
+
+        document.getElementById('waves-ptc-body').innerHTML = stats + liveBadge(settled) + hist;
+      }
+
       function renderWaves(data) {
         var slotMs = data.slot_ms || (data.attestations ? data.attestations.deadline_ms * 3 : 0);
         if (data.attestations) renderAttWave(data.attestations, data.settled, slotMs);
+        if (data.ptc) renderPtcWave(data.ptc, data.settled, slotMs, data.attestations ? data.attestations.payload_p50_ms : 0);
         if (data.columns) renderColWave(data.columns, data.settled);
       }
 

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -196,43 +196,46 @@
     .arrival-table th.sortable { cursor: pointer; user-select: none; }
     .arrival-table th.sortable:hover { color: var(--bs-emphasis-color); }
 
-    .arrival-wave-mini {
+    .arrival-hist {
       position: relative;
-      height: 40px;
-      max-width: 520px;
-      margin-top: 6px;
+      height: 110px;
+      max-width: 820px;
+      margin-top: 8px;
+      border-left: 1px solid var(--bs-border-color);
       border-bottom: 1px solid var(--bs-border-color);
     }
-    .arrival-wave-mini svg {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      height: 100%;
+    .arrival-hist.hist-sm { height: 72px; }
+    .arrival-hist .grid {
+      position: absolute; top: 0; bottom: 0; width: 1px;
+      background: var(--bs-border-color);
+      opacity: 0.45;
     }
-    .arrival-wave-mini .hover {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-    }
-    .arrival-wave-mini .deadline {
+    .arrival-hist .bar { position: absolute; bottom: 0; }
+    .arrival-hist .deadline {
       position: absolute; top: 0; bottom: 0; width: 0;
       border-left: 1px dashed var(--bs-secondary-color);
     }
-    .arrival-wave-mini .deadline-flag {
+    .arrival-hist .deadline .note {
       position: absolute;
-      top: -3px;
+      top: 1px;
       padding-left: 5px;
       font-size: 0.63rem;
       color: var(--bs-secondary-color);
       white-space: nowrap;
     }
-    .arrival-wave-axis {
-      display: flex;
-      justify-content: space-between;
-      max-width: 520px;
+    .arrival-hist-axis {
+      position: relative;
+      max-width: 820px;
+      height: 0.95rem;
       font-size: 0.63rem;
       color: var(--bs-secondary-color);
       font-variant-numeric: tabular-nums;
+    }
+    .arrival-hist-axis > span {
+      position: absolute;
+      top: 2px;
+      transform: translateX(-50%);
+      white-space: nowrap;
     }
   </style>
 
@@ -672,14 +675,89 @@
         requestAnimationFrame(syncStickyOffsets);
       }
 
-      // The wave rows join the summary block above the table, so they follow
-      // its grammar: numbers first, one small muted visual under them.
+      // The wave rows join the summary block above the table: bold numbers
+      // first, then a proper histogram on the same gridline-and-label grammar
+      // as the table's timeline header.
       function liveBadge(settled) {
         if (settled) return '';
         return ' <span class="badge rounded-pill text-bg-info ms-1" style="font-size: 11px;">live &mdash; data may still be arriving</span>';
       }
 
       var sep = '<span class="text-muted px-2">&middot;</span>';
+
+      function histAxis(axLo, axHi) {
+        var span = Math.max(1, axHi - axLo);
+        var steps = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000];
+        var step = steps[steps.length - 1];
+
+        for (var i = 0; i < steps.length; i++) {
+          if (span / steps[i] <= 7) { step = steps[i]; break; }
+        }
+
+        var lines = [];
+        for (var t = Math.ceil(axLo / step) * step; t < axHi; t += step) {
+          if (t > axLo) lines.push(t);
+        }
+
+        return { lo: axLo, hi: axHi, span: span, lines: lines };
+      }
+
+      // renderHist draws chunky bars with gaps into the histogram block:
+      // bins = [{ms, green, red, tip}], stacked red on green, scaled to the
+      // tallest bin. Returns null when there is nothing to draw.
+      function renderHist(ax, bins, binMs, deadlineMs, small) {
+        var pos = function(ms) { return (ms - ax.lo) / ax.span * 100; };
+        var peak = 0;
+
+        bins.forEach(function(b) {
+          if (b.green + b.red > peak) peak = b.green + b.red;
+        });
+        if (!peak) return null;
+
+        var html = '';
+
+        ax.lines.forEach(function(t) {
+          html += '<div class="grid" style="left:' + pos(t) + '%"></div>';
+        });
+
+        if (deadlineMs != null && deadlineMs > ax.lo && deadlineMs < ax.hi) {
+          html += '<div class="deadline" style="left:' + pos(deadlineMs) + '%">' +
+            '<span class="note" title="One third into the slot: validators attest now even without a block in hand">deadline</span></div>';
+        }
+
+        var slotW = binMs / ax.span * 100;
+        var barW = slotW * 0.7;
+        var off = (slotW - barW) / 2;
+
+        bins.forEach(function(b) {
+          var total = b.green + b.red;
+          if (!total) return;
+
+          var left = (pos(b.ms) + off).toFixed(3) + '%';
+          var width = barW.toFixed(3) + '%';
+          var greenH = b.green ? Math.max(2, b.green / peak * 100) : 0;
+
+          if (b.green) {
+            html += '<div class="bar" style="left:' + left + ';width:' + width + ';height:' + greenH +
+              '%;background:#34c38f;border-radius:' + (b.red ? '0' : '2px 2px 0 0') + '" title="' + b.tip + '"></div>';
+          }
+
+          if (b.red) {
+            html += '<div class="bar" style="left:' + left + ';width:' + width + ';bottom:' + greenH +
+              '%;height:' + Math.max(2, b.red / peak * 100) +
+              '%;background:#f46a6a;border-radius:2px 2px 0 0" title="' + b.tip + '"></div>';
+          }
+        });
+
+        var labels = '';
+
+        ax.lines.forEach(function(t) {
+          labels += '<span style="left:' + pos(t) + '%">' + fmtAxis(t) + '</span>';
+        });
+
+        return '<div class="arrival-hist' + (small ? ' hist-sm' : '') + '">' + html + '</div>' +
+          '<div class="arrival-hist-axis">' + labels + '</div>';
+      }
 
       function renderAttWave(att, settled) {
         if (!att.total_count) return;
@@ -694,19 +772,45 @@
           otherRoots.push(r.root ? r.root.slice(0, 10) + '\u2026' : 'smaller roots');
         });
 
-        var chunks = {};
-        var lo = null, hi = null, peak = 0;
+        var lo = null, hi = null;
 
         (att.roots || []).forEach(function(r) {
           (r.buckets || []).forEach(function(b) {
-            var c = chunks[b.ms] || (chunks[b.ms] = { viewed: 0, other: 0 });
-            c[r.viewed ? 'viewed' : 'other'] += b.count;
             if (lo == null || b.ms < lo) lo = b.ms;
             if (hi == null || b.ms > hi) hi = b.ms;
-            if (c.viewed + c.other > peak) peak = c.viewed + c.other;
           });
         });
-        if (lo == null || !peak) return;
+        if (lo == null) return;
+
+        // rebin the 50ms chunks until the bars are chunky enough to read
+        var binMs = 50;
+        var sizes = [50, 100, 250, 500, 1000];
+
+        for (var i = 0; i < sizes.length; i++) {
+          binMs = sizes[i];
+          if ((hi - lo) / binMs <= 64) break;
+        }
+
+        var binned = {};
+
+        (att.roots || []).forEach(function(r) {
+          (r.buckets || []).forEach(function(b) {
+            var ms = Math.floor(b.ms / binMs) * binMs;
+            var bin = binned[ms] || (binned[ms] = { ms: ms, green: 0, red: 0 });
+            bin[r.viewed || !viewed ? 'green' : 'red'] += b.count;
+          });
+        });
+
+        var bins = Object.keys(binned).map(function(ms) {
+          var b = binned[ms];
+          b.tip = fmtStr(b.ms) + '\u2013' + fmtStr(b.ms + binMs) + ': ' + (b.green + b.red).toLocaleString() +
+            ' attestations' + (b.red ? ' (' + b.red.toLocaleString() + ' for other roots)' : '');
+          return b;
+        });
+
+        var ax = histAxis(Math.max(0, lo - binMs), hi + binMs * 2);
+        var hist = renderHist(ax, bins, binMs, att.deadline_ms, false);
+        if (!hist) return;
 
         document.getElementById('waves-att').style.display = '';
 
@@ -720,68 +824,12 @@
             otherCount.toLocaleString() + '</b></span> <span class="text-muted">vote other roots</span>';
         }
 
-        var axLo = Math.max(0, lo - 100);
-        var axHi = hi + 150;
-        var span = Math.max(1, axHi - axLo);
-        var pos = function(ms) { return (ms - axLo) / span * 100; };
-
-        // the silhouette is one smooth area rather than 50ms picket bars: a
-        // polygon through the bucket midpoints, with zero buckets pinned just
-        // under the viewBox so quiet stretches show no line at all
-        var W = 100, H = 40;
-        var px = function(ms) { return (pos(ms + 25)).toFixed(2); };
-        var py = function(v) {
-          if (!v) return (H + 1.5).toFixed(2);
-          return (H - Math.max(1, v / peak * (H - 4))).toFixed(2);
-        };
-
-        var viewedPts = [], totalPts = [], hovers = '';
-        for (var ms = lo; ms <= hi; ms += 50) {
-          var c = chunks[ms] || { viewed: 0, other: 0 };
-          viewedPts.push(px(ms) + ',' + py(c.viewed));
-          totalPts.push(px(ms) + ',' + py(c.viewed + c.other));
-
-          if (c.viewed + c.other > 0) {
-            hovers += '<div class="hover" style="left:' + pos(ms) + '%;width:' + (50 / span * 100) +
-              '%" title="' + fmtStr(ms) + '\u2013' + fmtStr(ms + 50) + ': ' + (c.viewed + c.other).toLocaleString() +
-              ' attestations' + (c.other ? ' (' + c.other.toLocaleString() + ' for other roots)' : '') + '"></div>';
-          }
-        }
-
-        var area = function(pts, fill, stroke) {
-          var edge = (H + 2).toFixed(2);
-          return '<polygon points="' + pts[0].split(',')[0] + ',' + edge + ' ' + pts.join(' ') + ' ' +
-            pts[pts.length - 1].split(',')[0] + ',' + edge + '" fill="' + fill + '"/>' +
-            '<polyline points="' + pts.join(' ') + '" fill="none" stroke="' + stroke +
-            '" stroke-width="1.5" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
-        };
-
-        var svg = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="none">';
-        if (otherCount > 0) {
-          // wrong-head votes fill only the band between the two lines, so the
-          // fills never stack into a muddy overlap
-          svg += '<polygon points="' + totalPts.join(' ') + ' ' + viewedPts.slice().reverse().join(' ') +
-            '" fill="rgba(244,106,106,0.55)"/>';
-        }
-        svg += area(viewedPts, 'rgba(52,195,143,0.25)', '#34c38f') + '</svg>';
-
-        var deadline = '';
-        if (att.deadline_ms > axLo && att.deadline_ms < axHi) {
-          deadline = '<div class="deadline" style="left:' + pos(att.deadline_ms) +
-            '%" title="One third into the slot: validators attest now even without a block in hand">' +
-            '<span class="deadline-flag">' + fmtAxis(att.deadline_ms) + ' deadline</span></div>';
-        }
-
-        document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) +
-          '<div class="arrival-wave-mini">' + svg + deadline + hovers + '</div>' +
-          '<div class="arrival-wave-axis"><span>' + fmtAxis(axLo) + '</span><span>' + fmtAxis(axHi) + '</span></div>';
+        document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) + hist;
       }
 
       function renderColWave(cols, settled) {
         var entries = cols.columns || [];
         if (!entries.length || !cols.blob_count) return;
-
-        document.getElementById('waves-cols').style.display = '';
 
         var stats = '<b>' + cols.blob_count + '</b> blob' + (cols.blob_count > 1 ? 's' : '') +
           sep + '<b>' + cols.seen_columns + '</b><span class="text-muted">/' + entries.length + ' columns seen</span>';
@@ -800,51 +848,46 @@
         var seen = entries.map(function(c) { return c.first_seen_ms; })
           .filter(function(v) { return v != null; })
           .sort(function(a, b) { return a - b; });
-        if (!seen.length) {
-          document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled);
-          return;
+
+        var hist = '';
+
+        if (seen.length) {
+          // the burst is tight, so the window gets a floor: bars cluster
+          // against calm space instead of being stretched to fill the width
+          var spread = seen[seen.length - 1] - seen[0];
+          var window = Math.max(spread * 1.4, 250);
+          var axLo = Math.max(0, seen[0] - (window - spread) / 2);
+
+          var binMs = 5;
+          var sizes = [5, 10, 20, 50, 100];
+
+          for (var i = 0; i < sizes.length; i++) {
+            binMs = sizes[i];
+            if (window / binMs <= 56) break;
+          }
+
+          var binned = {};
+
+          seen.forEach(function(ms) {
+            var key = Math.floor(ms / binMs) * binMs;
+            binned[key] = (binned[key] || 0) + 1;
+          });
+
+          var bins = Object.keys(binned).map(function(ms) {
+            ms = +ms;
+            return {
+              ms: ms, green: binned[ms], red: 0,
+              tip: binned[ms] + ' column' + (binned[ms] > 1 ? 's' : '') + ' first seen ' +
+                fmtStr(ms) + '\u2013' + fmtStr(ms + binMs),
+            };
+          });
+
+          var ax = histAxis(axLo, axLo + window);
+          hist = renderHist(ax, bins, binMs, null, true) || '';
         }
 
-        // cumulative columns-seen-over-time, zoomed to the burst. The y scale
-        // is all columns, so an incomplete set visibly plateaus below the top.
-        var total = entries.length;
-        var spread = Math.max(40, seen[seen.length - 1] - seen[0]);
-        var axLo = Math.max(0, seen[0] - spread * 0.06);
-        var axHi = seen[seen.length - 1] + spread * 0.12;
-        var span = Math.max(1, axHi - axLo);
-        var pos = function(ms) { return (ms - axLo) / span * 100; };
-
-        var W = 100, H = 40;
-        var px = function(ms) { return pos(ms).toFixed(2); };
-        var py = function(v) { return (H - Math.max(0, v / total * (H - 4))).toFixed(2); };
-
-        var pts = [px(seen[0]) + ',' + py(0)];
-        seen.forEach(function(ms, i) {
-          pts.push(px(ms) + ',' + py(i + 1));
-        });
-        pts.push(px(axHi) + ',' + py(seen.length));
-
-        var edge = (H + 2).toFixed(2);
-        var svg = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="none">' +
-          '<polygon points="' + px(seen[0]) + ',' + edge + ' ' + pts.join(' ') + ' ' + px(axHi) + ',' + edge +
-          '" fill="rgba(52,195,143,0.25)"/>' +
-          '<polyline points="' + pts.join(' ') + '" fill="none" stroke="#34c38f"' +
-          ' stroke-width="1.5" vector-effect="non-scaling-stroke" stroke-linejoin="round"/></svg>';
-
-        // hover bins report how much of the set had spread by each moment
-        var hovers = '';
-        var bins = 24;
-        for (var b = 0; b < bins; b++) {
-          var upto = axLo + span * (b + 1) / bins;
-          var count = 0;
-          while (count < seen.length && seen[count] <= upto) count++;
-          hovers += '<div class="hover" style="left:' + (b / bins * 100) + '%;width:' + (100 / bins) +
-            '%" title="' + count + '/' + total + ' columns seen by ' + fmtStr(Math.round(upto)) + '"></div>';
-        }
-
-        document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) +
-          '<div class="arrival-wave-mini">' + svg + hovers + '</div>' +
-          '<div class="arrival-wave-axis"><span>' + fmtAxis(Math.round(axLo)) + '</span><span>' + fmtAxis(Math.round(axHi)) + '</span></div>';
+        document.getElementById('waves-cols').style.display = '';
+        document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) + hist;
       }
 
       function renderWaves(data) {

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -234,17 +234,6 @@
       color: var(--bs-secondary-color);
       font-variant-numeric: tabular-nums;
     }
-    /* same pill as the sources bar, one seamless segment per column */
-    .arrival-col-strip {
-      display: flex;
-      height: 10px;
-      max-width: 520px;
-      margin-top: 6px;
-      border-radius: 5px;
-      overflow: hidden;
-      background: var(--bs-secondary-bg);
-    }
-    .arrival-col-strip > div { flex: 1 1 auto; }
   </style>
 
   <div id="arrival-content" class="card-body px-0 py-1">
@@ -788,14 +777,6 @@
           '<div class="arrival-wave-axis"><span>' + fmtAxis(axLo) + '</span><span>' + fmtAxis(axHi) + '</span></div>';
       }
 
-      // heat maps 0..1 onto green..red for the column strip. The range is the
-      // strip's own spread with a floor: a healthy tight spread (a few tens of
-      // ms) renders as one even green pill, and red is reserved for columns
-      // that lag by real fractions of a second.
-      function heat(t) {
-        return 'hsl(' + Math.round(145 - t * 145) + ' 62% 44%)';
-      }
-
       function renderColWave(cols, settled) {
         var entries = cols.columns || [];
         if (!entries.length || !cols.blob_count) return;
@@ -819,43 +800,51 @@
         var seen = entries.map(function(c) { return c.first_seen_ms; })
           .filter(function(v) { return v != null; })
           .sort(function(a, b) { return a - b; });
-        var rLo = seen.length ? seen[0] : 0;
-        var rHi = seen.length ? seen[Math.floor((seen.length - 1) * 0.95)] : 1;
-        var rSpan = Math.max(400, rHi - rLo);
+        if (!seen.length) {
+          document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled);
+          return;
+        }
 
-        var segments = entries.map(function(c) {
-          var style = '';
-          var tip = 'column ' + c.index;
+        // cumulative columns-seen-over-time, zoomed to the burst. The y scale
+        // is all columns, so an incomplete set visibly plateaus below the top.
+        var total = entries.length;
+        var spread = Math.max(40, seen[seen.length - 1] - seen[0]);
+        var axLo = Math.max(0, seen[0] - spread * 0.06);
+        var axHi = seen[seen.length - 1] + spread * 0.12;
+        var span = Math.max(1, axHi - axLo);
+        var pos = function(ms) { return (ms - axLo) / span * 100; };
 
-          if (c.first_seen_ms != null) {
-            tip += ' \u00b7 first seen ' + fmtStr(c.first_seen_ms);
-            if (c.first_seen_by) {
-              tip += ' by ' + c.first_seen_by;
-              var extra = [c.implementation, (c.country_code || '').toUpperCase()].filter(Boolean).join(', ');
-              if (extra) tip += ' (' + extra + ')';
-            }
-          } else {
-            tip += ' \u00b7 not seen';
-          }
+        var W = 100, H = 40;
+        var px = function(ms) { return pos(ms).toFixed(2); };
+        var py = function(v) { return (H - Math.max(0, v / total * (H - 4))).toFixed(2); };
 
-          if (c.availability_pct != null) {
-            tip += ' \u00b7 availability ' + c.availability_pct.toFixed(1) + '% (' + c.probes + ' probes' +
-              (c.p50_response_ms ? ', p50 ' + c.p50_response_ms + 'ms' : '') + ')';
-          }
+        var pts = [px(seen[0]) + ',' + py(0)];
+        seen.forEach(function(ms, i) {
+          pts.push(px(ms) + ',' + py(i + 1));
+        });
+        pts.push(px(axHi) + ',' + py(seen.length));
 
-          // red flags a column that failed probes; otherwise shade by first
-          // seen; a never-seen column keeps the muted background
-          if (c.availability_pct != null && c.availability_pct < 100) {
-            style = 'background:#f46a6a';
-          } else if (c.first_seen_ms != null) {
-            style = 'background:' + heat(Math.min(1, Math.max(0, (c.first_seen_ms - rLo) / rSpan)));
-          }
+        var edge = (H + 2).toFixed(2);
+        var svg = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="none">' +
+          '<polygon points="' + px(seen[0]) + ',' + edge + ' ' + pts.join(' ') + ' ' + px(axHi) + ',' + edge +
+          '" fill="rgba(52,195,143,0.25)"/>' +
+          '<polyline points="' + pts.join(' ') + '" fill="none" stroke="#34c38f"' +
+          ' stroke-width="1.5" vector-effect="non-scaling-stroke" stroke-linejoin="round"/></svg>';
 
-          return '<div style="' + style + '" title="' + esc(tip) + '"></div>';
-        }).join('');
+        // hover bins report how much of the set had spread by each moment
+        var hovers = '';
+        var bins = 24;
+        for (var b = 0; b < bins; b++) {
+          var upto = axLo + span * (b + 1) / bins;
+          var count = 0;
+          while (count < seen.length && seen[count] <= upto) count++;
+          hovers += '<div class="hover" style="left:' + (b / bins * 100) + '%;width:' + (100 / bins) +
+            '%" title="' + count + '/' + total + ' columns seen by ' + fmtStr(Math.round(upto)) + '"></div>';
+        }
 
         document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) +
-          '<div class="arrival-col-strip">' + segments + '</div>';
+          '<div class="arrival-wave-mini">' + svg + hovers + '</div>' +
+          '<div class="arrival-wave-axis"><span>' + fmtAxis(Math.round(axLo)) + '</span><span>' + fmtAxis(Math.round(axHi)) + '</span></div>';
       }
 
       function renderWaves(data) {

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -195,6 +195,37 @@
     .arrival-hide-np [data-col="np"] { display: none; }
     .arrival-table th.sortable { cursor: pointer; user-select: none; }
     .arrival-table th.sortable:hover { color: var(--bs-emphasis-color); }
+
+    .arrival-wave-track { position: relative; height: 96px; }
+    .arrival-wave-track .grid {
+      position: absolute; top: 0; bottom: 0; width: 1px;
+      background: var(--bs-border-color);
+      opacity: 0.5;
+    }
+    .arrival-wave-track .bar { position: absolute; bottom: 0; }
+    .arrival-wave-track .deadline {
+      position: absolute; top: 0; bottom: 0; width: 0;
+      border-left: 1px dashed var(--bs-secondary-color);
+    }
+    .arrival-wave-track .deadline-label {
+      position: absolute; bottom: 2px; transform: translateX(4px);
+      font-size: 0.63rem;
+      color: var(--bs-secondary-color);
+      white-space: nowrap;
+    }
+    .arrival-wave-legend {
+      display: flex; flex-wrap: wrap;
+      gap: 0.3rem 1.2rem;
+      font-size: 0.8rem;
+      padding-top: 0.4rem;
+    }
+    .arrival-col-grid { display: flex; flex-wrap: wrap; gap: 3px; }
+    .arrival-col-cell {
+      width: 16px; height: 16px;
+      border-radius: 3px;
+      background: var(--bs-secondary-bg);
+    }
+    .arrival-col-cell.low { box-shadow: inset 0 0 0 2px #f46a6a; }
   </style>
 
   <div id="arrival-content" class="card-body px-0 py-1">
@@ -224,6 +255,22 @@
         <div id="arrival-body" class="px-2 pt-1"></div>
       </div>
     </div>
+    {{ if .XatuCbtEnabled }}
+    <div id="waves-att" style="display: none;">
+      <div class="row border-bottom p-2 mx-0">
+        <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="When the network first saw this slot's attestations, in 50ms buckets, split by the block root they vote for. Wrong-head votes mean those attesters had not imported this block in time.">Attestations:</span></div>
+        <div class="col-md-10" id="waves-att-stats"></div>
+      </div>
+      <div class="px-3 pt-2 pb-1 border-bottom" id="waves-att-chart"></div>
+    </div>
+    <div id="waves-cols" style="display: none;">
+      <div class="row border-bottom p-2 mx-0">
+        <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="PeerDAS data column sidecars: when each of the 128 columns of this block's blob data was first seen on the network, and how available each column measured under active custody probing.">Data columns:</span></div>
+        <div class="col-md-10" id="waves-cols-stats"></div>
+      </div>
+      <div class="px-3 pt-2 pb-2 border-bottom" id="waves-cols-chart"></div>
+    </div>
+    {{ end }}
     <div class="text-muted small px-2 pb-2 d-flex align-items-center" style="gap: 6px;">
       <img src="/images/xatu.png" alt="Xatu" style="width: 18px; height: 18px;" />
       Data from <a href="https://github.com/ethpandaops/xatu" target="_blank" rel="noopener">Xatu</a>
@@ -623,9 +670,216 @@
         requestAnimationFrame(syncStickyOffsets);
       }
 
+      // The wave panels share the arrival table's ruler style but not its
+      // bounds: the attestation wave runs on the 50ms chunk grid.
+      function waveAxis(lo, hi) {
+        var span = Math.max(1, hi - lo);
+        var steps = [50, 100, 250, 500, 1000, 2500, 5000];
+        var step = steps[steps.length - 1];
+
+        for (var i = 0; i < steps.length; i++) {
+          if (span / steps[i] <= 8) { step = steps[i]; break; }
+        }
+
+        var lines = [];
+        for (var t = Math.ceil(lo / step) * step; t < hi; t += step) {
+          if (t > lo) lines.push(t);
+        }
+
+        return { lo: lo, hi: hi, span: span, step: step, lines: lines };
+      }
+
+      var waveRootColors = ['#f46a6a', '#f1b44c', '#a78bfa', '#6c757d', '#50c3e6'];
+
+      function waveRootLabel(root, viewed) {
+        if (viewed) return 'this block';
+        if (!root) return 'other roots';
+        return root.slice(0, 10) + '…' + root.slice(-4);
+      }
+
+      function liveBadge(settled) {
+        if (settled) return '';
+        return ' <span class="badge rounded-pill text-bg-info ms-1" style="font-size: 11px;">live &mdash; data may still be arriving</span>';
+      }
+
+      function renderAttWave(att, settled) {
+        document.getElementById('waves-att').style.display = '';
+
+        // color per root: the viewed block green, competitors from the palette
+        var rootColor = {};
+        var next = 0;
+        (att.roots || []).forEach(function(r) {
+          rootColor[r.root] = r.viewed ? '#34c38f' : waveRootColors[next++ % waveRootColors.length];
+        });
+
+        var chunks = {};
+        var lo = null, hi = null, peak = 0;
+        (att.roots || []).forEach(function(r) {
+          (r.buckets || []).forEach(function(b) {
+            if (lo == null || b.ms < lo) lo = b.ms;
+            if (hi == null || b.ms > hi) hi = b.ms;
+            var c = chunks[b.ms] || (chunks[b.ms] = { total: 0, segs: [] });
+            c.total += b.count;
+            c.segs.push({ root: r.root, viewed: r.viewed, count: b.count });
+            if (c.total > peak) peak = c.total;
+          });
+        });
+        if (lo == null || !peak) return;
+
+        var viewed = null, otherCount = 0;
+        (att.roots || []).forEach(function(r) {
+          if (r.viewed) viewed = r; else otherCount += r.count;
+        });
+
+        var stats = '<b>' + att.total_count.toLocaleString() + '</b> attestations first seen';
+        if (viewed) {
+          stats += ' <span class="text-muted px-2">&middot;</span><span class="num" style="color:#34c38f"><b>' +
+            (viewed.count / att.total_count * 100).toFixed(1) + '%</b></span> <span class="text-muted">vote this block</span>';
+        }
+        if (otherCount > 0) {
+          stats += ' <span class="text-muted px-2">&middot;</span><span class="num" style="color:#f46a6a"><b>' +
+            otherCount.toLocaleString() + '</b></span> <span class="text-muted">vote other roots</span>';
+        }
+        document.getElementById('waves-att-stats').innerHTML = stats + liveBadge(settled);
+
+        var ax = waveAxis(Math.max(0, lo - 100), hi + 150);
+        var pos = function(ms) { return (ms - ax.lo) / ax.span * 100; };
+        var width = Math.max(0.2, 50 / ax.span * 100);
+
+        var html = axisHeader(ax, '');
+        html += '<div class="arrival-wave-track">';
+        ax.lines.forEach(function(t) {
+          html += '<div class="grid" style="left:' + pos(t) + '%"></div>';
+        });
+        if (att.deadline_ms > ax.lo && att.deadline_ms < ax.hi) {
+          html += '<div class="deadline" style="left:' + pos(att.deadline_ms) + '%">' +
+            '<span class="deadline-label" title="One third into the slot: validators attest now even without a block in hand">attestation deadline</span></div>';
+        }
+
+        Object.keys(chunks).forEach(function(ms) {
+          ms = +ms;
+          var c = chunks[ms];
+          var bottom = 0;
+          // stack the viewed block's votes on the baseline, competitors on top
+          c.segs.sort(function(a, b) { return (b.viewed ? 1 : 0) - (a.viewed ? 1 : 0); });
+          c.segs.forEach(function(seg) {
+            var h = Math.max(2, seg.count / peak * 100);
+            html += '<div class="bar" style="left:' + pos(ms) + '%;width:' + width + '%;height:' + h +
+              '%;bottom:' + bottom + '%;background:' + rootColor[seg.root] +
+              '" title="' + fmtStr(ms) + '–' + fmtStr(ms + 50) + ': ' + seg.count.toLocaleString() +
+              ' attestations for ' + waveRootLabel(seg.root, seg.viewed) + '"></div>';
+            bottom += h;
+          });
+        });
+        html += '</div>';
+
+        html += '<div class="arrival-wave-legend">' + (att.roots || []).map(function(r) {
+          return '<span><span class="arrival-dot me-1" style="background:' + rootColor[r.root] + '"></span>' +
+            (r.viewed ? '<b>this block</b>' : '<span class="text-muted" title="' + esc(r.root) + '">' + esc(waveRootLabel(r.root, false)) + '</span>') +
+            ' <span class="num">' + r.count.toLocaleString() + '</span>' +
+            ' <span class="text-muted small">(' + (r.count / att.total_count * 100).toFixed(1) + '%)</span></span>';
+        }).join('') + '</div>';
+
+        document.getElementById('waves-att-chart').innerHTML = html;
+      }
+
+      // heat maps 0..1 onto green..red for the column strip; the range is the
+      // strip's own spread, since all 128 columns land within a couple hundred
+      // milliseconds and the absolute-time palette would paint them all alike.
+      function heat(t) {
+        return 'hsl(' + Math.round(145 - t * 145) + ' 62% 44%)';
+      }
+
+      function renderColWave(cols, settled) {
+        document.getElementById('waves-cols').style.display = '';
+
+        var stats = '<b>' + cols.blob_count + '</b> blob' + (cols.blob_count > 1 ? 's' : '') +
+          ' <span class="text-muted px-2">&middot;</span><b>' + cols.seen_columns + '</b><span class="text-muted">/' + (cols.columns || []).length + ' columns seen</span>';
+        if (cols.seen_columns > 0) {
+          stats += ' <span class="text-muted px-2">&middot;</span><span class="text-muted">spread</span> ' +
+            fmtMsColored(cols.first_ms) + ' <span class="text-muted">&rarr;</span> ' + fmtMsColored(cols.last_ms);
+        }
+        if (cols.probed_columns > 0) {
+          var avgCls = cols.min_availability < 100 ? '#f1b44c' : '#34c38f';
+          stats += ' <span class="text-muted px-2">&middot;</span><span class="text-muted">availability</span> ' +
+            '<span class="num" style="color:' + avgCls + '"><b>' + cols.avg_availability.toFixed(1) + '%</b></span>' +
+            (cols.min_availability < 100 ? ' <span class="text-muted small">(worst column ' + cols.min_availability.toFixed(1) + '%)</span>' : '') +
+            ' <span class="text-muted small">from ' + cols.total_probes.toLocaleString() + ' probes</span>';
+        }
+        document.getElementById('waves-cols-stats').innerHTML = stats + liveBadge(settled);
+
+        // relative color range: min to p95 of the seen times. The span has a
+        // floor so a healthy tight spread (a few tens of ms) renders uniformly
+        // green; red is reserved for columns that lag by real fractions of a
+        // second, not for the slow half of a 60ms window.
+        var seen = (cols.columns || []).map(function(c) { return c.first_seen_ms; })
+          .filter(function(v) { return v != null; })
+          .sort(function(a, b) { return a - b; });
+        var rLo = seen.length ? seen[0] : 0;
+        var rHi = seen.length ? seen[Math.floor((seen.length - 1) * 0.95)] : 1;
+        var rSpan = Math.max(400, rHi - rLo);
+
+        var cells = (cols.columns || []).map(function(c) {
+          var tip = 'column ' + c.index;
+          var style = '';
+          var cls = 'arrival-col-cell';
+
+          if (c.first_seen_ms != null) {
+            var t = Math.min(1, Math.max(0, (c.first_seen_ms - rLo) / rSpan));
+            style = 'background:' + heat(t);
+            tip += ' · first seen ' + fmtStr(c.first_seen_ms);
+            if (c.first_seen_by) {
+              tip += ' by ' + c.first_seen_by;
+              var extra = [c.implementation, (c.country_code || '').toUpperCase()].filter(Boolean).join(', ');
+              if (extra) tip += ' (' + extra + ')';
+            }
+          } else {
+            tip += ' · not seen';
+          }
+
+          if (c.availability_pct != null) {
+            tip += ' · availability ' + c.availability_pct.toFixed(1) + '% (' + c.probes + ' probes' +
+              (c.p50_response_ms ? ', p50 ' + c.p50_response_ms + 'ms' : '') + ')';
+            if (c.availability_pct < 100) cls += ' low';
+          }
+
+          return '<div class="' + cls + '" style="' + style + '" title="' + esc(tip) + '"></div>';
+        }).join('');
+
+        document.getElementById('waves-cols-chart').innerHTML =
+          '<div class="arrival-col-grid">' + cells + '</div>' +
+          '<div class="text-muted small pt-2">first seen: ' +
+          '<span class="arrival-dot" style="background:' + heat(0) + '"></span> ' + fmtStr(rLo) +
+          ' &rarr; <span class="arrival-dot" style="background:' + heat(Math.min(1, (rHi - rLo) / rSpan)) + '"></span> ' + fmtStr(rHi) +
+          ' &middot; <span class="arrival-col-cell low d-inline-block align-middle" style="width:12px;height:12px"></span> availability below 100%</div>';
+      }
+
+      function renderWaves(data) {
+        if (data.attestations) renderAttWave(data.attestations, data.settled);
+        if (data.columns) renderColWave(data.columns, data.settled);
+      }
+
+      var wavesLoaded = false;
+
+      // The wave panels stay hidden when the fetch fails or returns nothing:
+      // they are additive context, so their failure should not add noise to
+      // the arrival panel above them.
+      function loadWaves() {
+        if (wavesLoaded || !document.getElementById('waves-att')) return;
+        wavesLoaded = true;
+        fetch('/slot/' + arrivalSlot + '/waves?root=' + encodeURIComponent(arrivalBlockRoot))
+          .then(function(r) {
+            if (!r.ok) throw new Error('status ' + r.status);
+            return r.json();
+          })
+          .then(renderWaves)
+          .catch(function() {});
+      }
+
       function loadArrival() {
         if (arrivalLoaded) return;
         arrivalLoaded = true;
+        loadWaves();
         fetch('/slot/' + arrivalSlot + '/arrival?root=' + encodeURIComponent(arrivalBlockRoot))
           .then(function(r) {
             if (!r.ok) throw new Error('status ' + r.status);

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -198,42 +198,53 @@
 
     .arrival-wave-mini {
       position: relative;
-      height: 30px;
-      max-width: 460px;
-      margin-top: 5px;
+      height: 40px;
+      max-width: 520px;
+      margin-top: 6px;
       border-bottom: 1px solid var(--bs-border-color);
     }
-    .arrival-wave-mini .bar { position: absolute; bottom: 0; }
+    .arrival-wave-mini svg {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+    }
+    .arrival-wave-mini .hover {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+    }
     .arrival-wave-mini .deadline {
       position: absolute; top: 0; bottom: 0; width: 0;
       border-left: 1px dashed var(--bs-secondary-color);
     }
+    .arrival-wave-mini .deadline-flag {
+      position: absolute;
+      top: -3px;
+      padding-left: 5px;
+      font-size: 0.63rem;
+      color: var(--bs-secondary-color);
+      white-space: nowrap;
+    }
     .arrival-wave-axis {
-      position: relative;
-      max-width: 460px;
       display: flex;
       justify-content: space-between;
+      max-width: 520px;
       font-size: 0.63rem;
       color: var(--bs-secondary-color);
       font-variant-numeric: tabular-nums;
     }
-    .arrival-wave-axis .dl {
-      position: absolute;
-      transform: translateX(-50%);
-      white-space: nowrap;
-    }
+    /* same pill as the sources bar, one seamless segment per column */
     .arrival-col-strip {
       display: flex;
-      gap: 1px;
-      height: 12px;
-      max-width: 460px;
-      margin-top: 5px;
-    }
-    .arrival-col-strip > div {
-      flex: 1 1 auto;
-      border-radius: 1px;
+      height: 10px;
+      max-width: 520px;
+      margin-top: 6px;
+      border-radius: 5px;
+      overflow: hidden;
       background: var(--bs-secondary-bg);
     }
+    .arrival-col-strip > div { flex: 1 1 auto; }
   </style>
 
   <div id="arrival-content" class="card-body px-0 py-1">
@@ -724,44 +735,63 @@
         var axHi = hi + 150;
         var span = Math.max(1, axHi - axLo);
         var pos = function(ms) { return (ms - axLo) / span * 100; };
-        var width = Math.max(0.3, 50 / span * 100);
 
-        var bars = '';
-        Object.keys(chunks).forEach(function(ms) {
-          ms = +ms;
-          var c = chunks[ms];
-          var tip = fmtStr(ms) + '\u2013' + fmtStr(ms + 50) + ': ' + (c.viewed + c.other).toLocaleString() + ' attestations' +
-            (c.other ? ' (' + c.other.toLocaleString() + ' for other roots)' : '');
-          var vh = c.viewed / peak * 100;
+        // the silhouette is one smooth area rather than 50ms picket bars: a
+        // polygon through the bucket midpoints, with zero buckets pinned just
+        // under the viewBox so quiet stretches show no line at all
+        var W = 100, H = 40;
+        var px = function(ms) { return (pos(ms + 25)).toFixed(2); };
+        var py = function(v) {
+          if (!v) return (H + 1.5).toFixed(2);
+          return (H - Math.max(1, v / peak * (H - 4))).toFixed(2);
+        };
 
-          if (c.viewed) {
-            bars += '<div class="bar" style="left:' + pos(ms) + '%;width:' + width + '%;height:' + Math.max(1.5, vh) +
-              '%;background:#34c38f" title="' + tip + '"></div>';
+        var viewedPts = [], totalPts = [], hovers = '';
+        for (var ms = lo; ms <= hi; ms += 50) {
+          var c = chunks[ms] || { viewed: 0, other: 0 };
+          viewedPts.push(px(ms) + ',' + py(c.viewed));
+          totalPts.push(px(ms) + ',' + py(c.viewed + c.other));
+
+          if (c.viewed + c.other > 0) {
+            hovers += '<div class="hover" style="left:' + pos(ms) + '%;width:' + (50 / span * 100) +
+              '%" title="' + fmtStr(ms) + '\u2013' + fmtStr(ms + 50) + ': ' + (c.viewed + c.other).toLocaleString() +
+              ' attestations' + (c.other ? ' (' + c.other.toLocaleString() + ' for other roots)' : '') + '"></div>';
           }
+        }
 
-          if (c.other) {
-            bars += '<div class="bar" style="left:' + pos(ms) + '%;width:' + width + '%;bottom:' + (c.viewed ? Math.max(1.5, vh) : 0) +
-              '%;height:' + Math.max(1.5, c.other / peak * 100) + '%;background:#f46a6a" title="' + tip + '"></div>';
-          }
-        });
+        var area = function(pts, fill, stroke) {
+          var edge = (H + 2).toFixed(2);
+          return '<polygon points="' + pts[0].split(',')[0] + ',' + edge + ' ' + pts.join(' ') + ' ' +
+            pts[pts.length - 1].split(',')[0] + ',' + edge + '" fill="' + fill + '"/>' +
+            '<polyline points="' + pts.join(' ') + '" fill="none" stroke="' + stroke +
+            '" stroke-width="1.5" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
+        };
+
+        var svg = '<svg viewBox="0 0 ' + W + ' ' + H + '" preserveAspectRatio="none">';
+        if (otherCount > 0) {
+          // wrong-head votes fill only the band between the two lines, so the
+          // fills never stack into a muddy overlap
+          svg += '<polygon points="' + totalPts.join(' ') + ' ' + viewedPts.slice().reverse().join(' ') +
+            '" fill="rgba(244,106,106,0.55)"/>';
+        }
+        svg += area(viewedPts, 'rgba(52,195,143,0.25)', '#34c38f') + '</svg>';
 
         var deadline = '';
-        var deadlineLabel = '';
         if (att.deadline_ms > axLo && att.deadline_ms < axHi) {
           deadline = '<div class="deadline" style="left:' + pos(att.deadline_ms) +
-            '%" title="One third into the slot: validators attest now even without a block in hand"></div>';
-          deadlineLabel = '<span class="dl" style="left:' + pos(att.deadline_ms) + '%">' + fmtAxis(att.deadline_ms) + ' deadline</span>';
+            '%" title="One third into the slot: validators attest now even without a block in hand">' +
+            '<span class="deadline-flag">' + fmtAxis(att.deadline_ms) + ' deadline</span></div>';
         }
 
         document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) +
-          '<div class="arrival-wave-mini">' + deadline + bars + '</div>' +
-          '<div class="arrival-wave-axis"><span>' + fmtAxis(axLo) + '</span>' + deadlineLabel + '<span>' + fmtAxis(axHi) + '</span></div>';
+          '<div class="arrival-wave-mini">' + svg + deadline + hovers + '</div>' +
+          '<div class="arrival-wave-axis"><span>' + fmtAxis(axLo) + '</span><span>' + fmtAxis(axHi) + '</span></div>';
       }
 
       // heat maps 0..1 onto green..red for the column strip. The range is the
       // strip's own spread with a floor: a healthy tight spread (a few tens of
-      // ms) renders uniformly green, and red is reserved for columns that lag
-      // by real fractions of a second.
+      // ms) renders as one even green pill, and red is reserved for columns
+      // that lag by real fractions of a second.
       function heat(t) {
         return 'hsl(' + Math.round(145 - t * 145) + ' 62% 44%)';
       }
@@ -793,7 +823,7 @@
         var rHi = seen.length ? seen[Math.floor((seen.length - 1) * 0.95)] : 1;
         var rSpan = Math.max(400, rHi - rLo);
 
-        var slivers = entries.map(function(c) {
+        var segments = entries.map(function(c) {
           var style = '';
           var tip = 'column ' + c.index;
 
@@ -825,8 +855,7 @@
         }).join('');
 
         document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) +
-          '<div class="arrival-col-strip">' + slivers + '</div>' +
-          '<div class="arrival-wave-axis"><span>column 0</span><span>' + (entries.length - 1) + '</span></div>';
+          '<div class="arrival-col-strip">' + segments + '</div>';
       }
 
       function renderWaves(data) {

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -235,20 +235,29 @@
       transform: translateX(-50%);
       white-space: nowrap;
     }
-    /* the sources bar's shape, subdivided per column: gapless segments in
-       one slim pill, so a healthy slot reads as a single solid bar and only
-       deviant columns surface as slivers */
-    .arrival-col-heat {
-      display: flex;
-      height: 12px;
-      margin-top: 8px;
-      border-radius: 6px;
-      overflow: hidden;
-      background: var(--bs-secondary-bg);
+    .arrival-hist svg {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
     }
-    .arrival-col-heat > div { flex: 1 1 auto; }
-    .arrival-col-heat > div.low {
-      background-image: repeating-linear-gradient(135deg, #f46a6a 0 3px, transparent 3px 6px);
+    .arrival-hist .hover {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+    }
+    .arrival-hist .hgrid {
+      position: absolute; left: 0; right: 0; height: 1px;
+      background: var(--bs-border-color);
+      opacity: 0.45;
+    }
+    .arrival-hist .ylab {
+      position: absolute;
+      left: 4px;
+      transform: translateY(-55%);
+      font-size: 0.63rem;
+      color: var(--bs-secondary-color);
+      font-variant-numeric: tabular-nums;
     }
     .arrival-heat-key {
       display: inline-block;
@@ -861,14 +870,18 @@
         document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) + hist;
       }
 
+      // The column chart follows the lab's data column propagation view:
+      // column index across, arrival time up, with each column's min, median
+      // and p90 reduced from every observing node's sighting.
       function renderColWave(cols, settled) {
         var entries = cols.columns || [];
         if (!entries.length || !cols.blob_count) return;
 
         var stats = '<b>' + cols.blob_count + '</b> blob' + (cols.blob_count > 1 ? 's' : '') +
           sep + '<b>' + cols.seen_columns + '</b><span class="text-muted">/' + entries.length + ' columns seen</span>';
-        if (cols.seen_columns > 0) {
-          stats += sep + fmtMsColored(cols.first_ms) + ' <span class="text-muted">&rarr;</span> ' + fmtMsColored(cols.last_ms);
+        if (cols.median_ms) {
+          stats += sep + '<span class="text-muted">median</span> ' + fmtMsColored(cols.median_ms) +
+            ' <span class="text-muted small">of ' + (cols.observations || 0).toLocaleString() + ' sightings</span>';
         }
         if (cols.probed_columns > 0) {
           var availColor = cols.min_availability < 100 ? '#f1b44c' : '#34c38f';
@@ -879,75 +892,120 @@
           }
         }
 
-        // one cell per column index, colored on the page's arrival-time
-        // scale. An absolute scale keeps a healthy slot one even green and
-        // saves the warm colors for columns that were genuinely late.
-        var unseen = 0;
-        var failed = 0;
+        var count = entries.length;
+        var maxT = 0;
 
-        var cells = entries.map(function(c) {
-          var style = '';
-          var cls = '';
+        entries.forEach(function(c) {
+          var top = c.p90_ms || c.p50_ms || c.first_seen_ms;
+          if (top != null && top > maxT) maxT = top;
+        });
+
+        document.getElementById('waves-cols').style.display = '';
+
+        if (!maxT) {
+          document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled);
+          return;
+        }
+
+        var yMax = Math.max(500, Math.ceil(maxT * 1.15 / 500) * 500);
+        var ySteps = [250, 500, 1000, 2500, 5000];
+        var yStep = ySteps[ySteps.length - 1];
+
+        for (var i = 0; i < ySteps.length; i++) {
+          if (yMax / ySteps[i] <= 4) { yStep = ySteps[i]; break; }
+        }
+
+        var X = function(i) { return ((i + 0.5) / count * 100).toFixed(2); };
+        var Y = function(ms) { return (100 - ms / yMax * 100).toFixed(2); };
+
+        // unseen columns break the lines rather than being interpolated over
+        var segs = [];
+        var cur = null;
+
+        entries.forEach(function(c, i) {
+          if (c.first_seen_ms == null) { cur = null; return; }
+
+          if (!cur) {
+            cur = { min: [], p50: [], p90: [] };
+            segs.push(cur);
+          }
+
+          var x = X(i);
+          cur.min.push(x + ',' + Y(c.first_seen_ms));
+          cur.p50.push(x + ',' + Y(c.p50_ms || c.first_seen_ms));
+          cur.p90.push(x + ',' + Y(c.p90_ms || c.p50_ms || c.first_seen_ms));
+        });
+
+        var svg = '<svg viewBox="0 0 100 100" preserveAspectRatio="none">';
+
+        segs.forEach(function(seg) {
+          if (seg.min.length === 1) {
+            // a lone column between gaps still deserves a visible dash
+            ['min', 'p50', 'p90'].forEach(function(k) {
+              var pt = seg[k][0].split(',');
+              seg[k] = [(+pt[0] - 0.3).toFixed(2) + ',' + pt[1], (+pt[0] + 0.3).toFixed(2) + ',' + pt[1]];
+            });
+          }
+
+          svg += '<polygon points="' + seg.p90.join(' ') + ' ' + seg.min.slice().reverse().join(' ') +
+            '" fill="rgba(115,128,141,0.16)"/>';
+          svg += '<polyline points="' + seg.p90.join(' ') + '" fill="none" stroke="#f1b44c" stroke-width="1.2" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
+          svg += '<polyline points="' + seg.p50.join(' ') + '" fill="none" stroke="#5b8def" stroke-width="1.5" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
+          svg += '<polyline points="' + seg.min.join(' ') + '" fill="none" stroke="#34c38f" stroke-width="1.5" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
+        });
+
+        svg += '</svg>';
+
+        var chart = '';
+
+        for (var ms = yStep; ms < yMax; ms += yStep) {
+          var top = (100 - ms / yMax * 100) + '%';
+          chart += '<div class="hgrid" style="top:' + top + '"></div>' +
+            '<span class="ylab" style="top:' + top + '">' + fmtAxis(ms) + '</span>';
+        }
+
+        for (var t = 16; t < count; t += 16) {
+          chart += '<div class="grid" style="left:' + (t / count * 100) + '%"></div>';
+        }
+
+        chart += svg;
+
+        entries.forEach(function(c, i) {
           var tip = 'column ' + c.index;
 
           if (c.first_seen_ms != null) {
-            style = 'background:' + timeColor(c.first_seen_ms);
-            tip += ' \u00b7 first seen ' + fmtStr(c.first_seen_ms);
-            if (c.first_seen_by) {
-              tip += ' by ' + c.first_seen_by;
-              var extra = [c.implementation, (c.country_code || '').toUpperCase()].filter(Boolean).join(', ');
-              if (extra) tip += ' (' + extra + ')';
-            }
+            tip += ' \u00b7 first ' + fmtStr(c.first_seen_ms);
+            if (c.first_seen_by) tip += ' by ' + c.first_seen_by;
+            if (c.p50_ms) tip += ' \u00b7 median ' + fmtStr(c.p50_ms);
+            if (c.p90_ms) tip += ' \u00b7 p90 ' + fmtStr(c.p90_ms);
+            if (c.observations) tip += ' \u00b7 ' + c.observations + ' sightings';
           } else {
-            unseen++;
             tip += ' \u00b7 not seen';
           }
 
           if (c.availability_pct != null) {
-            tip += ' \u00b7 availability ' + c.availability_pct.toFixed(1) + '% (' + c.probes + ' probes' +
-              (c.p50_response_ms ? ', p50 ' + c.p50_response_ms + 'ms' : '') + ')';
-            if (c.availability_pct < 100) {
-              failed++;
-              cls = ' class="low"';
-            }
+            tip += ' \u00b7 availability ' + c.availability_pct.toFixed(1) + '% (' + c.probes + ' probes)';
           }
 
-          return '<div' + cls + ' style="' + style + '" title="' + esc(tip) + '"></div>';
-        }).join('');
-
-        // one color for every column needs no key; explain only the states
-        // this slot actually has
-        var shades = {};
-
-        entries.forEach(function(c) {
-          if (c.first_seen_ms != null) shades[timeColor(c.first_seen_ms)] = true;
+          chart += '<div class="hover" style="left:' + (i / count * 100) + '%;width:' + (100 / count) +
+            '%" title="' + esc(tip) + '"></div>';
         });
 
-        var legendParts = [];
-
-        if (Object.keys(shades).length > 1) {
-          var chips = '';
-          [[0, '&lt;1s'], [1000, '1\u20132s'], [2000, '2\u20133s'], [3000, '3\u20134s'], [4000, '&ge;4s']].forEach(function(k) {
-            if (shades[timeColor(k[0])]) {
-              chips += '<span class="arrival-heat-key" style="background:' + timeColor(k[0]) + '"></span> ' + k[1] + ' ';
-            }
-          });
-          legendParts.push('first seen: ' + chips);
+        var labels = '<span style="left:0;transform:none">0</span>';
+        for (var lt = 16; lt < count; lt += 16) {
+          labels += '<span style="left:' + (lt / count * 100) + '%">' + lt + '</span>';
         }
-        if (unseen > 0) {
-          legendParts.push('<span class="arrival-heat-key"></span> not seen (' + unseen + ')');
-        }
-        if (failed > 0) {
-          legendParts.push('<span class="arrival-heat-key" style="background-image: repeating-linear-gradient(135deg, #f46a6a 0 3px, transparent 3px 6px)"></span> failed probes (' + failed + ')');
-        }
+        labels += '<span style="left:100%;transform:translateX(-100%)">' + (count - 1) + '</span>';
 
-        var legend = legendParts.length
-          ? '<div class="text-muted small pt-1">' + legendParts.join(sep) + '</div>'
-          : '';
+        var legend = '<div class="text-muted small pt-1">per column, across ' +
+          '<b>' + (cols.observations || 0).toLocaleString() + '</b> node sightings: ' +
+          '<span class="arrival-heat-key" style="background:#34c38f"></span> first ' +
+          '<span class="arrival-heat-key" style="background:#5b8def"></span> median ' +
+          '<span class="arrival-heat-key" style="background:#f1b44c"></span> p90</div>';
 
-        document.getElementById('waves-cols').style.display = '';
         document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) +
-          '<div class="arrival-col-heat">' + cells + '</div>' + legend;
+          '<div class="arrival-hist hist-sm">' + chart + '</div>' +
+          '<div class="arrival-hist-axis">' + labels + '</div>' + legend;
       }
 
       function renderWaves(data) {

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -199,7 +199,6 @@
     .arrival-hist {
       position: relative;
       height: 110px;
-      max-width: 820px;
       margin-top: 8px;
       border-left: 1px solid var(--bs-border-color);
       border-bottom: 1px solid var(--bs-border-color);
@@ -225,7 +224,6 @@
     }
     .arrival-hist-axis {
       position: relative;
-      max-width: 820px;
       height: 0.95rem;
       font-size: 0.63rem;
       color: var(--bs-secondary-color);
@@ -691,7 +689,7 @@
         var step = steps[steps.length - 1];
 
         for (var i = 0; i < steps.length; i++) {
-          if (span / steps[i] <= 7) { step = steps[i]; break; }
+          if (span / steps[i] <= 13) { step = steps[i]; break; }
         }
 
         var lines = [];
@@ -700,6 +698,23 @@
         }
 
         return { lo: axLo, hi: axHi, span: span, lines: lines };
+      }
+
+      // waveDomain spans the whole slot, so every slot's charts share one
+      // axis and the two rows line up vertically; data past the slot end
+      // stretches it rather than being cut off.
+      function waveDomain(slotMs, dataHi, binMs) {
+        return Math.max(slotMs || 12000, dataHi + binMs * 2);
+      }
+
+      function waveBin(domain) {
+        var sizes = [50, 100, 250, 500, 1000];
+
+        for (var i = 0; i < sizes.length; i++) {
+          if (domain / sizes[i] <= 130) return sizes[i];
+        }
+
+        return sizes[sizes.length - 1];
       }
 
       // renderHist draws chunky bars with gaps into the histogram block:
@@ -754,12 +769,13 @@
         ax.lines.forEach(function(t) {
           labels += '<span style="left:' + pos(t) + '%">' + fmtAxis(t) + '</span>';
         });
+        labels += '<span style="left:100%">' + fmtAxis(ax.hi) + '</span>';
 
         return '<div class="arrival-hist' + (small ? ' hist-sm' : '') + '">' + html + '</div>' +
           '<div class="arrival-hist-axis">' + labels + '</div>';
       }
 
-      function renderAttWave(att, settled) {
+      function renderAttWave(att, settled, slotMs) {
         if (!att.total_count) return;
 
         var viewed = null;
@@ -783,13 +799,8 @@
         if (lo == null) return;
 
         // rebin the 50ms chunks until the bars are chunky enough to read
-        var binMs = 50;
-        var sizes = [50, 100, 250, 500, 1000];
-
-        for (var i = 0; i < sizes.length; i++) {
-          binMs = sizes[i];
-          if ((hi - lo) / binMs <= 64) break;
-        }
+        // across the whole slot
+        var binMs = waveBin(waveDomain(slotMs, hi, 50));
 
         var binned = {};
 
@@ -808,7 +819,7 @@
           return b;
         });
 
-        var ax = histAxis(Math.max(0, lo - binMs), hi + binMs * 2);
+        var ax = histAxis(0, waveDomain(slotMs, hi, binMs));
         var hist = renderHist(ax, bins, binMs, att.deadline_ms, false);
         if (!hist) return;
 
@@ -827,7 +838,7 @@
         document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) + hist;
       }
 
-      function renderColWave(cols, settled) {
+      function renderColWave(cols, settled, slotMs) {
         var entries = cols.columns || [];
         if (!entries.length || !cols.blob_count) return;
 
@@ -852,20 +863,10 @@
         var hist = '';
 
         if (seen.length) {
-          // the burst is tight, so the window gets a floor: bars cluster
-          // against calm space instead of being stretched to fill the width
-          var spread = seen[seen.length - 1] - seen[0];
-          var window = Math.max(spread * 1.4, 250);
-          var axLo = Math.max(0, seen[0] - (window - spread) / 2);
-
-          var binMs = 5;
-          var sizes = [5, 10, 20, 50, 100];
-
-          for (var i = 0; i < sizes.length; i++) {
-            binMs = sizes[i];
-            if (window / binMs <= 56) break;
-          }
-
+          // same full-slot domain and bins as the attestation chart above,
+          // so the two rows line up vertically and read as one story
+          var dataHi = seen[seen.length - 1];
+          var binMs = waveBin(waveDomain(slotMs, dataHi, 50));
           var binned = {};
 
           seen.forEach(function(ms) {
@@ -882,7 +883,7 @@
             };
           });
 
-          var ax = histAxis(axLo, axLo + window);
+          var ax = histAxis(0, waveDomain(slotMs, dataHi, binMs));
           hist = renderHist(ax, bins, binMs, null, true) || '';
         }
 
@@ -891,8 +892,9 @@
       }
 
       function renderWaves(data) {
-        if (data.attestations) renderAttWave(data.attestations, data.settled);
-        if (data.columns) renderColWave(data.columns, data.settled);
+        var slotMs = data.slot_ms || (data.attestations ? data.attestations.deadline_ms * 3 : 0);
+        if (data.attestations) renderAttWave(data.attestations, data.settled, slotMs);
+        if (data.columns) renderColWave(data.columns, data.settled, slotMs);
       }
 
       var wavesLoaded = false;

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -774,7 +774,7 @@
       // renderHist draws chunky bars with gaps into the histogram block:
       // bins = [{ms, green, red, tip}], stacked red on green, scaled to the
       // tallest bin. Returns null when there is nothing to draw.
-      function renderHist(ax, bins, binMs, deadlineMs, small) {
+      function renderHist(ax, bins, binMs, marks, small) {
         var pos = function(ms) { return (ms - ax.lo) / ax.span * 100; };
         var peak = 0;
 
@@ -789,10 +789,14 @@
           html += '<div class="grid" style="left:' + pos(t) + '%"></div>';
         });
 
-        if (deadlineMs != null && deadlineMs > ax.lo && deadlineMs < ax.hi) {
-          html += '<div class="deadline" style="left:' + pos(deadlineMs) + '%">' +
-            '<span class="note" title="One third into the slot: validators attest now even without a block in hand">deadline</span></div>';
-        }
+        // each marker label gets its own row, so close markers stay readable
+        (marks || []).forEach(function(m, idx) {
+          if (m.ms <= ax.lo || m.ms >= ax.hi) return;
+
+          html += '<div class="deadline" style="left:' + pos(m.ms) + '%;border-left-color:' + m.color + '">' +
+            '<span class="note" style="top:' + (1 + idx * 13) + 'px;color:' + m.color + '" title="' + esc(m.title) + '">' +
+            m.label + '</span></div>';
+        });
 
         var slotW = binMs / ax.span * 100;
         var barW = slotW * 0.7;
@@ -873,8 +877,48 @@
           return b;
         });
 
+        var marks = [];
+
+        if (att.deadline_ms > 0) {
+          marks.push({
+            ms: att.deadline_ms, label: 'deadline', color: 'var(--bs-secondary-color)',
+            title: 'One third into the slot: validators attest now even without a block in hand',
+          });
+        }
+
+        // when the votes for this block pass 60% of the slot's expected
+        // attesters, walked over the cumulative viewed-root buckets
+        if (viewed && att.expected_count > 0) {
+          var need = att.expected_count * 0.6;
+          var cum = 0;
+          var thresholdMs = null;
+
+          (viewed.buckets || []).forEach(function(b) {
+            if (thresholdMs != null) return;
+            cum += b.count;
+            if (cum >= need) thresholdMs = b.ms + 50;
+          });
+
+          if (thresholdMs != null) {
+            marks.push({
+              ms: thresholdMs, label: '60% voted', color: '#34c38f',
+              title: 'Attestations for this block passed 60% of the slot\u2019s ' +
+                att.expected_count.toLocaleString() + ' expected attesters',
+            });
+          }
+        }
+
+        if (att.payload_p50_ms > 0) {
+          marks.push({
+            ms: att.payload_p50_ms, label: 'payload p50', color: '#e64980',
+            title: 'Median time the revealed execution payload reached observing nodes',
+          });
+        }
+
+        marks.sort(function(a, b) { return a.ms - b.ms; });
+
         var ax = histAxis(0, waveDomain(slotMs, hi, binMs));
-        var hist = renderHist(ax, bins, binMs, att.deadline_ms, false);
+        var hist = renderHist(ax, bins, binMs, marks, false);
         if (!hist) return;
 
         document.getElementById('waves-att').style.display = '';

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -1115,6 +1115,15 @@
           });
         }
 
+        if (ptc.deadline_ms > 0) {
+          marks.push({
+            ms: ptc.deadline_ms, label: 'PTC deadline', color: 'var(--bs-secondary-color)',
+            title: 'Votes are due within the first 75% of the slot; some clients vote as soon as they see the payload, others wait for the deadline',
+          });
+        }
+
+        marks.sort(function(a, b) { return a.ms - b.ms; });
+
         var ax = histAxis(0, waveDomain(slotMs, hi, binMs));
         var hist = renderHist(ax, bins, binMs, marks, true);
         if (!hist) return;

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -235,6 +235,26 @@
       transform: translateX(-50%);
       white-space: nowrap;
     }
+    .arrival-col-heat {
+      display: grid;
+      grid-template-columns: repeat(64, 1fr);
+      gap: 2px;
+      margin-top: 8px;
+    }
+    .arrival-col-heat > div {
+      height: 13px;
+      border-radius: 2px;
+      background: var(--bs-secondary-bg);
+    }
+    .arrival-col-heat > div.low { box-shadow: inset 0 0 0 2px #f46a6a; }
+    .arrival-heat-key {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 2px;
+      vertical-align: middle;
+      background: var(--bs-secondary-bg);
+    }
   </style>
 
   <div id="arrival-content" class="card-body px-0 py-1">
@@ -838,7 +858,7 @@
         document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) + hist;
       }
 
-      function renderColWave(cols, settled, slotMs) {
+      function renderColWave(cols, settled) {
         var entries = cols.columns || [];
         if (!entries.length || !cols.blob_count) return;
 
@@ -856,45 +876,63 @@
           }
         }
 
-        var seen = entries.map(function(c) { return c.first_seen_ms; })
-          .filter(function(v) { return v != null; })
-          .sort(function(a, b) { return a - b; });
+        // one cell per column index, colored on the page's arrival-time
+        // scale. An absolute scale keeps a healthy slot one even green and
+        // saves the warm colors for columns that were genuinely late.
+        var unseen = 0;
+        var failed = 0;
 
-        var hist = '';
+        var cells = entries.map(function(c) {
+          var style = '';
+          var cls = '';
+          var tip = 'column ' + c.index;
 
-        if (seen.length) {
-          // same full-slot domain and bins as the attestation chart above,
-          // so the two rows line up vertically and read as one story
-          var dataHi = seen[seen.length - 1];
-          var binMs = waveBin(waveDomain(slotMs, dataHi, 50));
-          var binned = {};
+          if (c.first_seen_ms != null) {
+            style = 'background:' + timeColor(c.first_seen_ms);
+            tip += ' \u00b7 first seen ' + fmtStr(c.first_seen_ms);
+            if (c.first_seen_by) {
+              tip += ' by ' + c.first_seen_by;
+              var extra = [c.implementation, (c.country_code || '').toUpperCase()].filter(Boolean).join(', ');
+              if (extra) tip += ' (' + extra + ')';
+            }
+          } else {
+            unseen++;
+            tip += ' \u00b7 not seen';
+          }
 
-          seen.forEach(function(ms) {
-            var key = Math.floor(ms / binMs) * binMs;
-            binned[key] = (binned[key] || 0) + 1;
-          });
+          if (c.availability_pct != null) {
+            tip += ' \u00b7 availability ' + c.availability_pct.toFixed(1) + '% (' + c.probes + ' probes' +
+              (c.p50_response_ms ? ', p50 ' + c.p50_response_ms + 'ms' : '') + ')';
+            if (c.availability_pct < 100) {
+              failed++;
+              cls = ' class="low"';
+            }
+          }
 
-          var bins = Object.keys(binned).map(function(ms) {
-            ms = +ms;
-            return {
-              ms: ms, green: binned[ms], red: 0,
-              tip: binned[ms] + ' column' + (binned[ms] > 1 ? 's' : '') + ' first seen ' +
-                fmtStr(ms) + '\u2013' + fmtStr(ms + binMs),
-            };
-          });
+          return '<div' + cls + ' style="' + style + '" title="' + esc(tip) + '"></div>';
+        }).join('');
 
-          var ax = histAxis(0, waveDomain(slotMs, dataHi, binMs));
-          hist = renderHist(ax, bins, binMs, null, true) || '';
+        var legend = '<div class="text-muted small pt-1">columns 0\u2013' + (entries.length - 1) + ', first seen: ';
+        [[0, '&lt;1s'], [1000, '1\u20132s'], [2000, '2\u20133s'], [3000, '3\u20134s'], [4000, '&ge;4s']].forEach(function(k) {
+          legend += '<span class="arrival-heat-key" style="background:' + timeColor(k[0]) + '"></span> ' + k[1] + ' ';
+        });
+        if (unseen > 0) {
+          legend += sep + '<span class="arrival-heat-key"></span> not seen (' + unseen + ')';
         }
+        if (failed > 0) {
+          legend += sep + '<span class="arrival-heat-key low" style="box-shadow: inset 0 0 0 2px #f46a6a"></span> failed probes (' + failed + ')';
+        }
+        legend += '</div>';
 
         document.getElementById('waves-cols').style.display = '';
-        document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) + hist;
+        document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) +
+          '<div class="arrival-col-heat">' + cells + '</div>' + legend;
       }
 
       function renderWaves(data) {
         var slotMs = data.slot_ms || (data.attestations ? data.attestations.deadline_ms * 3 : 0);
         if (data.attestations) renderAttWave(data.attestations, data.settled, slotMs);
-        if (data.columns) renderColWave(data.columns, data.settled, slotMs);
+        if (data.columns) renderColWave(data.columns, data.settled);
       }
 
       var wavesLoaded = false;

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -196,36 +196,44 @@
     .arrival-table th.sortable { cursor: pointer; user-select: none; }
     .arrival-table th.sortable:hover { color: var(--bs-emphasis-color); }
 
-    .arrival-wave-track { position: relative; height: 96px; }
-    .arrival-wave-track .grid {
-      position: absolute; top: 0; bottom: 0; width: 1px;
-      background: var(--bs-border-color);
-      opacity: 0.5;
+    .arrival-wave-mini {
+      position: relative;
+      height: 30px;
+      max-width: 460px;
+      margin-top: 5px;
+      border-bottom: 1px solid var(--bs-border-color);
     }
-    .arrival-wave-track .bar { position: absolute; bottom: 0; }
-    .arrival-wave-track .deadline {
+    .arrival-wave-mini .bar { position: absolute; bottom: 0; }
+    .arrival-wave-mini .deadline {
       position: absolute; top: 0; bottom: 0; width: 0;
       border-left: 1px dashed var(--bs-secondary-color);
     }
-    .arrival-wave-track .deadline-label {
-      position: absolute; bottom: 2px; transform: translateX(4px);
+    .arrival-wave-axis {
+      position: relative;
+      max-width: 460px;
+      display: flex;
+      justify-content: space-between;
       font-size: 0.63rem;
       color: var(--bs-secondary-color);
+      font-variant-numeric: tabular-nums;
+    }
+    .arrival-wave-axis .dl {
+      position: absolute;
+      transform: translateX(-50%);
       white-space: nowrap;
     }
-    .arrival-wave-legend {
-      display: flex; flex-wrap: wrap;
-      gap: 0.3rem 1.2rem;
-      font-size: 0.8rem;
-      padding-top: 0.4rem;
+    .arrival-col-strip {
+      display: flex;
+      gap: 1px;
+      height: 12px;
+      max-width: 460px;
+      margin-top: 5px;
     }
-    .arrival-col-grid { display: flex; flex-wrap: wrap; gap: 3px; }
-    .arrival-col-cell {
-      width: 16px; height: 16px;
-      border-radius: 3px;
+    .arrival-col-strip > div {
+      flex: 1 1 auto;
+      border-radius: 1px;
       background: var(--bs-secondary-bg);
     }
-    .arrival-col-cell.low { box-shadow: inset 0 0 0 2px #f46a6a; }
   </style>
 
   <div id="arrival-content" class="card-body px-0 py-1">
@@ -252,25 +260,19 @@
           <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Observing nodes per continent, with the region's earliest observation">Regions:</span></div>
           <div class="col-md-10" id="arrival-regions"></div>
         </div>
+        {{ if .XatuCbtEnabled }}
+        <div class="row border-bottom p-2 mx-0" id="waves-att" style="display: none;">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="When the network first saw this slot's attestations, in 50ms buckets. Votes for other roots mean those attesters had not imported this block in time.">Attestations:</span></div>
+          <div class="col-md-10" id="waves-att-body"></div>
+        </div>
+        <div class="row border-bottom p-2 mx-0" id="waves-cols" style="display: none;">
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="PeerDAS data column sidecars: when each of the 128 columns of this block's blob data was first seen, and how available each measured under custody probing.">Data columns:</span></div>
+          <div class="col-md-10" id="waves-cols-body"></div>
+        </div>
+        {{ end }}
         <div id="arrival-body" class="px-2 pt-1"></div>
       </div>
     </div>
-    {{ if .XatuCbtEnabled }}
-    <div id="waves-att" style="display: none;">
-      <div class="row border-bottom p-2 mx-0">
-        <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="When the network first saw this slot's attestations, in 50ms buckets, split by the block root they vote for. Wrong-head votes mean those attesters had not imported this block in time.">Attestations:</span></div>
-        <div class="col-md-10" id="waves-att-stats"></div>
-      </div>
-      <div class="px-3 pt-2 pb-1 border-bottom" id="waves-att-chart"></div>
-    </div>
-    <div id="waves-cols" style="display: none;">
-      <div class="row border-bottom p-2 mx-0">
-        <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="PeerDAS data column sidecars: when each of the 128 columns of this block's blob data was first seen on the network, and how available each column measured under active custody probing.">Data columns:</span></div>
-        <div class="col-md-10" id="waves-cols-stats"></div>
-      </div>
-      <div class="px-3 pt-2 pb-2 border-bottom" id="waves-cols-chart"></div>
-    </div>
-    {{ end }}
     <div class="text-muted small px-2 pb-2 d-flex align-items-center" style="gap: 6px;">
       <img src="/images/xatu.png" alt="Xatu" style="width: 18px; height: 18px;" />
       Data from <a href="https://github.com/ethpandaops/xatu" target="_blank" rel="noopener">Xatu</a>
@@ -670,188 +672,161 @@
         requestAnimationFrame(syncStickyOffsets);
       }
 
-      // The wave panels share the arrival table's ruler style but not its
-      // bounds: the attestation wave runs on the 50ms chunk grid.
-      function waveAxis(lo, hi) {
-        var span = Math.max(1, hi - lo);
-        var steps = [50, 100, 250, 500, 1000, 2500, 5000];
-        var step = steps[steps.length - 1];
-
-        for (var i = 0; i < steps.length; i++) {
-          if (span / steps[i] <= 8) { step = steps[i]; break; }
-        }
-
-        var lines = [];
-        for (var t = Math.ceil(lo / step) * step; t < hi; t += step) {
-          if (t > lo) lines.push(t);
-        }
-
-        return { lo: lo, hi: hi, span: span, step: step, lines: lines };
-      }
-
-      var waveRootColors = ['#f46a6a', '#f1b44c', '#a78bfa', '#6c757d', '#50c3e6'];
-
-      function waveRootLabel(root, viewed) {
-        if (viewed) return 'this block';
-        if (!root) return 'other roots';
-        return root.slice(0, 10) + '…' + root.slice(-4);
-      }
-
+      // The wave rows join the summary block above the table, so they follow
+      // its grammar: numbers first, one small muted visual under them.
       function liveBadge(settled) {
         if (settled) return '';
         return ' <span class="badge rounded-pill text-bg-info ms-1" style="font-size: 11px;">live &mdash; data may still be arriving</span>';
       }
 
-      function renderAttWave(att, settled) {
-        document.getElementById('waves-att').style.display = '';
+      var sep = '<span class="text-muted px-2">&middot;</span>';
 
-        // color per root: the viewed block green, competitors from the palette
-        var rootColor = {};
-        var next = 0;
+      function renderAttWave(att, settled) {
+        if (!att.total_count) return;
+
+        var viewed = null;
+        var otherCount = 0;
+        var otherRoots = [];
+
         (att.roots || []).forEach(function(r) {
-          rootColor[r.root] = r.viewed ? '#34c38f' : waveRootColors[next++ % waveRootColors.length];
+          if (r.viewed) { viewed = r; return; }
+          otherCount += r.count;
+          otherRoots.push(r.root ? r.root.slice(0, 10) + '\u2026' : 'smaller roots');
         });
 
         var chunks = {};
         var lo = null, hi = null, peak = 0;
+
         (att.roots || []).forEach(function(r) {
           (r.buckets || []).forEach(function(b) {
+            var c = chunks[b.ms] || (chunks[b.ms] = { viewed: 0, other: 0 });
+            c[r.viewed ? 'viewed' : 'other'] += b.count;
             if (lo == null || b.ms < lo) lo = b.ms;
             if (hi == null || b.ms > hi) hi = b.ms;
-            var c = chunks[b.ms] || (chunks[b.ms] = { total: 0, segs: [] });
-            c.total += b.count;
-            c.segs.push({ root: r.root, viewed: r.viewed, count: b.count });
-            if (c.total > peak) peak = c.total;
+            if (c.viewed + c.other > peak) peak = c.viewed + c.other;
           });
         });
         if (lo == null || !peak) return;
 
-        var viewed = null, otherCount = 0;
-        (att.roots || []).forEach(function(r) {
-          if (r.viewed) viewed = r; else otherCount += r.count;
-        });
+        document.getElementById('waves-att').style.display = '';
 
         var stats = '<b>' + att.total_count.toLocaleString() + '</b> attestations first seen';
         if (viewed) {
-          stats += ' <span class="text-muted px-2">&middot;</span><span class="num" style="color:#34c38f"><b>' +
+          stats += sep + '<span class="num" style="color:#34c38f"><b>' +
             (viewed.count / att.total_count * 100).toFixed(1) + '%</b></span> <span class="text-muted">vote this block</span>';
         }
         if (otherCount > 0) {
-          stats += ' <span class="text-muted px-2">&middot;</span><span class="num" style="color:#f46a6a"><b>' +
+          stats += sep + '<span class="num" style="color:#f46a6a" title="' + esc(otherRoots.join(', ')) + '"><b>' +
             otherCount.toLocaleString() + '</b></span> <span class="text-muted">vote other roots</span>';
         }
-        document.getElementById('waves-att-stats').innerHTML = stats + liveBadge(settled);
 
-        var ax = waveAxis(Math.max(0, lo - 100), hi + 150);
-        var pos = function(ms) { return (ms - ax.lo) / ax.span * 100; };
-        var width = Math.max(0.2, 50 / ax.span * 100);
+        var axLo = Math.max(0, lo - 100);
+        var axHi = hi + 150;
+        var span = Math.max(1, axHi - axLo);
+        var pos = function(ms) { return (ms - axLo) / span * 100; };
+        var width = Math.max(0.3, 50 / span * 100);
 
-        var html = axisHeader(ax, '');
-        html += '<div class="arrival-wave-track">';
-        ax.lines.forEach(function(t) {
-          html += '<div class="grid" style="left:' + pos(t) + '%"></div>';
-        });
-        if (att.deadline_ms > ax.lo && att.deadline_ms < ax.hi) {
-          html += '<div class="deadline" style="left:' + pos(att.deadline_ms) + '%">' +
-            '<span class="deadline-label" title="One third into the slot: validators attest now even without a block in hand">attestation deadline</span></div>';
-        }
-
+        var bars = '';
         Object.keys(chunks).forEach(function(ms) {
           ms = +ms;
           var c = chunks[ms];
-          var bottom = 0;
-          // stack the viewed block's votes on the baseline, competitors on top
-          c.segs.sort(function(a, b) { return (b.viewed ? 1 : 0) - (a.viewed ? 1 : 0); });
-          c.segs.forEach(function(seg) {
-            var h = Math.max(2, seg.count / peak * 100);
-            html += '<div class="bar" style="left:' + pos(ms) + '%;width:' + width + '%;height:' + h +
-              '%;bottom:' + bottom + '%;background:' + rootColor[seg.root] +
-              '" title="' + fmtStr(ms) + '–' + fmtStr(ms + 50) + ': ' + seg.count.toLocaleString() +
-              ' attestations for ' + waveRootLabel(seg.root, seg.viewed) + '"></div>';
-            bottom += h;
-          });
+          var tip = fmtStr(ms) + '\u2013' + fmtStr(ms + 50) + ': ' + (c.viewed + c.other).toLocaleString() + ' attestations' +
+            (c.other ? ' (' + c.other.toLocaleString() + ' for other roots)' : '');
+          var vh = c.viewed / peak * 100;
+
+          if (c.viewed) {
+            bars += '<div class="bar" style="left:' + pos(ms) + '%;width:' + width + '%;height:' + Math.max(1.5, vh) +
+              '%;background:#34c38f" title="' + tip + '"></div>';
+          }
+
+          if (c.other) {
+            bars += '<div class="bar" style="left:' + pos(ms) + '%;width:' + width + '%;bottom:' + (c.viewed ? Math.max(1.5, vh) : 0) +
+              '%;height:' + Math.max(1.5, c.other / peak * 100) + '%;background:#f46a6a" title="' + tip + '"></div>';
+          }
         });
-        html += '</div>';
 
-        html += '<div class="arrival-wave-legend">' + (att.roots || []).map(function(r) {
-          return '<span><span class="arrival-dot me-1" style="background:' + rootColor[r.root] + '"></span>' +
-            (r.viewed ? '<b>this block</b>' : '<span class="text-muted" title="' + esc(r.root) + '">' + esc(waveRootLabel(r.root, false)) + '</span>') +
-            ' <span class="num">' + r.count.toLocaleString() + '</span>' +
-            ' <span class="text-muted small">(' + (r.count / att.total_count * 100).toFixed(1) + '%)</span></span>';
-        }).join('') + '</div>';
+        var deadline = '';
+        var deadlineLabel = '';
+        if (att.deadline_ms > axLo && att.deadline_ms < axHi) {
+          deadline = '<div class="deadline" style="left:' + pos(att.deadline_ms) +
+            '%" title="One third into the slot: validators attest now even without a block in hand"></div>';
+          deadlineLabel = '<span class="dl" style="left:' + pos(att.deadline_ms) + '%">' + fmtAxis(att.deadline_ms) + ' deadline</span>';
+        }
 
-        document.getElementById('waves-att-chart').innerHTML = html;
+        document.getElementById('waves-att-body').innerHTML = stats + liveBadge(settled) +
+          '<div class="arrival-wave-mini">' + deadline + bars + '</div>' +
+          '<div class="arrival-wave-axis"><span>' + fmtAxis(axLo) + '</span>' + deadlineLabel + '<span>' + fmtAxis(axHi) + '</span></div>';
       }
 
-      // heat maps 0..1 onto green..red for the column strip; the range is the
-      // strip's own spread, since all 128 columns land within a couple hundred
-      // milliseconds and the absolute-time palette would paint them all alike.
+      // heat maps 0..1 onto green..red for the column strip. The range is the
+      // strip's own spread with a floor: a healthy tight spread (a few tens of
+      // ms) renders uniformly green, and red is reserved for columns that lag
+      // by real fractions of a second.
       function heat(t) {
         return 'hsl(' + Math.round(145 - t * 145) + ' 62% 44%)';
       }
 
       function renderColWave(cols, settled) {
+        var entries = cols.columns || [];
+        if (!entries.length || !cols.blob_count) return;
+
         document.getElementById('waves-cols').style.display = '';
 
         var stats = '<b>' + cols.blob_count + '</b> blob' + (cols.blob_count > 1 ? 's' : '') +
-          ' <span class="text-muted px-2">&middot;</span><b>' + cols.seen_columns + '</b><span class="text-muted">/' + (cols.columns || []).length + ' columns seen</span>';
+          sep + '<b>' + cols.seen_columns + '</b><span class="text-muted">/' + entries.length + ' columns seen</span>';
         if (cols.seen_columns > 0) {
-          stats += ' <span class="text-muted px-2">&middot;</span><span class="text-muted">spread</span> ' +
-            fmtMsColored(cols.first_ms) + ' <span class="text-muted">&rarr;</span> ' + fmtMsColored(cols.last_ms);
+          stats += sep + fmtMsColored(cols.first_ms) + ' <span class="text-muted">&rarr;</span> ' + fmtMsColored(cols.last_ms);
         }
         if (cols.probed_columns > 0) {
-          var avgCls = cols.min_availability < 100 ? '#f1b44c' : '#34c38f';
-          stats += ' <span class="text-muted px-2">&middot;</span><span class="text-muted">availability</span> ' +
-            '<span class="num" style="color:' + avgCls + '"><b>' + cols.avg_availability.toFixed(1) + '%</b></span>' +
-            (cols.min_availability < 100 ? ' <span class="text-muted small">(worst column ' + cols.min_availability.toFixed(1) + '%)</span>' : '') +
-            ' <span class="text-muted small">from ' + cols.total_probes.toLocaleString() + ' probes</span>';
+          var availColor = cols.min_availability < 100 ? '#f1b44c' : '#34c38f';
+          stats += sep + '<span class="num" style="color:' + availColor + '"><b>' + cols.avg_availability.toFixed(1) +
+            '%</b></span> <span class="text-muted">available (' + cols.total_probes.toLocaleString() + ' probes)</span>';
+          if (cols.min_availability < 100) {
+            stats += ' <span class="text-muted small">worst column ' + cols.min_availability.toFixed(1) + '%</span>';
+          }
         }
-        document.getElementById('waves-cols-stats').innerHTML = stats + liveBadge(settled);
 
-        // relative color range: min to p95 of the seen times. The span has a
-        // floor so a healthy tight spread (a few tens of ms) renders uniformly
-        // green; red is reserved for columns that lag by real fractions of a
-        // second, not for the slow half of a 60ms window.
-        var seen = (cols.columns || []).map(function(c) { return c.first_seen_ms; })
+        var seen = entries.map(function(c) { return c.first_seen_ms; })
           .filter(function(v) { return v != null; })
           .sort(function(a, b) { return a - b; });
         var rLo = seen.length ? seen[0] : 0;
         var rHi = seen.length ? seen[Math.floor((seen.length - 1) * 0.95)] : 1;
         var rSpan = Math.max(400, rHi - rLo);
 
-        var cells = (cols.columns || []).map(function(c) {
-          var tip = 'column ' + c.index;
+        var slivers = entries.map(function(c) {
           var style = '';
-          var cls = 'arrival-col-cell';
+          var tip = 'column ' + c.index;
 
           if (c.first_seen_ms != null) {
-            var t = Math.min(1, Math.max(0, (c.first_seen_ms - rLo) / rSpan));
-            style = 'background:' + heat(t);
-            tip += ' · first seen ' + fmtStr(c.first_seen_ms);
+            tip += ' \u00b7 first seen ' + fmtStr(c.first_seen_ms);
             if (c.first_seen_by) {
               tip += ' by ' + c.first_seen_by;
               var extra = [c.implementation, (c.country_code || '').toUpperCase()].filter(Boolean).join(', ');
               if (extra) tip += ' (' + extra + ')';
             }
           } else {
-            tip += ' · not seen';
+            tip += ' \u00b7 not seen';
           }
 
           if (c.availability_pct != null) {
-            tip += ' · availability ' + c.availability_pct.toFixed(1) + '% (' + c.probes + ' probes' +
+            tip += ' \u00b7 availability ' + c.availability_pct.toFixed(1) + '% (' + c.probes + ' probes' +
               (c.p50_response_ms ? ', p50 ' + c.p50_response_ms + 'ms' : '') + ')';
-            if (c.availability_pct < 100) cls += ' low';
           }
 
-          return '<div class="' + cls + '" style="' + style + '" title="' + esc(tip) + '"></div>';
+          // red flags a column that failed probes; otherwise shade by first
+          // seen; a never-seen column keeps the muted background
+          if (c.availability_pct != null && c.availability_pct < 100) {
+            style = 'background:#f46a6a';
+          } else if (c.first_seen_ms != null) {
+            style = 'background:' + heat(Math.min(1, Math.max(0, (c.first_seen_ms - rLo) / rSpan)));
+          }
+
+          return '<div style="' + style + '" title="' + esc(tip) + '"></div>';
         }).join('');
 
-        document.getElementById('waves-cols-chart').innerHTML =
-          '<div class="arrival-col-grid">' + cells + '</div>' +
-          '<div class="text-muted small pt-2">first seen: ' +
-          '<span class="arrival-dot" style="background:' + heat(0) + '"></span> ' + fmtStr(rLo) +
-          ' &rarr; <span class="arrival-dot" style="background:' + heat(Math.min(1, (rHi - rLo) / rSpan)) + '"></span> ' + fmtStr(rHi) +
-          ' &middot; <span class="arrival-col-cell low d-inline-block align-middle" style="width:12px;height:12px"></span> availability below 100%</div>';
+        document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) +
+          '<div class="arrival-col-strip">' + slivers + '</div>' +
+          '<div class="arrival-wave-axis"><span>column 0</span><span>' + (entries.length - 1) + '</span></div>';
       }
 
       function renderWaves(data) {

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -235,18 +235,21 @@
       transform: translateX(-50%);
       white-space: nowrap;
     }
+    /* the sources bar's shape, subdivided per column: gapless segments in
+       one slim pill, so a healthy slot reads as a single solid bar and only
+       deviant columns surface as slivers */
     .arrival-col-heat {
-      display: grid;
-      grid-template-columns: repeat(64, 1fr);
-      gap: 2px;
+      display: flex;
+      height: 12px;
       margin-top: 8px;
-    }
-    .arrival-col-heat > div {
-      height: 13px;
-      border-radius: 2px;
+      border-radius: 6px;
+      overflow: hidden;
       background: var(--bs-secondary-bg);
     }
-    .arrival-col-heat > div.low { box-shadow: inset 0 0 0 2px #f46a6a; }
+    .arrival-col-heat > div { flex: 1 1 auto; }
+    .arrival-col-heat > div.low {
+      background-image: repeating-linear-gradient(135deg, #f46a6a 0 3px, transparent 3px 6px);
+    }
     .arrival-heat-key {
       display: inline-block;
       width: 10px;
@@ -912,17 +915,35 @@
           return '<div' + cls + ' style="' + style + '" title="' + esc(tip) + '"></div>';
         }).join('');
 
-        var legend = '<div class="text-muted small pt-1">columns 0\u2013' + (entries.length - 1) + ', first seen: ';
-        [[0, '&lt;1s'], [1000, '1\u20132s'], [2000, '2\u20133s'], [3000, '3\u20134s'], [4000, '&ge;4s']].forEach(function(k) {
-          legend += '<span class="arrival-heat-key" style="background:' + timeColor(k[0]) + '"></span> ' + k[1] + ' ';
+        // one color for every column needs no key; explain only the states
+        // this slot actually has
+        var shades = {};
+
+        entries.forEach(function(c) {
+          if (c.first_seen_ms != null) shades[timeColor(c.first_seen_ms)] = true;
         });
+
+        var legendParts = [];
+
+        if (Object.keys(shades).length > 1) {
+          var chips = '';
+          [[0, '&lt;1s'], [1000, '1\u20132s'], [2000, '2\u20133s'], [3000, '3\u20134s'], [4000, '&ge;4s']].forEach(function(k) {
+            if (shades[timeColor(k[0])]) {
+              chips += '<span class="arrival-heat-key" style="background:' + timeColor(k[0]) + '"></span> ' + k[1] + ' ';
+            }
+          });
+          legendParts.push('first seen: ' + chips);
+        }
         if (unseen > 0) {
-          legend += sep + '<span class="arrival-heat-key"></span> not seen (' + unseen + ')';
+          legendParts.push('<span class="arrival-heat-key"></span> not seen (' + unseen + ')');
         }
         if (failed > 0) {
-          legend += sep + '<span class="arrival-heat-key low" style="box-shadow: inset 0 0 0 2px #f46a6a"></span> failed probes (' + failed + ')';
+          legendParts.push('<span class="arrival-heat-key" style="background-image: repeating-linear-gradient(135deg, #f46a6a 0 3px, transparent 3px 6px)"></span> failed probes (' + failed + ')');
         }
-        legend += '</div>';
+
+        var legend = legendParts.length
+          ? '<div class="text-muted small pt-1">' + legendParts.join(sep) + '</div>'
+          : '';
 
         document.getElementById('waves-cols').style.display = '';
         document.getElementById('waves-cols-body').innerHTML = stats + liveBadge(settled) +

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -207,13 +207,20 @@
     }
     .arrival-hist.hist-sm { height: 72px; }
     .arrival-hist.hist-tall { height: 210px; }
-    .arrival-hist .endlab {
+    /* y axis labels live in a gutter left of the plot, not inside it */
+    .tl-flex { display: flex; align-items: stretch; }
+    .tl-y {
+      position: relative;
+      width: 2.6rem;
+      flex: none;
+    }
+    .tl-y > span {
       position: absolute;
-      right: 5px;
+      right: 8px;
       transform: translateY(-50%);
-      font-size: 0.72rem;
-      font-weight: 600;
-      text-shadow: 0 0 3px var(--bs-body-bg), 0 0 3px var(--bs-body-bg);
+      font-size: 0.63rem;
+      color: var(--bs-secondary-color);
+      font-variant-numeric: tabular-nums;
     }
     .arrival-hist .grid {
       position: absolute; top: 0; bottom: 0; width: 1px;
@@ -233,6 +240,7 @@
       font-size: 0.63rem;
       color: var(--bs-secondary-color);
       white-space: nowrap;
+      text-shadow: 0 0 3px var(--bs-body-bg), 0 0 3px var(--bs-body-bg), 0 0 3px var(--bs-body-bg);
     }
     .arrival-hist-axis {
       position: relative;
@@ -792,6 +800,7 @@
             count: data.head.total_count,
             denom: data.head.total_count,
             of: 'observing nodes',
+            unit: 'nodes',
           });
         }
 
@@ -812,6 +821,7 @@
             count: data.payload.total_count,
             denom: data.payload.total_count,
             of: 'observing nodes',
+            unit: 'nodes',
           });
         }
 
@@ -822,6 +832,7 @@
             count: data.executed.total_count,
             denom: data.executed.total_count,
             of: 'reporting execution clients',
+            unit: 'clients',
           });
         }
 
@@ -842,12 +853,16 @@
         var ax = histAxis(0, slotMs);
         var pos = function(ms) { return (ms - ax.lo) / ax.span * 100; };
 
+        // headroom above the 100% line hosts the marker labels, so they never
+        // sit on top of the curves
+        var Y = function(pct) { return 9 + (100 - Math.min(100, pct)) * 0.91; };
+
+        var ylabs = '';
         var chart = '';
 
-        chart += '<span class="ylab" style="top:0%">100%</span>';
-        [25, 50, 75].forEach(function(pct) {
-          chart += '<div class="hgrid" style="top:' + (100 - pct) + '%"></div>' +
-            '<span class="ylab" style="top:' + (100 - pct) + '%">' + pct + '%</span>';
+        [100, 75, 50, 25].forEach(function(pct) {
+          ylabs += '<span style="top:' + Y(pct) + '%">' + pct + '%</span>';
+          chart += '<div class="hgrid" style="top:' + Y(pct) + '%"></div>';
         });
 
         ax.lines.forEach(function(t) {
@@ -892,11 +907,22 @@
 
         marks.sort(function(a, b) { return a.ms - b.ms; });
 
-        marks.forEach(function(m, idx) {
+        // labels share the top row and only stack when they would overlap
+        var placedMarks = [];
+
+        marks.forEach(function(m) {
           if (m.ms <= ax.lo || m.ms >= ax.hi) return;
 
-          chart += '<div class="deadline" style="left:' + pos(m.ms) + '%;border-left-color:' + m.color + '">' +
-            '<span class="note" style="top:' + (1 + idx * 13) + 'px;color:' + m.color + '" title="' + esc(m.title) + '">' +
+          var x = pos(m.ms);
+          var width = m.label.length * 0.62;
+          var row = 0;
+
+          while (placedMarks.some(function(pm) { return pm.row === row && x < pm.x + pm.w + 1.5 && x + width > pm.x; })) row++;
+
+          placedMarks.push({ x: x, w: width, row: row });
+
+          chart += '<div class="deadline" style="left:' + x + '%;border-left-color:' + m.color + '">' +
+            '<span class="note" style="top:' + (2 + row * 14) + 'px;color:' + m.color + '" title="' + esc(m.title) + '">' +
             m.label + '</span></div>';
         });
 
@@ -905,17 +931,16 @@
 
         series.forEach(function(sr) {
           var cum = 0;
-          var pts = ['0,100'];
+          var pts = ['0,' + Y(0).toFixed(2)];
 
           sr.buckets.forEach(function(b) {
             var x = Math.min(100, pos(b.ms + 50)).toFixed(2);
-            pts.push(x + ',' + (100 - cum / sr.denom * 100).toFixed(2));
+            pts.push(x + ',' + Y(cum / sr.denom * 100).toFixed(2));
             cum += b.count;
-            pts.push(x + ',' + (100 - cum / sr.denom * 100).toFixed(2));
+            pts.push(x + ',' + Y(cum / sr.denom * 100).toFixed(2));
           });
 
-          sr.finalPct = cum / sr.denom * 100;
-          pts.push('100,' + (100 - sr.finalPct).toFixed(2));
+          pts.push('100,' + Y(cum / sr.denom * 100).toFixed(2));
           svg += '<polyline points="' + pts.join(' ') + '" fill="none" stroke="' + sr.color +
             '" stroke-width="2" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
         });
@@ -939,25 +964,6 @@
             '%" title="by ' + fmtStr(Math.round(upto)) + ': ' + parts.join(' \u00b7 ') + '"></div>';
         }
 
-        // name each line at its right end instead of asking the reader to map
-        // legend swatches; stacked labels get pushed apart when lines end at
-        // the same level
-        var slots = series.map(function(sr, i) { return { i: i, top: 100 - sr.finalPct }; });
-        slots.sort(function(a, b) { return a.top - b.top; });
-
-        var minGap = 7;
-        for (var li = 1; li < slots.length; li++) {
-          if (slots[li].top < slots[li - 1].top + minGap) slots[li].top = slots[li - 1].top + minGap;
-        }
-
-        var endlabs = '';
-        slots.forEach(function(sl) {
-          var sr = series[sl.i];
-          endlabs += '<span class="endlab" style="top:' + Math.min(93, Math.max(3, sl.top + 3)) +
-            '%;color:' + sr.color + '">' + sr.label + '</span>';
-        });
-        chart += endlabs;
-
         var labels = '';
 
         ax.lines.forEach(function(t) {
@@ -966,20 +972,24 @@
         labels += '<span style="left:100%">' + fmtAxis(ax.hi) + '</span>';
 
         var stats = series.map(function(sr) {
-          return '<span style="color:' + sr.color + ';font-weight:600" title="of ' +
+          return '<span style="white-space: nowrap"><span style="color:' + sr.color + ';font-weight:600" title="of ' +
             (sr.denom !== sr.count ? sr.denom.toLocaleString() + ' ' : '') + sr.of + '">' + sr.label + '</span> <b>' +
             sr.count.toLocaleString() + '</b>' +
-            (sr.denom !== sr.count ? '<span class="text-muted">/' + sr.denom.toLocaleString() + '</span>' : '');
+            (sr.denom > sr.count ? '<span class="text-muted">/' + sr.denom.toLocaleString() + '</span>' : '') +
+            (sr.unit ? ' <span class="text-muted small">' + sr.unit + '</span>' : '') + '</span>';
         }).join(sep);
 
         if (viewed && viewed.viewed && att.total_count > viewed.count) {
-          stats += sep + '<span class="num" style="color:#f46a6a"><b>' +
-            (att.total_count - viewed.count).toLocaleString() + '</b></span> <span class="text-muted">vote other roots</span>';
+          stats += sep + '<span style="white-space: nowrap"><span class="num" style="color:#f46a6a"><b>' +
+            (att.total_count - viewed.count).toLocaleString() + '</b></span> <span class="text-muted">vote other roots</span></span>';
         }
 
         document.getElementById('waves-timeline-body').innerHTML = stats + liveBadge(data.settled) +
-          '<div class="arrival-hist hist-tall">' + chart + svg + hovers + '</div>' +
-          '<div class="arrival-hist-axis">' + labels + '</div>';
+          '<div class="tl-flex" style="margin-top: 8px">' +
+          '<div class="tl-y">' + ylabs + '</div>' +
+          '<div class="arrival-hist hist-tall" style="flex: 1 1 auto; min-width: 0; margin-top: 0">' + chart + svg + hovers + '</div>' +
+          '</div>' +
+          '<div class="arrival-hist-axis" style="margin-left: 2.6rem">' + labels + '</div>';
       }
 
       // The column chart follows the lab's data column propagation view:

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -894,24 +894,25 @@
           });
         }
 
-        // when the votes for this block pass 60% of the slot's expected
-        // attesters, walked over the cumulative viewed-root buckets
-        if (viewed && att.expected_count > 0) {
-          var need = att.expected_count * 0.6;
+        // when the votes for this block clear the builder payment quorum,
+        // walked over the cumulative viewed-root buckets; the count and its
+        // ratio both come from the chain spec via the response
+        if (viewed && att.expected_count > 0 && att.threshold_count > 0) {
           var cum = 0;
           var thresholdMs = null;
 
           (viewed.buckets || []).forEach(function(b) {
             if (thresholdMs != null) return;
             cum += b.count;
-            if (cum >= need) thresholdMs = b.ms + 50;
+            if (cum >= att.threshold_count) thresholdMs = b.ms + 50;
           });
 
           if (thresholdMs != null) {
+            var pct = Math.round(att.threshold_count / att.expected_count * 100);
             marks.push({
-              ms: thresholdMs, label: '60% voted', color: '#34c38f',
-              title: 'Attestations for this block passed 60% of the slot\u2019s ' +
-                att.expected_count.toLocaleString() + ' expected attesters',
+              ms: thresholdMs, label: pct + '% voted', color: '#34c38f',
+              title: 'Attestations for this block passed ' + att.threshold_count.toLocaleString() +
+                ' of the slot\u2019s ' + att.expected_count.toLocaleString() + ' expected attesters',
             });
           }
         }

--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -206,6 +206,15 @@
       border-bottom: 1px solid var(--bs-border-color);
     }
     .arrival-hist.hist-sm { height: 72px; }
+    .arrival-hist.hist-tall { height: 210px; }
+    .arrival-hist .endlab {
+      position: absolute;
+      right: 5px;
+      transform: translateY(-50%);
+      font-size: 0.72rem;
+      font-weight: 600;
+      text-shadow: 0 0 3px var(--bs-body-bg), 0 0 3px var(--bs-body-bg);
+    }
     .arrival-hist .grid {
       position: absolute; top: 0; bottom: 0; width: 1px;
       background: var(--bs-border-color);
@@ -214,7 +223,8 @@
     .arrival-hist .bar { position: absolute; bottom: 0; }
     .arrival-hist .deadline {
       position: absolute; top: 0; bottom: 0; width: 0;
-      border-left: 1px dashed var(--bs-secondary-color);
+      border-left: 2px dashed #f46a6a;
+      opacity: 0.9;
     }
     .arrival-hist .deadline .note {
       position: absolute;
@@ -773,21 +783,25 @@
           if (!viewed) viewed = (att.roots || [])[0];
         }
 
+        // block phase first, then the payload phase, so the legend reads in
+        // the order the slot unfolds
+        if (data.head && data.head.total_count) {
+          series.push({
+            label: 'head adopted', color: '#20c997',
+            buckets: data.head.buckets || [],
+            count: data.head.total_count,
+            denom: data.head.total_count,
+            of: 'observing nodes',
+          });
+        }
+
         if (viewed) {
           series.push({
             label: 'attestations', color: '#5b8def',
             buckets: viewed.buckets || [],
             count: viewed.count,
             denom: att.expected_count || viewed.count,
-          });
-        }
-
-        if (data.ptc && data.ptc.total_count) {
-          series.push({
-            label: 'PTC votes', color: '#9775fa',
-            buckets: (data.ptc.buckets || []).map(function(b) { return { ms: b.ms, count: b.present + b.missing }; }),
-            count: data.ptc.total_count,
-            denom: data.ptc.expected_count || data.ptc.total_count,
+            of: 'expected attesters',
           });
         }
 
@@ -797,15 +811,27 @@
             buckets: data.payload.buckets || [],
             count: data.payload.total_count,
             denom: data.payload.total_count,
+            of: 'observing nodes',
           });
         }
 
-        if (data.head && data.head.total_count) {
+        if (data.executed && data.executed.total_count) {
           series.push({
-            label: 'head adopted', color: '#20c997',
-            buckets: data.head.buckets || [],
-            count: data.head.total_count,
-            denom: data.head.total_count,
+            label: 'executed', color: '#f1b44c',
+            buckets: data.executed.buckets || [],
+            count: data.executed.total_count,
+            denom: data.executed.total_count,
+            of: 'reporting execution clients',
+          });
+        }
+
+        if (data.ptc && data.ptc.total_count) {
+          series.push({
+            label: 'PTC votes', color: '#9775fa',
+            buckets: (data.ptc.buckets || []).map(function(b) { return { ms: b.ms, count: b.present + b.missing }; }),
+            count: data.ptc.total_count,
+            denom: data.ptc.expected_count || data.ptc.total_count,
+            of: 'the PTC',
           });
         }
 
@@ -818,6 +844,7 @@
 
         var chart = '';
 
+        chart += '<span class="ylab" style="top:0%">100%</span>';
         [25, 50, 75].forEach(function(pct) {
           chart += '<div class="hgrid" style="top:' + (100 - pct) + '%"></div>' +
             '<span class="ylab" style="top:' + (100 - pct) + '%">' + pct + '%</span>';
@@ -831,14 +858,14 @@
 
         if (att && att.deadline_ms > 0) {
           marks.push({
-            ms: att.deadline_ms, label: 'attestation deadline', color: 'var(--bs-secondary-color)',
+            ms: att.deadline_ms, label: 'attestation deadline', color: '#f46a6a',
             title: 'ATTESTATION_DUE_BPS into the slot: validators attest now even without a block in hand',
           });
         }
 
         if (data.ptc && data.ptc.deadline_ms > 0) {
           marks.push({
-            ms: data.ptc.deadline_ms, label: 'PTC deadline', color: 'var(--bs-secondary-color)',
+            ms: data.ptc.deadline_ms, label: 'PTC deadline', color: '#f46a6a',
             title: 'PAYLOAD_ATTESTATION_DUE_BPS into the slot: PTC votes are due by here',
           });
         }
@@ -887,9 +914,10 @@
             pts.push(x + ',' + (100 - cum / sr.denom * 100).toFixed(2));
           });
 
-          pts.push('100,' + (100 - cum / sr.denom * 100).toFixed(2));
+          sr.finalPct = cum / sr.denom * 100;
+          pts.push('100,' + (100 - sr.finalPct).toFixed(2));
           svg += '<polyline points="' + pts.join(' ') + '" fill="none" stroke="' + sr.color +
-            '" stroke-width="1.6" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
+            '" stroke-width="2" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>';
         });
 
         svg += '</svg>';
@@ -911,6 +939,25 @@
             '%" title="by ' + fmtStr(Math.round(upto)) + ': ' + parts.join(' \u00b7 ') + '"></div>';
         }
 
+        // name each line at its right end instead of asking the reader to map
+        // legend swatches; stacked labels get pushed apart when lines end at
+        // the same level
+        var slots = series.map(function(sr, i) { return { i: i, top: 100 - sr.finalPct }; });
+        slots.sort(function(a, b) { return a.top - b.top; });
+
+        var minGap = 7;
+        for (var li = 1; li < slots.length; li++) {
+          if (slots[li].top < slots[li - 1].top + minGap) slots[li].top = slots[li - 1].top + minGap;
+        }
+
+        var endlabs = '';
+        slots.forEach(function(sl) {
+          var sr = series[sl.i];
+          endlabs += '<span class="endlab" style="top:' + Math.min(93, Math.max(3, sl.top + 3)) +
+            '%;color:' + sr.color + '">' + sr.label + '</span>';
+        });
+        chart += endlabs;
+
         var labels = '';
 
         ax.lines.forEach(function(t) {
@@ -919,8 +966,9 @@
         labels += '<span style="left:100%">' + fmtAxis(ax.hi) + '</span>';
 
         var stats = series.map(function(sr) {
-          return '<span class="arrival-heat-key" style="background:' + sr.color + '"></span> ' + sr.label +
-            ' <b>' + sr.count.toLocaleString() + '</b>' +
+          return '<span style="color:' + sr.color + ';font-weight:600" title="of ' +
+            (sr.denom !== sr.count ? sr.denom.toLocaleString() + ' ' : '') + sr.of + '">' + sr.label + '</span> <b>' +
+            sr.count.toLocaleString() + '</b>' +
             (sr.denom !== sr.count ? '<span class="text-muted">/' + sr.denom.toLocaleString() + '</span>' : '');
         }).join(sep);
 
@@ -930,7 +978,7 @@
         }
 
         document.getElementById('waves-timeline-body').innerHTML = stats + liveBadge(data.settled) +
-          '<div class="arrival-hist">' + chart + svg + hovers + '</div>' +
+          '<div class="arrival-hist hist-tall">' + chart + svg + hovers + '</div>' +
           '<div class="arrival-hist-axis">' + labels + '</div>';
       }
 
@@ -1085,7 +1133,8 @@
       function loadWaves() {
         if (wavesLoaded || !document.getElementById('waves-timeline')) return;
         wavesLoaded = true;
-        fetch('/slot/' + arrivalSlot + '/waves?root=' + encodeURIComponent(arrivalBlockRoot))
+        fetch('/slot/' + arrivalSlot + '/waves?root=' + encodeURIComponent(arrivalBlockRoot) +
+          '&exec=' + encodeURIComponent(arrivalExecHash) + '&num=' + encodeURIComponent(arrivalExecNumber))
           .then(function(r) {
             if (!r.ok) throw new Error('status ' + r.status);
             return r.json();

--- a/templates/slot_arrival_template_test.go
+++ b/templates/slot_arrival_template_test.go
@@ -68,14 +68,14 @@ func TestArrivalTemplateGatesCbtPanels(t *testing.T) {
 	}
 
 	with := render(true)
-	for _, want := range []string{`id="waves-att"`, `id="waves-cols"`} {
+	for _, want := range []string{`id="waves-timeline"`, `id="waves-cols"`} {
 		if !bytes.Contains([]byte(with), []byte(want)) {
 			t.Errorf("cbt-enabled output missing %q", want)
 		}
 	}
 
 	without := render(false)
-	if bytes.Contains([]byte(without), []byte(`id="waves-att"`)) {
+	if bytes.Contains([]byte(without), []byte(`id="waves-timeline"`)) {
 		t.Error("cbt panels rendered without a cbt source")
 	}
 	// the fetch guards on the panel's existence, so the JS may ship either way

--- a/templates/slot_arrival_template_test.go
+++ b/templates/slot_arrival_template_test.go
@@ -38,3 +38,45 @@ func TestArrivalTemplateExecutes(t *testing.T) {
 		}
 	}
 }
+
+// The cbt panels are gated on XatuCbtEnabled: their markup and fetch must
+// only render when a cbt source is configured.
+func TestArrivalTemplateGatesCbtPanels(t *testing.T) {
+	body, err := Files.ReadFile("slot/arrival.html")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	tmpl, err := template.New("t").Funcs(template.FuncMap(templateFuncs)).Parse(string(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	render := func(cbt bool) string {
+		data := &models.SlotPageData{
+			Slot:           12345,
+			XatuCbtEnabled: cbt,
+			Block:          &models.SlotPageBlockData{BlockRoot: []byte{0xab, 0xcd}},
+		}
+
+		var out bytes.Buffer
+		if err := tmpl.ExecuteTemplate(&out, "block_arrival", data); err != nil {
+			t.Fatalf("execute (cbt=%v): %v", cbt, err)
+		}
+
+		return out.String()
+	}
+
+	with := render(true)
+	for _, want := range []string{`id="waves-att"`, `id="waves-cols"`} {
+		if !bytes.Contains([]byte(with), []byte(want)) {
+			t.Errorf("cbt-enabled output missing %q", want)
+		}
+	}
+
+	without := render(false)
+	if bytes.Contains([]byte(without), []byte(`id="waves-att"`)) {
+		t.Error("cbt panels rendered without a cbt source")
+	}
+	// the fetch guards on the panel's existence, so the JS may ship either way
+}

--- a/types/config.go
+++ b/types/config.go
@@ -294,6 +294,9 @@ type XatuConfig struct {
 	// transformed models live on a different cluster, so a cbt source slots in
 	// alongside this one rather than sharing its connection.
 	Raw XatuSourceConfig `yaml:"raw"`
+	// Cbt holds the connection to the xatu-cbt transformed models. Optional;
+	// features backed by cbt tables stay hidden when no DSN is set.
+	Cbt XatuCbtSourceConfig `yaml:"cbt"`
 }
 
 // XatuSourceConfig is the connection to one ClickHouse instance holding xatu
@@ -307,6 +310,17 @@ type XatuSourceConfig struct {
 	// instances and page loads share one cached response.
 	ClickhouseCachedDsn string `yaml:"clickhouseCachedDsn" envconfig:"XATU_RAW_CLICKHOUSE_CACHED_DSN"`
 	Database            string `yaml:"database" envconfig:"XATU_RAW_DATABASE"`
+}
+
+// XatuCbtSourceConfig is the connection to a ClickHouse instance holding
+// xatu-cbt transformed models. It mirrors XatuSourceConfig; the envconfig tags
+// carry the source name, so each source needs its own struct.
+type XatuCbtSourceConfig struct {
+	ClickhouseDsn       string `yaml:"clickhouseDsn" envconfig:"XATU_CBT_CLICKHOUSE_DSN"`
+	ClickhouseCachedDsn string `yaml:"clickhouseCachedDsn" envconfig:"XATU_CBT_CLICKHOUSE_CACHED_DSN"`
+	// Database names the per-network database holding the cbt models; defaults
+	// to the network name.
+	Database string `yaml:"database" envconfig:"XATU_CBT_DATABASE"`
 }
 
 type DatabaseConfig struct {

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -24,6 +24,7 @@ type SlotPageData struct {
 	SlotBlocks             []*SlotPageSlotBlock    `json:"slot_blocks"`
 	TracoorUrl             string                  `json:"tracoor_url"`
 	XatuEnabled            bool                    `json:"xatu_enabled"`
+	XatuCbtEnabled         bool                    `json:"xatu_cbt_enabled"`
 	SystemContracts        []*types.SystemContract `json:"system_contracts"`
 	TransactionDetails     []*SlotPageTransaction  `json:"transaction_details"`
 

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -49,10 +49,16 @@ type SlotAttestationBucket struct {
 }
 
 // SlotColumnWave describes how the slot's data column sidecars spread and how
-// available they measured afterwards, one entry per column index.
+// available they measured afterwards, one entry per column index. Timings are
+// reduced from every observing node's sighting, so each column carries its
+// own percentiles rather than one network-first value.
 type SlotColumnWave struct {
 	BlobCount   int `json:"blob_count"`
 	SeenColumns int `json:"seen_columns"`
+	// Observations counts every node-column sighting behind the percentiles.
+	Observations int `json:"observations"`
+	// MedianMs is the median of all sightings across all columns.
+	MedianMs uint32 `json:"median_ms"`
 	// FirstMs and LastMs span the per-column first-seen times.
 	FirstMs uint32 `json:"first_ms"`
 	LastMs  uint32 `json:"last_ms"`
@@ -72,6 +78,11 @@ type SlotColumnWave struct {
 type SlotColumn struct {
 	Index       uint32  `json:"index"`
 	FirstSeenMs *uint32 `json:"first_seen_ms,omitempty"`
+	// P50Ms and P90Ms are percentiles of when each observing node saw this
+	// column; FirstSeenMs is their minimum.
+	P50Ms        uint32 `json:"p50_ms,omitempty"`
+	P90Ms        uint32 `json:"p90_ms,omitempty"`
+	Observations int    `json:"observations,omitempty"`
 	// FirstSeenBy is the display name of the node that saw the column first.
 	FirstSeenBy     string   `json:"first_seen_by,omitempty"`
 	Implementation  string   `json:"implementation,omitempty"`

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -16,7 +16,18 @@ type SlotWavesResponse struct {
 	SlotMs       uint32               `json:"slot_ms"`
 	Attestations *SlotAttestationWave `json:"attestations,omitempty"`
 	Ptc          *SlotPtcWave         `json:"ptc,omitempty"`
-	Columns      *SlotColumnWave      `json:"columns,omitempty"`
+	// Payload and Head bucket when each observing node first saw the revealed
+	// execution payload and first adopted the block as head.
+	Payload *SlotSeenWave   `json:"payload,omitempty"`
+	Head    *SlotSeenWave   `json:"head,omitempty"`
+	Columns *SlotColumnWave `json:"columns,omitempty"`
+}
+
+// SlotSeenWave buckets when observing nodes first saw one per-slot object,
+// in 50ms chunks capped to the slot.
+type SlotSeenWave struct {
+	TotalCount int                      `json:"total_count"`
+	Buckets    []*SlotAttestationBucket `json:"buckets,omitempty"`
 }
 
 // SlotPtcWave is the payload timeliness committee's voting wave on gloas
@@ -25,6 +36,8 @@ type SlotWavesResponse struct {
 type SlotPtcWave struct {
 	TotalCount   int `json:"total_count"`
 	PresentCount int `json:"present_count"`
+	// ExpectedCount is the committee size, PTC_SIZE from the chain spec.
+	ExpectedCount int `json:"expected_count,omitempty"`
 	// DeadlineMs is when PTC votes are due: 75% of the slot.
 	DeadlineMs uint32           `json:"deadline_ms"`
 	Buckets    []*SlotPtcBucket `json:"buckets,omitempty"`
@@ -50,10 +63,6 @@ type SlotAttestationWave struct {
 	// ThresholdCount is the vote count where the block clears the builder
 	// payment quorum (BUILDER_PAYMENT_THRESHOLD of ExpectedCount).
 	ThresholdCount int `json:"threshold_count,omitempty"`
-	// PayloadP50Ms is the median time the separately-gossiped execution
-	// payload reached observing nodes; zero on networks without the gloas
-	// payload series.
-	PayloadP50Ms uint32 `json:"payload_p50_ms,omitempty"`
 	// Roots is ordered by vote count, largest first. Low-volume roots beyond
 	// the first few are merged into one entry with an empty Root.
 	Roots []*SlotAttestationRoot `json:"roots,omitempty"`

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -45,9 +45,11 @@ type SlotAttestationWave struct {
 	// DeadlineMs is a third of the slot, the point where validators that have
 	// not seen a block attest anyway, which the wave visibly spikes around.
 	DeadlineMs uint32 `json:"deadline_ms"`
-	// ExpectedCount is how many validators were due to attest in this slot,
-	// so the chart can mark when the votes for the block pass 60% of it.
+	// ExpectedCount is how many validators were due to attest in this slot.
 	ExpectedCount int `json:"expected_count,omitempty"`
+	// ThresholdCount is the vote count where the block clears the builder
+	// payment quorum (BUILDER_PAYMENT_THRESHOLD of ExpectedCount).
+	ThresholdCount int `json:"threshold_count,omitempty"`
 	// PayloadP50Ms is the median time the separately-gossiped execution
 	// payload reached observing nodes; zero on networks without the gloas
 	// payload series.

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -1,0 +1,79 @@
+package models
+
+// SlotWavesResponse is the JSON payload for the xatu-cbt backed panels on the
+// slot page's propagation tab: the attestation first-seen wave and the data
+// column propagation strip. Either section is nil when its table has no rows
+// for the slot. The count fields are deliberately plain int, which keeps the
+// whole model on the page cache's JSON path, where nil sections survive a
+// cache round-trip; see the note on SlotArrivalResponse.
+type SlotWavesResponse struct {
+	Slot uint64 `json:"slot"`
+	// Settled is false while the cbt transformations may still be rewriting
+	// this slot's rows; such responses are cached for one slot only.
+	Settled      bool                 `json:"settled"`
+	Attestations *SlotAttestationWave `json:"attestations,omitempty"`
+	Columns      *SlotColumnWave      `json:"columns,omitempty"`
+}
+
+// SlotAttestationWave is the network's attestation traffic for one slot,
+// bucketed into 50ms chunks by when each attestation was first seen by any
+// observing node, and split by the block root the attestations vote for.
+type SlotAttestationWave struct {
+	TotalCount int `json:"total_count"`
+	// DeadlineMs is a third of the slot, the point where validators that have
+	// not seen a block attest anyway, which the wave visibly spikes around.
+	DeadlineMs uint32 `json:"deadline_ms"`
+	// Roots is ordered by vote count, largest first. Low-volume roots beyond
+	// the first few are merged into one entry with an empty Root.
+	Roots []*SlotAttestationRoot `json:"roots,omitempty"`
+}
+
+// SlotAttestationRoot is one voted block root's share of the wave.
+type SlotAttestationRoot struct {
+	Root string `json:"root"`
+	// Viewed marks the root of the block the page is showing, so the template
+	// can separate votes for this block from wrong-head votes.
+	Viewed  bool                     `json:"viewed,omitempty"`
+	Count   int                      `json:"count"`
+	Buckets []*SlotAttestationBucket `json:"buckets,omitempty"`
+}
+
+// SlotAttestationBucket is one 50ms chunk: attestations first seen between Ms
+// and Ms+50 after slot start.
+type SlotAttestationBucket struct {
+	Ms    uint32 `json:"ms"`
+	Count int    `json:"count"`
+}
+
+// SlotColumnWave describes how the slot's data column sidecars spread and how
+// available they measured afterwards, one entry per column index.
+type SlotColumnWave struct {
+	BlobCount   int `json:"blob_count"`
+	SeenColumns int `json:"seen_columns"`
+	// FirstMs and LastMs span the per-column first-seen times.
+	FirstMs uint32 `json:"first_ms"`
+	LastMs  uint32 `json:"last_ms"`
+	// Availability aggregates over the probed columns.
+	ProbedColumns   int           `json:"probed_columns"`
+	AvgAvailability float64       `json:"avg_availability"`
+	MinAvailability float64       `json:"min_availability"`
+	TotalProbes     int           `json:"total_probes"`
+	WorstP50Ms      uint32        `json:"worst_p50_ms"`
+	Columns         []*SlotColumn `json:"columns,omitempty"`
+}
+
+// SlotColumn is one data column's propagation and availability measurements.
+// FirstSeenMs and AvailabilityPct are optional because the two series come
+// from different tables: a column can be seen but never probed and the other
+// way round.
+type SlotColumn struct {
+	Index       uint32  `json:"index"`
+	FirstSeenMs *uint32 `json:"first_seen_ms,omitempty"`
+	// FirstSeenBy is the display name of the node that saw the column first.
+	FirstSeenBy     string   `json:"first_seen_by,omitempty"`
+	Implementation  string   `json:"implementation,omitempty"`
+	CountryCode     string   `json:"country_code,omitempty"`
+	AvailabilityPct *float64 `json:"availability_pct,omitempty"`
+	Probes          int      `json:"probes,omitempty"`
+	P50ResponseMs   uint32   `json:"p50_response_ms,omitempty"`
+}

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -17,10 +17,12 @@ type SlotWavesResponse struct {
 	Attestations *SlotAttestationWave `json:"attestations,omitempty"`
 	Ptc          *SlotPtcWave         `json:"ptc,omitempty"`
 	// Payload and Head bucket when each observing node first saw the revealed
-	// execution payload and first adopted the block as head.
-	Payload *SlotSeenWave   `json:"payload,omitempty"`
-	Head    *SlotSeenWave   `json:"head,omitempty"`
-	Columns *SlotColumnWave `json:"columns,omitempty"`
+	// execution payload and first adopted the block as head; Executed buckets
+	// when each node's execution client finished importing the payload.
+	Payload  *SlotSeenWave   `json:"payload,omitempty"`
+	Head     *SlotSeenWave   `json:"head,omitempty"`
+	Executed *SlotSeenWave   `json:"executed,omitempty"`
+	Columns  *SlotColumnWave `json:"columns,omitempty"`
 }
 
 // SlotSeenWave buckets when observing nodes first saw one per-slot object,

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -15,7 +15,24 @@ type SlotWavesResponse struct {
 	// instead of stopping wherever the data does.
 	SlotMs       uint32               `json:"slot_ms"`
 	Attestations *SlotAttestationWave `json:"attestations,omitempty"`
+	Ptc          *SlotPtcWave         `json:"ptc,omitempty"`
 	Columns      *SlotColumnWave      `json:"columns,omitempty"`
+}
+
+// SlotPtcWave is the payload timeliness committee's voting wave on gloas
+// networks: when each PTC member's vote was first seen, split by whether it
+// judged the payload present. Nil on networks without the gloas schema.
+type SlotPtcWave struct {
+	TotalCount   int              `json:"total_count"`
+	PresentCount int              `json:"present_count"`
+	Buckets      []*SlotPtcBucket `json:"buckets,omitempty"`
+}
+
+// SlotPtcBucket is one 50ms chunk of PTC votes.
+type SlotPtcBucket struct {
+	Ms      uint32 `json:"ms"`
+	Present int    `json:"present"`
+	Missing int    `json:"missing"`
 }
 
 // SlotAttestationWave is the network's attestation traffic for one slot,

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -23,9 +23,11 @@ type SlotWavesResponse struct {
 // networks: when each PTC member's vote was first seen, split by whether it
 // judged the payload present. Nil on networks without the gloas schema.
 type SlotPtcWave struct {
-	TotalCount   int              `json:"total_count"`
-	PresentCount int              `json:"present_count"`
-	Buckets      []*SlotPtcBucket `json:"buckets,omitempty"`
+	TotalCount   int `json:"total_count"`
+	PresentCount int `json:"present_count"`
+	// DeadlineMs is when PTC votes are due: 75% of the slot.
+	DeadlineMs uint32           `json:"deadline_ms"`
+	Buckets    []*SlotPtcBucket `json:"buckets,omitempty"`
 }
 
 // SlotPtcBucket is one 50ms chunk of PTC votes.

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -10,7 +10,10 @@ type SlotWavesResponse struct {
 	Slot uint64 `json:"slot"`
 	// Settled is false while the cbt transformations may still be rewriting
 	// this slot's rows; such responses are cached for one slot only.
-	Settled      bool                 `json:"settled"`
+	Settled bool `json:"settled"`
+	// SlotMs is the slot duration, so the charts can span the whole slot
+	// instead of stopping wherever the data does.
+	SlotMs       uint32               `json:"slot_ms"`
 	Attestations *SlotAttestationWave `json:"attestations,omitempty"`
 	Columns      *SlotColumnWave      `json:"columns,omitempty"`
 }

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -26,6 +26,13 @@ type SlotAttestationWave struct {
 	// DeadlineMs is a third of the slot, the point where validators that have
 	// not seen a block attest anyway, which the wave visibly spikes around.
 	DeadlineMs uint32 `json:"deadline_ms"`
+	// ExpectedCount is how many validators were due to attest in this slot,
+	// so the chart can mark when the votes for the block pass 60% of it.
+	ExpectedCount int `json:"expected_count,omitempty"`
+	// PayloadP50Ms is the median time the separately-gossiped execution
+	// payload reached observing nodes; zero on networks without the gloas
+	// payload series.
+	PayloadP50Ms uint32 `json:"payload_p50_ms,omitempty"`
 	// Roots is ordered by vote count, largest first. Low-volume roots beyond
 	// the first few are merged into one entry with an empty Root.
 	Roots []*SlotAttestationRoot `json:"roots,omitempty"`

--- a/utils/xatu_env_test.go
+++ b/utils/xatu_env_test.go
@@ -14,7 +14,10 @@ func TestXatuEnvNamesAreNamespaced(t *testing.T) {
 	bare := map[string]func(*types.Config) bool{
 		"ENABLED":        func(c *types.Config) bool { return c.Xatu.Enabled },
 		"CLICKHOUSE_DSN": func(c *types.Config) bool { return c.Xatu.Raw.ClickhouseDsn != "" },
-		"DATABASE":       func(c *types.Config) bool { return c.Xatu.Raw.Database != "" },
+		"DATABASE":       func(c *types.Config) bool { return c.Xatu.Raw.Database != "" || c.Xatu.Cbt.Database != "" },
+		"CLICKHOUSE_CACHED_DSN": func(c *types.Config) bool {
+			return c.Xatu.Raw.ClickhouseCachedDsn != "" || c.Xatu.Cbt.ClickhouseCachedDsn != ""
+		},
 	}
 
 	for name, bound := range bare {
@@ -37,6 +40,8 @@ func TestXatuEnvNamesAreNamespaced(t *testing.T) {
 		{"XATU_ENABLED", func(c *types.Config) bool { return c.Xatu.Enabled }},
 		{"XATU_RAW_CLICKHOUSE_DSN", func(c *types.Config) bool { return c.Xatu.Raw.ClickhouseDsn == "v" }},
 		{"XATU_RAW_DATABASE", func(c *types.Config) bool { return c.Xatu.Raw.Database == "v" }},
+		{"XATU_CBT_CLICKHOUSE_DSN", func(c *types.Config) bool { return c.Xatu.Cbt.ClickhouseDsn == "v" }},
+		{"XATU_CBT_DATABASE", func(c *types.Config) bool { return c.Xatu.Cbt.Database == "v" }},
 		{"XATU_NETWORK_NAME", func(c *types.Config) bool { return c.Xatu.NetworkName == "v" }},
 	} {
 		value := "v"


### PR DESCRIPTION
Stacked on #<!-- -->the block-arrival PR (`feat/xatu-block-arrival`) — this diff is only the delta.

Adds two panels to the propagation tab, both from xatu-cbt's transformed models and both showing data a beacon node cannot report about itself:

**Attestation wave** — when the network first saw the slot's ~28k attestations, in 50ms buckets, split by the block root they vote for. Wrong-head votes render as their own series, and the one-third-slot attestation deadline is marked; the deadline spike of validators who attested without the block in hand is clearly visible.

**Data columns** — per-column first-seen times and probe-measured availability for the slot's PeerDAS data column sidecars: a 128-cell strip colored by first-seen time, with availability outliers ringed. Hidden for blobless and pre-Fusaka slots.

Both are served by one lazy `/slot/{slot}/waves` endpoint following the arrival endpoint's caching ladder, scoped to the viewed block root, and gated on a new optional `xatu.cbt` config source (one database per network on the refined cluster; the database defaults to the network name). Without a cbt DSN nothing renders and nothing is queried.

Plumbing notes:
- The xatu client's query path is now source-agnostic: build closures return plain SQL and encode page tokens with their own generated package. Raw and cbt are two instances of the same client, each with its own connections, semaphore and settle delay.
- Every cbt query filters both `slot` and `slot_start_date_time`: the refined cluster enforces `force_primary_key`, and which column leads the key differs between tables.
- The cbt settle delay is a fixed two minutes, measured against production: availability probes run within the probed slot, the attestation chunk window extends 12s past slot start, and transformation batches lag under a minute.

Depends on ethpandaops/xatu-cbt#301: without that rename, any binary linking both xatu's and xatu-cbt's generated packages panics at init on duplicate protobuf descriptor registrations (`common.proto`, `clickhouse/annotations.proto`, and the `clickhouse.v1.*` extensions). go.mod is pinned to that branch and needs a re-pin once it merges. ethpandaops/clickhouse-proto-gen#43 adds the generator flag so future regenerations keep the fix.

Verified against production mainnet ClickHouse: both panels render for a live slot (28,141 attestations, 99.9% voting the viewed block, 41 wrong-head votes; 9 blobs, 128/128 columns seen in a 64ms spread, 100% availability from 718 probes), pre-Fusaka slots omit the column panel, cached reruns answer in ~1ms, and both endpoints boot-degrade cleanly when unreachable.

https://claude.ai/code/session_01PqWvkAjYgCjjhtu83gJeXP