### PR TITLE
Round the arrival timeline axis labels to whole milliseconds

### DIFF
--- a/templates/slot/arrival.html
+++ b/templates/slot/arrival.html
@@ -400,8 +400,9 @@
         if (ms >= 1000) return (ms / 1000).toFixed(2) + 's';
         return ms + 'ms';
       }
-      // Axis ticks are round numbers, so drop the trailing zeroes fmtStr keeps.
+      // Axis bounds are fractional (lo/hi carry float noise), so round to whole ms.
       function fmtAxis(ms) {
+        ms = Math.round(ms);
         if (ms < 1000) return ms + 'ms';
         return String(+(ms / 1000).toFixed(2)) + 's';
       }


### PR DESCRIPTION
The timeline axis bounds are computed as fractions of the observation spread, so the left label could render float noise like `220.64999999999998ms`. `fmtAxis` now rounds to whole milliseconds before formatting.

https://claude.ai/code/session_01QTfZjLgwhNK5i4At7BfrBR