### PR TITLE
Rename inclusion list committee root to dependent root (consensus-specs alpha.14)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4915,7 +4915,7 @@ const docTemplate = `{
         "api.APISlotInclusionList": {
             "type": "object",
             "properties": {
-                "inclusion_list_committee_root": {
+                "dependent_root": {
                     "type": "string"
                 },
                 "signature": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4912,7 +4912,7 @@
         "api.APISlotInclusionList": {
             "type": "object",
             "properties": {
-                "inclusion_list_committee_root": {
+                "dependent_root": {
                     "type": "string"
                 },
                 "signature": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1421,7 +1421,7 @@ definitions:
     type: object
   api.APISlotInclusionList:
     properties:
-      inclusion_list_committee_root:
+      dependent_root:
         type: string
       signature:
         type: string

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethpandaops/eth-das-guardian v0.1.1
 	github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260812120339-e742ab5a2de1
+	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827134632-36d49bf23aef
 	github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3
 	github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethpandaops/eth-das-guardian v0.1.1
 	github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135002-38c12e37286c
+	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135229-5c907ec076d6
 	github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3
 	github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethpandaops/eth-das-guardian v0.1.1
 	github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135229-5c907ec076d6
+	github.com/ethpandaops/go-eth2-client v0.1.7
 	github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3
 	github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethpandaops/eth-das-guardian v0.1.1
 	github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b
 	github.com/ethpandaops/ethwallclock v0.4.0
-	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827134632-36d49bf23aef
+	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135002-38c12e37286c
 	github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3
 	github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b h1:hcP42xFgU4d
 github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b/go.mod h1:my+mlolmidi2VzoaGhchtcxDVbp1ZNVQJtnkk3oe6+M=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135002-38c12e37286c h1:oYdBGOouiTFcQ++0GcFSjFCOGA+EX7/315s713KfFCE=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135002-38c12e37286c/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135229-5c907ec076d6 h1:Gao+SMCax395TyfpJsjdxi3bKDZ2YdzLBgzmVch63dU=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135229-5c907ec076d6/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3 h1:83LDwFEAijcssPdQ8ojzzbi+2mD3a+zL1b4V4cY1sMo=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3/go.mod h1:sDLPtT/bQgK+vExtPq77y2W4yHq9tRdiDu852yptTcU=
 github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8 h1:YfAXAt5fQcEnzPccCfByhXY2Vy9FlGrOp+NxGLx3QNY=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b h1:hcP42xFgU4d
 github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b/go.mod h1:my+mlolmidi2VzoaGhchtcxDVbp1ZNVQJtnkk3oe6+M=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135229-5c907ec076d6 h1:Gao+SMCax395TyfpJsjdxi3bKDZ2YdzLBgzmVch63dU=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135229-5c907ec076d6/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
+github.com/ethpandaops/go-eth2-client v0.1.7 h1:EzZP50rrpVsjk2U8cOpN+kgNDTd/9IZNQXkh9t8G9AQ=
+github.com/ethpandaops/go-eth2-client v0.1.7/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3 h1:83LDwFEAijcssPdQ8ojzzbi+2mD3a+zL1b4V4cY1sMo=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3/go.mod h1:sDLPtT/bQgK+vExtPq77y2W4yHq9tRdiDu852yptTcU=
 github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8 h1:YfAXAt5fQcEnzPccCfByhXY2Vy9FlGrOp+NxGLx3QNY=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b h1:hcP42xFgU4d
 github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b/go.mod h1:my+mlolmidi2VzoaGhchtcxDVbp1ZNVQJtnkk3oe6+M=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260812120339-e742ab5a2de1 h1:Hhupjk3QgnoIvmL2owPLMbcraDsd1sgKnd3pWx2pz5E=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260812120339-e742ab5a2de1/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827134632-36d49bf23aef h1:uEy+6+2euYzUpX/5MmtmkMj5phBhiFCKoLbIA9rLOSQ=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827134632-36d49bf23aef/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3 h1:83LDwFEAijcssPdQ8ojzzbi+2mD3a+zL1b4V4cY1sMo=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3/go.mod h1:sDLPtT/bQgK+vExtPq77y2W4yHq9tRdiDu852yptTcU=
 github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8 h1:YfAXAt5fQcEnzPccCfByhXY2Vy9FlGrOp+NxGLx3QNY=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b h1:hcP42xFgU4d
 github.com/ethpandaops/ethcore v0.0.0-20260807103219-0fb0622e156b/go.mod h1:my+mlolmidi2VzoaGhchtcxDVbp1ZNVQJtnkk3oe6+M=
 github.com/ethpandaops/ethwallclock v0.4.0 h1:+sgnhf4pk6hLPukP076VxkiLloE4L0Yk1yat+ZyHh1g=
 github.com/ethpandaops/ethwallclock v0.4.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827134632-36d49bf23aef h1:uEy+6+2euYzUpX/5MmtmkMj5phBhiFCKoLbIA9rLOSQ=
-github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827134632-36d49bf23aef/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135002-38c12e37286c h1:oYdBGOouiTFcQ++0GcFSjFCOGA+EX7/315s713KfFCE=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260827135002-38c12e37286c/go.mod h1:MXQukU/345puJmB2EikoaeQIFizk3zbekPxwYyxG/t8=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3 h1:83LDwFEAijcssPdQ8ojzzbi+2mD3a+zL1b4V4cY1sMo=
 github.com/ethpandaops/xatu v1.22.1-0.20260824050538-619c572d19c3/go.mod h1:sDLPtT/bQgK+vExtPq77y2W4yHq9tRdiDu852yptTcU=
 github.com/ethpandaops/xatu-cbt v0.0.0-20260825024339-8eadec716ac8 h1:YfAXAt5fQcEnzPccCfByhXY2Vy9FlGrOp+NxGLx3QNY=

--- a/handlers/api/slot_inclusion_lists_v1.go
+++ b/handlers/api/slot_inclusion_lists_v1.go
@@ -30,12 +30,12 @@ type APISlotInclusionListsData struct {
 
 // APISlotInclusionList is a single signed inclusion list (EIP-7805).
 type APISlotInclusionList struct {
-	ValidatorIndex             uint64                             `json:"validator_index"`
-	ValidatorName              string                             `json:"validator_name,omitempty"`
-	InclusionListCommitteeRoot string                             `json:"inclusion_list_committee_root"`
-	Signature                  string                             `json:"signature"`
-	TransactionsCount          uint64                             `json:"transactions_count"`
-	Transactions               []*APISlotInclusionListTransaction `json:"transactions"`
+	ValidatorIndex    uint64                             `json:"validator_index"`
+	ValidatorName     string                             `json:"validator_name,omitempty"`
+	DependentRoot     string                             `json:"dependent_root"`
+	Signature         string                             `json:"signature"`
+	TransactionsCount uint64                             `json:"transactions_count"`
+	Transactions      []*APISlotInclusionListTransaction `json:"transactions"`
 }
 
 // APISlotInclusionListTransaction describes one transaction in an inclusion list.
@@ -109,11 +109,11 @@ func APISlotInclusionListsV1(w http.ResponseWriter, r *http.Request) {
 
 		valIndex := uint64(il.Message.ValidatorIndex)
 		listEntry := &APISlotInclusionList{
-			ValidatorIndex:             valIndex,
-			ValidatorName:              services.GlobalBeaconService.GetValidatorNameAt(valIndex, phase0.Slot(dbSlot.Slot)),
-			InclusionListCommitteeRoot: fmt.Sprintf("0x%x", il.Message.InclusionListCommitteeRoot[:]),
-			Signature:                  fmt.Sprintf("0x%x", il.Signature[:]),
-			Transactions:               make([]*APISlotInclusionListTransaction, 0, len(il.Message.Transactions)),
+			ValidatorIndex: valIndex,
+			ValidatorName:  services.GlobalBeaconService.GetValidatorNameAt(valIndex, phase0.Slot(dbSlot.Slot)),
+			DependentRoot:  fmt.Sprintf("0x%x", il.Message.DependentRoot[:]),
+			Signature:      fmt.Sprintf("0x%x", il.Signature[:]),
+			Transactions:   make([]*APISlotInclusionListTransaction, 0, len(il.Message.Transactions)),
 		}
 
 		for idx, txBytes := range il.Message.Transactions {

--- a/handlers/slot.go
+++ b/handlers/slot.go
@@ -1767,8 +1767,8 @@ func getSlotPageInclusionLists(pageData *models.SlotPageBlockData, slot phase0.S
 				Index: uint64(il.Message.ValidatorIndex),
 				Name:  services.GlobalBeaconService.GetValidatorNameAt(uint64(il.Message.ValidatorIndex), slot),
 			},
-			InclusionListCommitteeRoot: il.Message.InclusionListCommitteeRoot[:],
-			Signature:                  il.Signature[:],
+			DependentRoot: il.Message.DependentRoot[:],
+			Signature:     il.Signature[:],
 		}
 
 		ilData.Transactions = decodeInclusionListTransactions(il, sysContracts)

--- a/templates/slot/inclusion_lists.html
+++ b/templates/slot/inclusion_lists.html
@@ -12,10 +12,10 @@
           </div>
         </div>
         <div class="row border-bottom p-1 mx-0">
-          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="The hash-tree-root of the IL committee">IL Committee Root:</span></div>
+          <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="The shuffling dependent root of the block the inclusion list committee was computed from">Dependent Root:</span></div>
           <div class="col-md-10 text-monospace text-break">
-            0x{{ printf "%x" $inclusionList.InclusionListCommitteeRoot }}
-            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $inclusionList.InclusionListCommitteeRoot }}"></i>
+            0x{{ printf "%x" $inclusionList.DependentRoot }}
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="0x{{ printf "%x" $inclusionList.DependentRoot }}"></i>
           </div>
         </div>
         <div class="row border-bottom p-1 mx-0">

--- a/types/models/slot.go
+++ b/types/models/slot.go
@@ -476,12 +476,12 @@ type SlotPagePtcAggregate struct {
 
 // SlotPageInclusionList holds data for an inclusion list entry on the slot page.
 type SlotPageInclusionList struct {
-	Validator                  types.NamedValidator   `json:"validator"`
-	InclusionListCommitteeRoot []byte                 `json:"inclusion_list_committee_root"`
-	Transactions               []*SlotPageTransaction `json:"transactions"`
-	TransactionsCount          uint64                 `json:"transactions_count"`
-	TransactionsIncluded       []bool                 `json:"transactions_included"`
-	Signature                  []byte                 `json:"signature"`
+	Validator            types.NamedValidator   `json:"validator"`
+	DependentRoot        []byte                 `json:"dependent_root"`
+	Transactions         []*SlotPageTransaction `json:"transactions"`
+	TransactionsCount    uint64                 `json:"transactions_count"`
+	TransactionsIncluded []bool                 `json:"transactions_included"`
+	Signature            []byte                 `json:"signature"`
 }
 
 type SlotPageExecutionProof struct {


### PR DESCRIPTION
consensus-specs [v1.7.0-alpha.14](https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.14) replaced `InclusionList.inclusion_list_committee_root` with `dependent_root`. `master-latest` fails on alpha.14 networks with:

```
beacon block stream failed to decode inclusion_list event: inclusion list committee root missing
```

Changes:
- bump `go-eth2-client` to master (`5c907ec0`) — brings the heze alpha.14 containers (ethpandaops/go-eth2-client#52) and the fixed `inclusion_list` SSE decoder (ethpandaops/go-eth2-client#53)
- slot page inclusion list section: `IL Committee Root` → `Dependent Root` (`templates/slot/inclusion_lists.html`, `types/models/slot.go`)
- `/api/v1/slot/{slot}/inclusion_lists`: `inclusion_list_committee_root` → `dependent_root` (`handlers/api/slot_inclusion_lists_v1.go`), swagger regenerated

Screenshot of the slot page pending a heze/IL devnet.

https://claude.ai/code/session_01E47DJeAkHBdyG1G3Ld7fzK