### PR TITLE
Use Gloas activation/exit churn limits for queue churn display

### DIFF
--- a/clients/consensus/chainstate.go
+++ b/clients/consensus/chainstate.go
@@ -586,6 +586,29 @@ func (cs *ChainState) GetActivationChurnLimit(epoch phase0.Epoch, totalActiveBal
 	return churn
 }
 
+// GetExitChurnLimit returns the per-epoch churn budget that voluntary exits consume.
+//
+// Gloas (EIP-8061) derives it from CHURN_LIMIT_QUOTIENT_GLOAS like the activation churn, but
+// without the MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS cap. Before Gloas exits share the
+// activation/exit churn limit with deposits.
+// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/beacon-chain.md#new-get_exit_churn_limit
+func (cs *ChainState) GetExitChurnLimit(epoch phase0.Epoch, totalActiveBalance uint64) uint64 {
+	if cs.specs == nil {
+		return 0
+	}
+
+	if !cs.IsEip7732Enabled(epoch) || cs.specs.ChurnLimitQuotientGloas == 0 {
+		return cs.GetActivationExitChurnLimit(totalActiveBalance)
+	}
+
+	churn := totalActiveBalance / cs.specs.ChurnLimitQuotientGloas
+	if churn < cs.specs.MinPerEpochChurnLimitElectra {
+		churn = cs.specs.MinPerEpochChurnLimitElectra
+	}
+
+	return churn - churn%cs.specs.EffectiveBalanceIncrement
+}
+
 // GetConsolidationChurnLimit returns the per-epoch churn limit reserved for consolidations
 // at the given epoch.
 //

--- a/clients/consensus/chainstate_churn_test.go
+++ b/clients/consensus/chainstate_churn_test.go
@@ -1,0 +1,72 @@
+package consensus
+
+import (
+	"testing"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+)
+
+const gwei = uint64(1_000_000_000)
+
+func newChurnTestChainState() *ChainState {
+	gloasForkEpoch := uint64(100)
+
+	specs := &ChainSpec{}
+	specs.GloasForkEpoch = &gloasForkEpoch
+	specs.ChurnLimitQuotient = 65536
+	specs.EffectiveBalanceIncrement = 1 * gwei
+	specs.MinPerEpochChurnLimitElectra = 128 * gwei
+	specs.MaxPerEpochActivationExitChurnLimit = 256 * gwei
+	specs.ChurnLimitQuotientGloas = 32768
+	specs.MaxPerEpochActivationChurnLimitGloas = 256 * gwei
+
+	return &ChainState{specs: specs}
+}
+
+func TestActivationAndExitChurnLimits(t *testing.T) {
+	cs := newChurnTestChainState()
+
+	const preGloas, postGloas = phase0.Epoch(99), phase0.Epoch(100)
+
+	tests := []struct {
+		name               string
+		epoch              phase0.Epoch
+		totalActiveBalance uint64
+		wantActivation     uint64
+		wantExit           uint64
+	}{
+		// Below the floor both formulas return MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA.
+		{"pre-gloas floor", preGloas, 1_000_000 * gwei, 128 * gwei, 128 * gwei},
+		{"gloas floor", postGloas, 1_000_000 * gwei, 128 * gwei, 128 * gwei},
+
+		// 8M ETH: Electra gives 8M/2^16 = 122 -> floor 128; Gloas gives 8M/2^15 = 244.
+		{"pre-gloas mid", preGloas, 8_000_000 * gwei, 128 * gwei, 128 * gwei},
+		{"gloas mid", postGloas, 8_000_000 * gwei, 244 * gwei, 244 * gwei},
+
+		// 35M ETH: activation churn is capped at 256 ETH; the Gloas exit churn is not.
+		{"pre-gloas cap", preGloas, 35_000_000 * gwei, 256 * gwei, 256 * gwei},
+		{"gloas cap", postGloas, 35_000_000 * gwei, 256 * gwei, 1068 * gwei},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cs.GetActivationChurnLimit(tt.epoch, tt.totalActiveBalance); got != tt.wantActivation {
+				t.Errorf("GetActivationChurnLimit() = %d, want %d", got/gwei, tt.wantActivation/gwei)
+			}
+			if got := cs.GetExitChurnLimit(tt.epoch, tt.totalActiveBalance); got != tt.wantExit {
+				t.Errorf("GetExitChurnLimit() = %d, want %d", got/gwei, tt.wantExit/gwei)
+			}
+		})
+	}
+}
+
+func TestChurnLimitsWithoutSpecs(t *testing.T) {
+	cs := &ChainState{}
+
+	if got := cs.GetActivationChurnLimit(0, 1); got != 0 {
+		t.Errorf("GetActivationChurnLimit() without specs = %d, want 0", got)
+	}
+	if got := cs.GetExitChurnLimit(0, 1); got != 0 {
+		t.Errorf("GetExitChurnLimit() without specs = %d, want 0", got)
+	}
+}

--- a/handlers/api/network_overview_v1.go
+++ b/handlers/api/network_overview_v1.go
@@ -298,13 +298,17 @@ func buildNetworkOverviewData(ctx context.Context) (*APINetworkOverviewData, tim
 			}
 
 			if validatorStats.TotalEligibleEther > 0 {
-				etherChurnPerEpoch := chainState.GetActivationExitChurnLimit(validatorStats.TotalEligibleEther)
+				// Deposits consume the activation-only churn budget from Gloas on (EIP-8061).
+				etherChurnPerEpoch := chainState.GetActivationChurnLimit(currentEpoch, validatorStats.TotalEligibleEther)
 				queueStats.EtherChurnPerDay = etherChurnPerEpoch * 225 // ~225 epochs per day
 
-				if queueStats.EtherChurnPerDay > 0 {
+				// Exits have their own (uncapped) churn budget since Gloas; before that it is
+				// the same shared activation/exit limit.
+				exitChurnPerDay := chainState.GetExitChurnLimit(currentEpoch, validatorStats.TotalEligibleEther) * 225
+				if exitChurnPerDay > 0 {
 					// Calculate exit time in seconds, assuming each validator has the average balance
 					exitEtherAmount := queueStats.ExitingValidatorCount * validatorStats.AverageBalance
-					exitDays := float64(exitEtherAmount) / float64(queueStats.EtherChurnPerDay)
+					exitDays := float64(exitEtherAmount) / float64(exitChurnPerDay)
 					queueStats.ExitEstimatedTimeToProcess = uint64(exitDays * 24 * 60 * 60)
 				}
 			}

--- a/handlers/deposits.go
+++ b/handlers/deposits.go
@@ -134,7 +134,8 @@ func buildDepositsPageData(ctx context.Context, firstEpoch uint64, pageSize uint
 
 		pageData.EnteringValidatorCount = queuedDeposits.TotalNew
 		pageData.EnteringEtherAmount = uint64(queuedDeposits.TotalGwei)
-		pageData.EtherChurnPerEpoch = chainState.GetActivationExitChurnLimit(totalEligibleEther)
+		// Deposits consume the activation-only churn budget from Gloas on (EIP-8061).
+		pageData.EtherChurnPerEpoch = chainState.GetActivationChurnLimit(currentEpoch, totalEligibleEther)
 		pageData.EtherChurnPerDay = pageData.EtherChurnPerEpoch * 225
 
 		// QueueEstimation is 0 for an empty or all-postponed queue; leave the time unset so

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -161,7 +161,8 @@ func buildIndexPageData(ctx context.Context) (*models.IndexPageData, time.Durati
 		if queuedDeposits != nil {
 			pageData.EnteringValidatorCount = queuedDeposits.TotalNew
 			pageData.EnteringEtherAmount = uint64(queuedDeposits.TotalGwei)
-			pageData.EtherChurnPerEpoch = chainState.GetActivationExitChurnLimit(pageData.TotalEligibleEther)
+			// Deposits consume the activation-only churn budget from Gloas on (EIP-8061).
+			pageData.EtherChurnPerEpoch = chainState.GetActivationChurnLimit(currentEpoch, pageData.TotalEligibleEther)
 			pageData.EtherChurnPerDay = pageData.EtherChurnPerEpoch * 225
 
 			// QueueEstimation is the epoch the queue is fully processed; render the remaining


### PR DESCRIPTION
## Summary

The pending-deposits tooltip on the index page (and the deposits page header / `network_overview` API) showed a churn limit computed with the **Electra** `get_activation_exit_churn_limit` (`CHURN_LIMIT_QUOTIENT = 2^16`), while the queue time estimate next to it already used the **Gloas** `get_activation_churn_limit` (EIP-8061, `CHURN_LIMIT_QUOTIENT_GLOAS = 2^15`). Between ~4.2M and ~16.8M ETH total active balance the displayed "X ETH per epoch" understated the real activation churn by up to 2x and disagreed with the estimate.

- `handlers/index.go`, `handlers/deposits.go`: churn label uses `GetActivationChurnLimit`
- `handlers/api/network_overview_v1.go`: `ether_churn_per_day` uses the activation churn; the exit-queue estimate uses the new `GetExitChurnLimit` (Gloas exit churn has no 256 ETH cap, so e.g. mainnet is ~1068 vs 256 ETH/epoch)
- `clients/consensus/chainstate.go`: new `GetExitChurnLimit`, falling back to the shared Electra limit pre-Gloas
- Unit test covering floor / mid-range / cap pre- and post-Gloas

No visible change on small devnets (both formulas hit the 128 ETH floor) or on mainnet-scale deposit churn (both hit the 256 ETH cap).

## Test plan

- [x] `go build ./...`, `go vet`
- [x] `go test ./clients/consensus/ -run Churn`

https://claude.ai/code/session_018rnAaHWq9mkEHdK7KVBi97
