### PR TITLE
Raise submit page gas limits for EIP-8037 state costs

### DIFF
--- a/ui-package/src/components/SubmitBuilderDepositsForm/BuilderDepositEntry.tsx
+++ b/ui-package/src/components/SubmitBuilderDepositsForm/BuilderDepositEntry.tsx
@@ -4,6 +4,7 @@ import { Modal } from 'react-bootstrap';
 
 import { IDeposit } from '../SubmitDepositsForm/DepositsTable';
 import { toReadableAmount } from '../../utils/ReadableAmount';
+import { BUILDER_DEPOSIT_REQUEST_GAS_LIMIT } from '../../utils/GasLimits';
 
 interface IBuilderDepositEntryProps {
   deposit: IDeposit;
@@ -84,7 +85,7 @@ const BuilderDepositEntry = (props: IBuilderDepositEntryProps): React.ReactEleme
       chainId: chain?.id,
       value: totalValue,
       data,
-      gas: 300000n,
+      gas: BUILDER_DEPOSIT_REQUEST_GAS_LIMIT,
     }).then(tx => {
       console.log(tx);
     }).catch(error => {

--- a/ui-package/src/components/SubmitBuilderExitsForm/BuilderExitReview.tsx
+++ b/ui-package/src/components/SubmitBuilderExitsForm/BuilderExitReview.tsx
@@ -4,6 +4,7 @@ import { Modal } from 'react-bootstrap';
 
 import { toReadableAmount } from '../../utils/ReadableAmount';
 import { useQueueDataCache } from '../../hooks/useQueueDataCache';
+import { BUILDER_EXIT_REQUEST_GAS_LIMIT } from '../../utils/GasLimits';
 
 interface IBuilderExitReviewProps {
   pubkey: string;
@@ -199,7 +200,7 @@ const BuilderExitReview = (props: IBuilderExitReviewProps) => {
       value: requestFee,
       // calldata (48 bytes): builder pubkey. source_address = msg.sender.
       data: ("0x" + props.pubkey.replace(/^0x/, "")) as `0x${string}`,
-      gas: 200000n,
+      gas: BUILDER_EXIT_REQUEST_GAS_LIMIT,
     }).then(tx => {
       console.log(tx);
     }).catch(error => {

--- a/ui-package/src/components/SubmitConsolidationsForm/ConsolidationReview.tsx
+++ b/ui-package/src/components/SubmitConsolidationsForm/ConsolidationReview.tsx
@@ -5,6 +5,7 @@ import { IValidator } from './SubmitConsolidationsFormProps';
 import { toReadableAmount } from '../../utils/ReadableAmount';
 import { Modal } from 'react-bootstrap';
 import { useQueueDataCache } from '../../hooks/useQueueDataCache';
+import { CONSOLIDATION_REQUEST_GAS_LIMIT } from '../../utils/GasLimits';
 
 interface IConsolidationReviewProps {
   sourceValidator: IValidator;
@@ -252,7 +253,7 @@ const ConsolidationReview = (props: IConsolidationReviewProps) => {
       // https://eips.ethereum.org/EIPS/eip-7251#add-consolidation-request
       // calldata (96 bytes): sourceValidator.pubkey (48 bytes) + targetValidator.pubkey (48 bytes)
       data: "0x" + props.sourceValidator.pubkey.substring(2) + props.targetValidator.pubkey.substring(2),
-      gas: 200000n,
+      gas: CONSOLIDATION_REQUEST_GAS_LIMIT,
     }).then(tx => {
       console.log(tx);
     }).catch(error => {

--- a/ui-package/src/components/SubmitDepositsForm/DepositEntry.tsx
+++ b/ui-package/src/components/SubmitDepositsForm/DepositEntry.tsx
@@ -7,6 +7,7 @@ import { IDeposit } from './DepositsTable';
 import { toReadableAmount } from '../../utils/ReadableAmount';
 import { DepositContractAbi } from './DepositContract';
 import { GatingContractData, PREFIX_TO_DEPOSIT_TYPE } from './GatingContract';
+import { DEPOSIT_GAS_LIMIT } from '../../utils/GasLimits';
 
 interface IDepositEntryProps {
   deposit: IDeposit;
@@ -243,7 +244,7 @@ const DepositEntry = (props: IDepositEntryProps): React.ReactElement => {
       functionName: "deposit",
       args: args,
       value: BigInt(props.deposit.amount) * BigInt(10 ** 9),
-      gas: 150000n,
+      gas: DEPOSIT_GAS_LIMIT,
     }).then(tx => {
       console.log(tx);
     }).catch(error => {

--- a/ui-package/src/components/SubmitDepositsForm/TopupDepositForm.tsx
+++ b/ui-package/src/components/SubmitDepositsForm/TopupDepositForm.tsx
@@ -11,6 +11,7 @@ import { toReadableAmount } from '../../utils/ReadableAmount';
 import { topupRoot } from './TopUpRoot';
 import { GatingContractData, DEPOSIT_TYPES } from './GatingContract';
 import { GatingStatusBanner } from './GatingStatusBanner';
+import { DEPOSIT_GAS_LIMIT } from '../../utils/GasLimits';
 
 // Define SSZ types for deposit data root calculation
 const DepositMessage = new ContainerType({
@@ -142,7 +143,7 @@ const TopupDepositForm = (props: ITopupDepositFormProps): React.ReactElement => 
       functionName: "deposit",
       args: args,
       value: amountWei,
-      gas: 150000n,
+      gas: DEPOSIT_GAS_LIMIT,
     }).then(tx => {
       console.log(tx);
     }).catch(error => {

--- a/ui-package/src/components/SubmitWithdrawalsForm/WithdrawalReview.tsx
+++ b/ui-package/src/components/SubmitWithdrawalsForm/WithdrawalReview.tsx
@@ -5,6 +5,7 @@ import { IValidator } from './SubmitWithdrawalsFormProps';
 import { toReadableAmount } from '../../utils/ReadableAmount';
 import { Modal } from 'react-bootstrap';
 import { useQueueDataCache } from '../../hooks/useQueueDataCache';
+import { WITHDRAWAL_REQUEST_GAS_LIMIT } from '../../utils/GasLimits';
 
 interface IWithdrawalReviewProps {
   validator: IValidator;
@@ -246,7 +247,7 @@ const WithdrawalReview = (props: IWithdrawalReviewProps) => {
       // https://eips.ethereum.org/EIPS/eip-7002#add-withdrawal-request
       // calldata (56 bytes): sourceValidator.pubkey (48 bytes) + amount (8 bytes)
       data: "0x" + props.validator.pubkey.substring(2) + props.withdrawalAmount.toString(16).padStart(16, "0"),
-      gas: 200000n,
+      gas: WITHDRAWAL_REQUEST_GAS_LIMIT,
     }).then(tx => {
       console.log(tx);
     }).catch(error => {

--- a/ui-package/src/utils/GasLimits.ts
+++ b/ui-package/src/utils/GasLimits.ts
@@ -1,0 +1,45 @@
+/**
+ * Gas limits for the transactions submitted from the explorer's submit pages.
+ *
+ * Each value is the measured worst case of the target contract plus headroom.
+ * The worst case assumes every storage slot the call touches is cold and gets
+ * created (written from zero), which is what the request predeploys do whenever
+ * the queue grows past its previous high-water mark and after the per-block
+ * system call has reset the request count and the queue pointers.
+ *
+ * Slot creation dominates the cost from the Amsterdam fork on: EIP-8037 prices
+ * a created slot at 64 state bytes * 1530 gas = 97,920 state gas on top of
+ * 5,000 regular gas, replacing the flat 20,000 + 2,100 charged before, so every
+ * created slot adds 80,820 gas. State gas is drawn from the transaction gas
+ * limit as well (the separate reservoir only holds what exceeds EIP-7825's
+ * 16,777,216 regular-gas cap), so the limit has to cover both dimensions.
+ *
+ * Worst cases measured with `evm t8n --state.fork Amsterdam` against the
+ * deployed predeploy bytecode, with an all non-zero calldata payload:
+ *
+ *   deposit contract, deposit()   246,366  (branch node + deposit_count created)
+ *   EIP-7002 withdrawal request   541,333  (count, tail, 3 queue slots created)
+ *   EIP-7251 consolidation        645,234  (count, tail, 4 queue slots created)
+ *   EIP-8282 builder exit         541,141  (count, tail, 3 queue slots created)
+ *   EIP-8282 builder deposit      852,938  (count, tail, 6 queue slots created)
+ *
+ * The request contracts also run the EIP-1559 style fee loop, which grows with
+ * the excess request counter (~14 gas per unit of excess). The numbers above
+ * include an excess of 100; the headroom covers far beyond what the fee can
+ * realistically reach, since the fee itself grows as e^(excess/17) wei.
+ */
+
+/** Deposit contract `deposit()`, used for both new deposits and top-ups. */
+export const DEPOSIT_GAS_LIMIT = 300000n;
+
+/** EIP-7002 withdrawal request predeploy (partial withdrawals and exits). */
+export const WITHDRAWAL_REQUEST_GAS_LIMIT = 600000n;
+
+/** EIP-7251 consolidation request predeploy. */
+export const CONSOLIDATION_REQUEST_GAS_LIMIT = 700000n;
+
+/** EIP-8282 builder exit request predeploy. */
+export const BUILDER_EXIT_REQUEST_GAS_LIMIT = 600000n;
+
+/** EIP-8282 builder deposit request predeploy. */
+export const BUILDER_DEPOSIT_REQUEST_GAS_LIMIT = 950000n;


### PR DESCRIPTION
## Problem

The gas limits hardcoded on the submit pages are below what their transactions need once [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) (State Creation Gas Cost Increase, scheduled for Glamsterdam) activates.

EIP-8037 prices a created storage slot at `64 bytes × 1530 CPSB = 97,920` state gas plus `5,000` regular gas, replacing the flat `20,000 + 2,100` cold charge — **+80,820 gas per created slot**. State gas is drawn from the transaction gas limit too: the separate reservoir only holds what exceeds EIP-7825's `16,777,216` regular-gas cap, so `tx.gas` has to cover both dimensions.

The EIP-7002/7251/8282 request predeploys are hit hardest. The end-of-block system call zeroes the request-count slot every block and resets the queue pointers on every drain, so the first request in a block recreates them; a queue growing past its high-water mark creates another 3-6.

## Measurements

Worst case = every touched slot cold and created, all-nonzero calldata, excess = 100. Measured with `evm t8n --state.fork Amsterdam` against the deployed predeploy bytecode and the geas-assembled EIP-8282 contracts:

| Flow | Contract | Slots created | Pre-fork | Amsterdam | Old limit | New limit |
|---|---|---|---|---|---|---|
| Deposit / top-up | deposit contract | 2 | 84,726 | **246,366** | 150,000 ✗ | 300,000 |
| Withdrawal / exit | EIP-7002 | 5 | 135,793 | **541,333** | 200,000 ✗ | 600,000 |
| Consolidation | EIP-7251 | 6 | 158,922 | **645,234** | 200,000 ✗ | 700,000 |
| Builder exit | EIP-8282 exits | 5 | 135,649 | **541,141** | 200,000 ✗ | 600,000 |
| Builder deposit | EIP-8282 deposits | 8 | 204,986 | **852,938** | 300,000 ✗ | 950,000 |

Verified the failure directly: a 7002 withdrawal request at `gas: 200000` returns `status 0x0` under Amsterdam; the exact threshold is 539,893 at excess = 0.

The predeploys' EIP-1559-style fee loop adds ~14 gas per unit of excess, which the headroom covers comfortably — the fee itself grows as `e^(excess/17)` wei, so a meaningful excess is unreachable in practice. The deposit contract's worst case is the *first* deposit (branch node and `deposit_count` both created); a maximally deep merkle branch is slightly cheaper at 240,730.

## Changes

- New `ui-package/src/utils/GasLimits.ts` holding the five constants with the derivation and the measured figures.
- The six call sites (`WithdrawalReview`, `ConsolidationReview`, `BuilderExitReview`, `BuilderDepositEntry`, `DepositEntry`, `TopupDepositForm`) import from it.

A gas limit is only a cap, so these values are equally correct pre-fork — no fork branching needed.

## Notes for reviewers

Two things that cost time to pin down and are worth knowing if you re-measure:

- **`evm t8n` does not set `vm.BlockContext.CostPerStateByte`** (`cmd/evm/internal/t8ntool/execution.go` leaves it zero), so state gas silently measures as **0** and Amsterdam looks *cheaper* than Osaka. I patched that field to `params.CostPerStateByte` in a local build to get the numbers above.
- **glamsterdam devnet-8 is not charging state gas yet** — contract creations there go as low as 39,986 gas, impossible under the `120 × 1530` account-creation charge. Failures showing up today would come from a node built off current geth master (kurtosis or a newer devnet), not devnet-8.

## Testing

`npm run build` in `ui-package/` passes. The package has no test suite.