### PR TITLE
fix: use distinct PTC validators as the slot waves denominator

### DIFF
--- a/handlers/slot_waves.go
+++ b/handlers/slot_waves.go
@@ -137,10 +137,9 @@ func buildSlotWavesData(ctx context.Context, slot phase0.Slot, blockRoot, execHa
 		}
 
 		if ptc != nil {
-			// votes are due within PAYLOAD_ATTESTATION_DUE_BPS of the slot,
-			// from a committee of PTC_SIZE
+			// votes are due within PAYLOAD_ATTESTATION_DUE_BPS of the slot
 			ptc.DeadlineMs = bpsOfSlot(chainState, chainState.GetSpecs().PayloadAttestationDueBps, 7500)
-			ptc.ExpectedCount = int(chainState.GetSpecs().PtcSize) //nolint:gosec // committee sizes are small
+			ptc.ExpectedCount = expectedPtcVoters(queryCtx, chainState, slot)
 		}
 
 		payload, err = loadSeenWave(queryCtx, xatu.GlobalClient, "beacon_api_eth_v1_events_execution_payload_gossip", "block_root", slot, slotTime, settled, blockRoot, slotMs)
@@ -297,6 +296,25 @@ func loadExecutedWave(ctx context.Context, client *xatu.Client, execHash string,
 	}
 
 	return wave, nil
+}
+
+// expectedPtcVoters returns the number of distinct validators in the slot's
+// PTC. The wave counts one vote per validator, while PTC_SIZE counts seats and
+// a validator can hold several seats when the committee is sampled by
+// effective balance, so the seat count overstates the denominator. Falls back
+// to PTC_SIZE when the committee cannot be resolved.
+func expectedPtcVoters(ctx context.Context, chainState *consensus.ChainState, slot phase0.Slot) int {
+	members := services.GlobalBeaconService.GetSlotPtc(ctx, slot)
+	if len(members) == 0 {
+		return int(chainState.GetSpecs().PtcSize) //nolint:gosec // committee sizes are small
+	}
+
+	unique := make(map[phase0.ValidatorIndex]struct{}, len(members))
+	for _, v := range members {
+		unique[v] = struct{}{}
+	}
+
+	return len(unique)
 }
 
 // expectedAttesters is how many validators were due to attest in the slot:

--- a/types/models/slot_waves.go
+++ b/types/models/slot_waves.go
@@ -38,7 +38,8 @@ type SlotSeenWave struct {
 type SlotPtcWave struct {
 	TotalCount   int `json:"total_count"`
 	PresentCount int `json:"present_count"`
-	// ExpectedCount is the committee size, PTC_SIZE from the chain spec.
+	// ExpectedCount is the number of distinct validators in the PTC, or
+	// PTC_SIZE when the committee cannot be resolved.
 	ExpectedCount int `json:"expected_count,omitempty"`
 	// DeadlineMs is when PTC votes are due: 75% of the slot.
 	DeadlineMs uint32           `json:"deadline_ms"`


### PR DESCRIPTION
The PTC wave on the slot arrival tab counts one vote per validator (`ptcWaveQuery` groups by `validator_index`), but the denominator is `PTC_SIZE`, which counts seats. The committee is sampled by effective balance, so a validator can hold several seats and the seat count overstates what the wave can ever reach. On glamsterdam-devnet-8 the 512 seats map to 442 to 458 distinct validators per slot, so the chart shows roughly 80% participation for slots where every voting node actually voted. This came up while looking into the "PTC voted too early" reports on that devnet, see https://gist.github.com/nflaig/525b3c1a726622b6a057eae582ac50bb.

This resolves the slot's PTC via `GetSlotPtc` and uses the number of distinct validators as `expected_count`, falling back to `PTC_SIZE` when the committee cannot be resolved.
